### PR TITLE
Use the optional flag when adding events for key fulfillments

### DIFF
--- a/core/encryption/src/tests/decryptionExtensions.test.ts
+++ b/core/encryption/src/tests/decryptionExtensions.test.ts
@@ -11,7 +11,11 @@ import {
     KeySolicitationData,
     makeSessionKeys,
 } from '../decryptionExtensions'
-import { EncryptedData, UserInboxPayload_GroupEncryptionSessions } from '@river-build/proto'
+import {
+    AddEventResponse_Error,
+    EncryptedData,
+    UserInboxPayload_GroupEncryptionSessions,
+} from '@river-build/proto'
 import { GroupEncryptionSession, UserDevice, UserDeviceCollection } from '../olmLib'
 import { bin_fromHexString, bin_toHexString, dlog } from '@river-build/dlog'
 
@@ -280,9 +284,11 @@ class MockDecryptionExtensions extends BaseDecryptionExtensions {
         return Promise.resolve()
     }
 
-    public sendKeyFulfillment(args: KeyFulfilmentData): Promise<void> {
+    public sendKeyFulfillment(
+        args: KeyFulfilmentData,
+    ): Promise<{ error?: AddEventResponse_Error }> {
         log('sendKeyFulfillment', args)
-        return Promise.resolve()
+        return Promise.resolve({})
     }
 
     public encryptAndShareGroupSessions(args: GroupSessionsData): Promise<void> {
@@ -405,8 +411,10 @@ class MockGroupEncryptionClient
         return Promise.resolve()
     }
 
-    public sendKeyFulfillment(_args: KeyFulfilmentData): Promise<void> {
-        return Promise.resolve()
+    public sendKeyFulfillment(
+        _args: KeyFulfilmentData,
+    ): Promise<{ error?: AddEventResponse_Error }> {
+        return Promise.resolve({})
     }
 
     public uploadDeviceKeys(): Promise<void> {

--- a/core/sdk/src/clientDecryptionExtensions.ts
+++ b/core/sdk/src/clientDecryptionExtensions.ts
@@ -10,7 +10,11 @@ import {
     KeySolicitationData,
     UserDevice,
 } from '@river-build/encryption'
-import { EncryptedData, UserInboxPayload_GroupEncryptionSessions } from '@river-build/proto'
+import {
+    AddEventResponse_Error,
+    EncryptedData,
+    UserInboxPayload_GroupEncryptionSessions,
+} from '@river-build/proto'
 import { make_MemberPayload_KeyFulfillment, make_MemberPayload_KeySolicitation } from './types'
 
 import { Client } from './client'
@@ -231,14 +235,17 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
         userAddress,
         deviceKey,
         sessionIds,
-    }: KeyFulfilmentData): Promise<void> {
+    }: KeyFulfilmentData): Promise<{ error?: AddEventResponse_Error }> {
         const fulfillment = make_MemberPayload_KeyFulfillment({
             userAddress: userAddress,
             deviceKey: deviceKey,
             sessionIds: sessionIds,
         })
 
-        await this.client.makeEventAndAddToStream(streamId, fulfillment)
+        const { error } = await this.client.makeEventAndAddToStream(streamId, fulfillment, {
+            optional: true,
+        })
+        return { error }
     }
 
     public async uploadDeviceKeys(): Promise<void> {


### PR DESCRIPTION
Currently when we repond to KeySolicitations we first post a KeyFulfillment to the channel. Lots of users can post this fulfillment at the same time, but the node will only accept one of them

After this change, instead of throwing tons of errors polluting all logs, we now pass “optional: true” and check the error in the calling code