### PR TITLE
getActiveOperators RewardsDistribution update for Active status

### DIFF
--- a/contracts/src/base/registry/facets/distribution/RewardsDistribution.sol
+++ b/contracts/src/base/registry/facets/distribution/RewardsDistribution.sol
@@ -258,7 +258,7 @@ contract RewardsDistribution is
       NodeOperatorStatus currentStatus = nos.statusByOperator[operator];
 
       if (
-        currentStatus == NodeOperatorStatus.Approved &&
+        currentStatus == NodeOperatorStatus.Active &&
         _isActiveSinceLastCycle(nos.approvalTimeByOperator[operator])
       ) {
         expectedOperators[i] = operator;

--- a/contracts/src/base/registry/facets/operator/NodeOperatorFacet.sol
+++ b/contracts/src/base/registry/facets/operator/NodeOperatorFacet.sol
@@ -73,7 +73,7 @@ contract NodeOperatorFacet is INodeOperator, OwnableBase, ERC721ABase, Facet {
     // Exiting -> Standby
     // Standby -> Approved
     // Approved -> Exiting || Active
-    // Active -> Exiting
+    // Active -> Exiting || Approved
     if (
       currentStatus == NodeOperatorStatus.Exiting &&
       newStatus != NodeOperatorStatus.Standby
@@ -92,7 +92,8 @@ contract NodeOperatorFacet is INodeOperator, OwnableBase, ERC721ABase, Facet {
       revert NodeOperator__InvalidStatusTransition();
     } else if (
       currentStatus == NodeOperatorStatus.Active &&
-      newStatus != NodeOperatorStatus.Exiting
+      (newStatus != NodeOperatorStatus.Exiting &&
+        newStatus != NodeOperatorStatus.Approved)
     ) {
       revert NodeOperator__InvalidStatusTransition();
     }

--- a/contracts/src/base/registry/facets/operator/NodeOperatorFacet.sol
+++ b/contracts/src/base/registry/facets/operator/NodeOperatorFacet.sol
@@ -72,7 +72,8 @@ contract NodeOperatorFacet is INodeOperator, OwnableBase, ERC721ABase, Facet {
     // Check for valid newStatus transitions
     // Exiting -> Standby
     // Standby -> Approved
-    // Approved -> Exiting
+    // Approved -> Exiting || Active
+    // Active -> Exiting
     if (
       currentStatus == NodeOperatorStatus.Exiting &&
       newStatus != NodeOperatorStatus.Standby
@@ -85,6 +86,12 @@ contract NodeOperatorFacet is INodeOperator, OwnableBase, ERC721ABase, Facet {
       revert NodeOperator__InvalidStatusTransition();
     } else if (
       currentStatus == NodeOperatorStatus.Approved &&
+      (newStatus != NodeOperatorStatus.Exiting &&
+        newStatus != NodeOperatorStatus.Active)
+    ) {
+      revert NodeOperator__InvalidStatusTransition();
+    } else if (
+      currentStatus == NodeOperatorStatus.Active &&
       newStatus != NodeOperatorStatus.Exiting
     ) {
       revert NodeOperator__InvalidStatusTransition();

--- a/contracts/test/base/registry/RewardsDistribution.t.sol
+++ b/contracts/test/base/registry/RewardsDistribution.t.sol
@@ -427,7 +427,7 @@ contract RewardsDistributionTest is
     internal
     givenOperatorsHaveRegistered(operators)
     givenOperatorsHaveCommissionRates(operators)
-    givenOperatorsHaveBeenApproved(operators)
+    givenOperatorsAreActive(operators)
   {}
 
   function setupUsersAndDelegation(
@@ -1398,14 +1398,16 @@ contract RewardsDistributionTest is
     _;
   }
 
-  modifier givenOperatorHasBeenApproved(address _operator) {
+  modifier givenOperatorIsActive(address _operator) {
     setOperatorStatus(_operator, NodeOperatorStatus.Approved);
+    setOperatorStatus(_operator, NodeOperatorStatus.Active);
     _;
   }
 
-  modifier givenOperatorsHaveBeenApproved(Entity[] memory operators) {
+  modifier givenOperatorsAreActive(Entity[] memory operators) {
     for (uint256 i = 0; i < operators.length; i++) {
       setOperatorStatus(operators[i].addr, NodeOperatorStatus.Approved);
+      setOperatorStatus(operators[i].addr, NodeOperatorStatus.Active);
     }
     _;
   }


### PR DESCRIPTION
getActiveOperators should look for Active operators not Approved operators, the latter of which may not have any operational nodes attached and therefore should not be included in weekly reward distribution. This PR brings the codebase to reflect this change. As a consequence new operators will need to traverse the following statuses to become Active and eligible for rewards: Standby (on registration) -> Approved (DAO) -> Active (DAO).

moved to https://github.com/river-build/river/pull/63