### PR TITLE
Fix parseChannelMetadataJSON

### DIFF
--- a/core/web3/src/Utils.ts
+++ b/core/web3/src/Utils.ts
@@ -79,3 +79,26 @@ export const findDynamicPricingModule = (pricingModules: PricingModuleStruct[]) 
 
 export const findFixedPricingModule = (pricingModules: PricingModuleStruct[]) =>
     pricingModules.find((module) => module.name === FIXED_PRICING)
+
+export function parseChannelMetadataJSON(metadataStr: string): {
+    name: string
+    description: string
+} {
+    try {
+        const result = JSON.parse(metadataStr)
+        if (
+            typeof result === 'object' &&
+            result !== null &&
+            'name' in result &&
+            'description' in result
+        ) {
+            return result as { name: string; description: string }
+        }
+    } catch (error) {
+        /* empty */
+    }
+    return {
+        name: metadataStr,
+        description: '',
+    }
+}

--- a/core/web3/src/v3/Space.ts
+++ b/core/web3/src/v3/Space.ts
@@ -31,6 +31,7 @@ import { IRuleEntitlement } from '.'
 import { IBanningShim } from './IBanningShim'
 import { IERC721AQueryableShim } from './IERC721AQueryableShim'
 import { ContractVersion } from '../IStaticContractsInfo'
+import { parseChannelMetadataJSON } from '../Utils'
 
 interface AddressToEntitlement {
     [address: string]: EntitlementShim
@@ -152,20 +153,6 @@ export class Space {
         }
     }
 
-    private parseChannelMetadataJSON(metadataStr: string): { name: string; description: string } {
-        try {
-            return JSON.parse(metadataStr) as {
-                name: string
-                description: string
-            }
-        } catch (error) {
-            return {
-                name: metadataStr,
-                description: '',
-            }
-        }
-    }
-
     public async getChannel(channelNetworkId: string): Promise<ChannelDetails | null> {
         // get most of the channel details except the roles which
         // require a separate call to get each role's details
@@ -174,7 +161,7 @@ export class Space {
             : `0x${channelNetworkId}`
         const channelInfo = await this.Channels.read.getChannel(channelId)
         const roles = await this.getChannelRoleEntitlements(channelInfo)
-        const metadata = this.parseChannelMetadataJSON(channelInfo.metadata)
+        const metadata = parseChannelMetadataJSON(channelInfo.metadata)
         return {
             spaceNetworkId: this.spaceId,
             channelNetworkId: channelNetworkId.replace('0x', ''),
@@ -190,7 +177,7 @@ export class Space {
             ? channelNetworkId
             : `0x${channelNetworkId}`
         const channelInfo = await this.Channels.read.getChannel(channelId)
-        const metadata = this.parseChannelMetadataJSON(channelInfo.metadata)
+        const metadata = parseChannelMetadataJSON(channelInfo.metadata)
         return {
             name: metadata.name,
             channelNetworkId: channelInfo.id.replace('0x', ''),
@@ -203,7 +190,7 @@ export class Space {
         const channels: ChannelMetadata[] = []
         const getOutput = await this.Channels.read.getChannels()
         for (const o of getOutput) {
-            const metadata = this.parseChannelMetadataJSON(o.metadata)
+            const metadata = parseChannelMetadataJSON(o.metadata)
             channels.push({
                 name: metadata.name,
                 description: metadata.description,
@@ -389,7 +376,7 @@ export class Space {
         // add the channel to the list if it is not already added
         for (const c of allChannels) {
             if (!channelMetadatas.has(c.id) && isRoleIdInArray(c.roleIds, roleId)) {
-                const metadata = this.parseChannelMetadataJSON(c.metadata)
+                const metadata = parseChannelMetadataJSON(c.metadata)
                 channelMetadatas.set(c.id, {
                     channelNetworkId: c.id.replace('0x', ''),
                     name: metadata.name,

--- a/core/web3/tests/utils.test.ts
+++ b/core/web3/tests/utils.test.ts
@@ -1,0 +1,18 @@
+import { parseChannelMetadataJSON } from '../src/Utils'
+
+describe('utils.test.ts', () => {
+    test('channelMetadataJson', async () => {
+        expect(parseChannelMetadataJSON('{"name":"name","description":"description"}')).toEqual({
+            name: 'name',
+            description: 'description',
+        })
+        expect(parseChannelMetadataJSON('name')).toEqual({
+            name: 'name',
+            description: '',
+        })
+        expect(parseChannelMetadataJSON('11111')).toEqual({
+            name: '11111',
+            description: '',
+        })
+    })
+})


### PR DESCRIPTION
11111 is “valid” json, so the helper was returning empty strings for the name. see

https://linear.app/hnt-labs/issue/HNT-6513/%5Bchannels%5D-channel-name-is-not-displayed-correctly-if-name-is-numbers