### PR TITLE
Add miniblockNum and eventNum to the forEachEvent iterator

### DIFF
--- a/core/node/events/miniblock.go
+++ b/core/node/events/miniblock.go
@@ -108,14 +108,17 @@ func (b *MiniblockInfo) lastEvent() *ParsedEvent {
 	}
 }
 
-func (b *MiniblockInfo) forEachEvent(op func(e *ParsedEvent) (bool, error)) error {
+func (b *MiniblockInfo) forEachEvent(op func(e *ParsedEvent, minibockNum int64, eventNum int64) (bool, error)) error {
+	blockNum := b.header().MiniblockNum
+	eventNum := b.header().EventNumOffset
 	for _, event := range b.events {
-		c, err := op(event)
+		c, err := op(event, blockNum, eventNum)
+		eventNum++
 		if !c {
 			return err
 		}
 	}
-	c, err := op(b.headerEvent)
+	c, err := op(b.headerEvent, blockNum, eventNum)
 	if !c {
 		return err
 	}

--- a/core/node/events/stream.go
+++ b/core/node/events/stream.go
@@ -628,7 +628,7 @@ func (s *streamImpl) Sub(ctx context.Context, cookie *SyncCookie, receiver SyncR
 
 		// append events from blocks
 		envelopes := make([]*Envelope, 0, 16)
-		err = s.view.forEachEvent(miniblockIndex, func(e *ParsedEvent) (bool, error) {
+		err = s.view.forEachEvent(miniblockIndex, func(e *ParsedEvent, minibockNum int64, eventNum int64) (bool, error) {
 			envelopes = append(envelopes, e.Envelope)
 			return true, nil
 		})

--- a/core/node/events/stream_viewstate_joinable.go
+++ b/core/node/events/stream_viewstate_joinable.go
@@ -30,7 +30,7 @@ func (r *streamViewImpl) GetChannelMembers() (*mapset.Set[string], error) {
 		members.Add(userId)
 	}
 
-	updateFn := func(e *ParsedEvent) (bool, error) {
+	updateFn := func(e *ParsedEvent, minibockNum int64, eventNum int64) (bool, error) {
 		switch payload := e.Event.Payload.(type) {
 		case *protocol.StreamEvent_MemberPayload:
 			switch payload := payload.MemberPayload.Content.(type) {
@@ -67,7 +67,7 @@ func (r *streamViewImpl) GetMembership(userAddress []byte) (protocol.MembershipO
 		retValue = protocol.MembershipOp_SO_JOIN
 	}
 
-	updateFn := func(e *ParsedEvent) (bool, error) {
+	updateFn := func(e *ParsedEvent, minibockNum int64, eventNum int64) (bool, error) {
 		switch payload := e.Event.Payload.(type) {
 		case *protocol.StreamEvent_MemberPayload:
 			switch payload := payload.MemberPayload.Content.(type) {
@@ -101,7 +101,7 @@ func (r *streamViewImpl) GetKeySolicitations(userAddress []byte) ([]*protocol.Me
 		member = proto.Clone(member).(*protocol.MemberPayload_Snapshot_Member)
 	}
 
-	updateFn := func(e *ParsedEvent) (bool, error) {
+	updateFn := func(e *ParsedEvent, minibockNum int64, eventNum int64) (bool, error) {
 		switch payload := e.Event.Payload.(type) {
 		case *protocol.StreamEvent_MemberPayload:
 			switch payload := payload.MemberPayload.Content.(type) {

--- a/core/node/events/stream_viewstate_space.go
+++ b/core/node/events/stream_viewstate_space.go
@@ -42,7 +42,7 @@ func (r *streamViewImpl) GetChannelInfo(channelId shared.StreamId) (*SpacePayloa
 	}
 	channel, _ := findChannel(snap.Channels, channelId[:])
 
-	updateFn := func(e *ParsedEvent) (bool, error) {
+	updateFn := func(e *ParsedEvent, minibockNum int64, eventNum int64) (bool, error) {
 		switch payload := e.Event.Payload.(type) {
 		case *StreamEvent_SpacePayload:
 			switch spacePayload := payload.SpacePayload.Content.(type) {

--- a/core/node/events/stream_viewstate_user.go
+++ b/core/node/events/stream_viewstate_user.go
@@ -62,7 +62,7 @@ func (r *streamViewImpl) GetUserMembership(streamId shared.StreamId) (Membership
 		retValue = membership.Op
 	}
 
-	updateFn := func(e *ParsedEvent) (bool, error) {
+	updateFn := func(e *ParsedEvent, minibockNum int64, eventNum int64) (bool, error) {
 		switch payload := e.Event.Payload.(type) {
 		case *StreamEvent_UserPayload:
 			switch payload := payload.UserPayload.Content.(type) {


### PR DESCRIPTION
I want to add updatedAtEventNum for some items in the snapshot so that we can do proper cache invalidation. This refactor is required to keep things consistant when dealing with events past the snapshot