### PR TITLE
Exclude the proto package from the turbo cache

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,7 @@
         "build": {
             // note: output globs are relative to each package's `package.json`
             // (and not the monorepo root
-            "outputs": ["dist/**", "build/**", "out/**"],
+            "outputs": ["dist/**", "build/**", "out/**", "!river/core/proto/dist/**"],
             "cache": true,
             "dependsOn": ["^build"]
         },


### PR DESCRIPTION
@serge i think all the protobuf files should be in a single folder under packages. Pretty sure the new structure will break the river-build/proto package that we publish to npm

fixes breakages here: https://github.com/river-build/river/actions/runs/9238352486/job/25416317936?pr=70