### PR TITLE
Fix uninitialized client pool on stream node for xchain checks

### DIFF
--- a/core/node/rpc/server.go
+++ b/core/node/rpc/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/river-build/river/core/node/protocol/protocolconnect"
 	"github.com/river-build/river/core/node/registries"
 	"github.com/river-build/river/core/node/storage"
+	"github.com/river-build/river/core/xchain/entitlement"
 	"github.com/rs/cors"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
@@ -126,6 +127,10 @@ func (s *Service) start() error {
 	err = s.initCacheAndSync()
 	if err != nil {
 		return AsRiverError(err).Message("Failed to init cache and sync").LogError(s.defaultLogger)
+	}
+
+	if err = entitlement.Init(s.serverCtx, s.config); err != nil {
+		return AsRiverError(err).Message("Failed to init entitlement").LogError(s.defaultLogger)
 	}
 
 	go s.riverChain.ChainMonitor.RunWithBlockPeriod(


### PR DESCRIPTION
The shared library for entitlement checks requires initialization - porting this init call to the stream node.