### PR TITLE
Fix go warning

### DIFF
--- a/core/node/auth/space_contract_v3.go
+++ b/core/node/auth/space_contract_v3.go
@@ -76,10 +76,10 @@ func (sc *SpaceContractV3) IsMember(
 	}
 
 	spaceAsErc271, err := erc721.NewErc721(space.address, sc.backend)
-
-	if err != nil || space == nil {
+	if err != nil {
 		return false, err
 	}
+
 	isMember, err := spaceAsErc271.BalanceOf(nil, user)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
this was putting up a warning for me in vscode,
we already checked for nil space pointer above