### PR TITLE
Pass the entire config into can_create_stream

### DIFF
--- a/core/node/rpc/create_stream.go
+++ b/core/node/rpc/create_stream.go
@@ -56,7 +56,7 @@ func (s *Service) createStream(ctx context.Context, req *CreateStreamRequest) (*
 
 	log.Debug("createStream", "parsedEvents", parsedEvents)
 
-	csRules, err := rules.CanCreateStream(ctx, &s.config.Stream, time.Now(), streamId, parsedEvents)
+	csRules, err := rules.CanCreateStream(ctx, s.config, time.Now(), streamId, parsedEvents)
 	if err != nil {
 		return nil, err
 	}

--- a/core/node/rules/can_create_stream.go
+++ b/core/node/rules/can_create_stream.go
@@ -19,7 +19,7 @@ import (
 
 type csParams struct {
 	ctx                 context.Context
-	cfg                 *config.StreamConfig
+	cfg                 *config.Config
 	streamId            shared.StreamId
 	parsedEvents        []*events.ParsedEvent
 	inceptionPayload    IsInceptionPayload
@@ -100,7 +100,7 @@ type csUserInboxRules struct {
 */
 func CanCreateStream(
 	ctx context.Context,
-	cfg *config.StreamConfig,
+	cfg *config.Config,
 	currentTime time.Time,
 	streamId shared.StreamId,
 	parsedEvents []*events.ParsedEvent,
@@ -510,10 +510,10 @@ func (ru *csMediaRules) checkMediaInceptionPayload() error {
 	if len(ru.inception.ChannelId) == 0 {
 		return RiverError(Err_BAD_STREAM_CREATION_PARAMS, "channel id must not be empty for media stream")
 	}
-	if ru.inception.ChunkCount > int32(ru.params.cfg.Media.MaxChunkCount) {
+	if ru.inception.ChunkCount > int32(ru.params.cfg.Stream.Media.MaxChunkCount) {
 		return RiverError(
 			Err_BAD_STREAM_CREATION_PARAMS,
-			fmt.Sprintf("chunk count must be less than or equal to %d", ru.params.cfg.Media.MaxChunkCount),
+			fmt.Sprintf("chunk count must be less than or equal to %d", ru.params.cfg.Stream.Media.MaxChunkCount),
 		)
 	}
 
@@ -668,7 +668,7 @@ func (ru *csGdmChannelRules) checkGDMPayloads() error {
 
 	// GDM memberships cannot exceed the configured limit. the first event is the inception event
 	// and is subtracted from the parsed events count.
-	membershipLimit := ru.params.cfg.GetMembershipLimit(ru.params.streamId)
+	membershipLimit := ru.params.cfg.Stream.GetMembershipLimit(ru.params.streamId)
 	if len(ru.params.parsedEvents)-1 > membershipLimit {
 		return RiverError(
 			Err_INVALID_ARGUMENT,


### PR DESCRIPTION
I will need it to gate user stream creation