### PR TITLE
Revert "Add defaults to the metadata in the create stream calls (#45)"

### DIFF
--- a/core/sdk/src/client.ts
+++ b/core/sdk/src/client.ts
@@ -400,7 +400,7 @@ export class Client
         const response = await this.rpcClient.createStream({
             events: userEvents,
             streamId: streamIdAsBytes(userStreamId),
-            metadata: metadata ?? {},
+            metadata: metadata,
         })
         return unpackStream(response.stream)
     }
@@ -421,7 +421,7 @@ export class Client
         const response = await this.rpcClient.createStream({
             events: userDeviceKeyEvents,
             streamId: streamIdAsBytes(userDeviceKeyStreamId),
-            metadata: metadata ?? {},
+            metadata: metadata,
         })
         return unpackStream(response.stream)
     }
@@ -442,7 +442,7 @@ export class Client
         const response = await this.rpcClient.createStream({
             events: userInboxEvents,
             streamId: streamIdAsBytes(userInboxStreamId),
-            metadata: metadata ?? {},
+            metadata: metadata,
         })
         return unpackStream(response.stream)
     }
@@ -464,7 +464,7 @@ export class Client
         const response = await this.rpcClient.createStream({
             events: userSettingsEvents,
             streamId: userSettingsStreamId,
-            metadata: metadata ?? {},
+            metadata: metadata,
         })
         return unpackStream(response.stream)
     }


### PR DESCRIPTION
This reverts commit e84a2ea6997965fdbec3c0abd9b71424e2e9a6ae.

(turns out it was a turbo cache thing)