### PR TITLE
node: Support unloading stream view for inactive streams

### DIFF
--- a/core/node/events/stream_cache.go
+++ b/core/node/events/stream_cache.go
@@ -5,6 +5,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/river-build/river/core/node/infra"
+
 	. "github.com/river-build/river/core/node/base"
 	"github.com/river-build/river/core/node/config"
 	"github.com/river-build/river/core/node/contracts"
@@ -23,6 +26,17 @@ const (
 	MiniblockCandidateBatchSize = 50
 )
 
+var (
+	streamCacheSizeGauge = infra.NewGaugeVec(
+		"stream_cache_size", "Number of streams in stream cache",
+		"chain_id", "address",
+	)
+	streamCacheUnloadedGauge = infra.NewGaugeVec(
+		"stream_cache_unloaded", "Number of unloaded streams in stream cache",
+		"chain_id", "address",
+	)
+)
+
 type StreamCacheParams struct {
 	Storage      storage.StreamStorage
 	Wallet       *crypto.Wallet
@@ -33,6 +47,7 @@ type StreamCacheParams struct {
 
 type StreamCache interface {
 	GetStream(ctx context.Context, streamId StreamId) (SyncStream, StreamView, error)
+	GetSyncStream(ctx context.Context, streamId StreamId) (SyncStream, error)
 	CreateStream(ctx context.Context, streamId StreamId) (SyncStream, StreamView, error)
 	ForceFlushAll(ctx context.Context)
 	GetLoadedViews(ctx context.Context) []StreamView
@@ -54,6 +69,9 @@ type streamCacheImpl struct {
 	// transaction instead of one by one. This can be deleted once the StreamRegistry facet is updated to allow for
 	// batch registrations.
 	registerMiniBlocksBatched bool
+
+	streamCacheSizeGauge     prometheus.Gauge
+	streamCacheUnloadedGauge prometheus.Gauge
 }
 
 var _ StreamCache = (*streamCacheImpl)(nil)
@@ -67,6 +85,14 @@ func NewStreamCache(
 	s := &streamCacheImpl{
 		params:                    params,
 		registerMiniBlocksBatched: true,
+		streamCacheSizeGauge: streamCacheSizeGauge.With(prometheus.Labels{
+			"chain_id": params.Riverchain.ChainId.String(),
+			"address":  params.Wallet.Address.String(),
+		}),
+		streamCacheUnloadedGauge: streamCacheUnloadedGauge.With(prometheus.Labels{
+			"chain_id": params.Riverchain.ChainId.String(),
+			"address":  params.Wallet.Address.String(),
+		}),
 	}
 
 	streams, err := params.Registry.GetAllStreams(ctx, appliedBlockNum)
@@ -113,12 +139,20 @@ func (s *streamCacheImpl) cacheCleanup(ctx context.Context, pollInterval time.Du
 	for {
 		select {
 		case <-time.After(pollInterval):
+			totalStreamsCount := 0
+			unloadedStreamsCount := 0
+			// TODO: add data structure that supports to loop over streams that have their view loaded instead of
+			// looping over all streams.
 			s.cache.Range(func(streamID, streamVal any) bool {
+				totalStreamsCount++
 				if stream := streamVal.(*streamImpl); stream.tryCleanup(expiration) {
-					log.Debug("stream view evicted from cache", "streamId", stream.streamId)
+					unloadedStreamsCount++
+					log.Debug("stream view is unloaded from cache", "streamId", stream.streamId)
 				}
 				return true
 			})
+			s.streamCacheSizeGauge.Set(float64(totalStreamsCount))
+			s.streamCacheUnloadedGauge.Set(float64(unloadedStreamsCount))
 		case <-ctx.Done():
 			log.Debug("stream cache cache cleanup shutdown")
 			return
@@ -126,8 +160,12 @@ func (s *streamCacheImpl) cacheCleanup(ctx context.Context, pollInterval time.Du
 	}
 }
 
-func (s *streamCacheImpl) tryLoadStreamRecord(ctx context.Context, streamId StreamId) (SyncStream, StreamView, error) {
-	// Same code is called for GetStream and CreateStream.
+func (s *streamCacheImpl) tryLoadStreamRecord(
+	ctx context.Context,
+	streamId StreamId,
+	loadView bool,
+) (SyncStream, StreamView, error) {
+	// Same code is called for GetStream, GetSyncStream and CreateStream.
 	// For GetStream the fact that record is not in cache means that there is race to get it during creation:
 	// Blockchain record is already created, but this fact is not reflected yet in local storage.
 	// This may happen if somebody observes record allocation on blockchain and tries to get stream
@@ -177,11 +215,14 @@ func (s *streamCacheImpl) tryLoadStreamRecord(ctx context.Context, streamId Stre
 		err := s.params.Storage.CreateStreamStorage(ctx, streamId, mb)
 		if err != nil {
 			if AsRiverError(err).Code == Err_ALREADY_EXISTS {
-				// Attempt to load stream from storage. Might as well do it while under lock.
-				err = stream.loadInternal(ctx)
-				if err == nil {
-					return stream, stream.view, nil
+				if loadView {
+					// Attempt to load stream from storage. Might as well do it while under lock.
+					if err = stream.loadInternal(ctx); err == nil {
+						return stream, stream.view, nil
+					}
+					return nil, nil, err
 				}
+				return stream, nil, err
 			}
 			return nil, nil, err
 		}
@@ -202,6 +243,10 @@ func (s *streamCacheImpl) tryLoadStreamRecord(ctx context.Context, streamId Stre
 			return nil, nil, RiverError(Err_INTERNAL, "tryLoadStreamRecord: Cache corruption", "streamId", streamId)
 		}
 		stream = entry.(*streamImpl)
+		if !loadView {
+			return stream, nil, err
+		}
+
 		view, err := stream.GetView(ctx)
 		if err != nil {
 			return nil, nil, err
@@ -213,7 +258,7 @@ func (s *streamCacheImpl) tryLoadStreamRecord(ctx context.Context, streamId Stre
 func (s *streamCacheImpl) GetStream(ctx context.Context, streamId StreamId) (SyncStream, StreamView, error) {
 	entry, _ := s.cache.Load(streamId)
 	if entry == nil {
-		return s.tryLoadStreamRecord(ctx, streamId)
+		return s.tryLoadStreamRecord(ctx, streamId, true)
 	}
 	stream := entry.(*streamImpl)
 
@@ -225,6 +270,15 @@ func (s *streamCacheImpl) GetStream(ctx context.Context, streamId StreamId) (Syn
 		// TODO: if stream is not present in local storage, schedule reconciliation.
 		return nil, nil, err
 	}
+}
+
+func (s *streamCacheImpl) GetSyncStream(ctx context.Context, streamId StreamId) (SyncStream, error) {
+	entry, _ := s.cache.Load(streamId)
+	if entry == nil {
+		syncStream, _, err := s.tryLoadStreamRecord(ctx, streamId, false)
+		return syncStream, err
+	}
+	return entry.(*streamImpl), nil
 }
 
 func (s *streamCacheImpl) CreateStream(
@@ -309,11 +363,12 @@ func (s *streamCacheImpl) onNewBlockBatch(ctx context.Context) {
 		tasks      sync.WaitGroup
 	)
 
-	// TODO: visiting every stream here is not efficient,
-	// most streams are cold. Add data structure to keep track of streams
-	// that are eligible for miniblock production.
 	s.cache.Range(func(key, value interface{}) bool {
-		stream := value.(*streamImpl)
+		streamVal, ok := s.cache.Load(key)
+		if !ok {
+			return true
+		}
+		stream := streamVal.(*streamImpl)
 		if stream.canCreateMiniblock() {
 			candidates[stream.streamId] = stream
 			if len(candidates) == MiniblockCandidateBatchSize {
@@ -362,7 +417,13 @@ func (s *streamCacheImpl) processMiniblockProposalBatch(
 
 		proposal, err := c.ProposeNextMiniblock(ctx, false)
 		if err != nil {
-			log.Error("processMiniblockProposalBatch: Error creating new miniblock proposal", "streamId", c.streamId, "err", err)
+			log.Error(
+				"processMiniblockProposalBatch: Error creating new miniblock proposal",
+				"streamId",
+				c.streamId,
+				"err",
+				err,
+			)
 			continue
 		}
 		if proposal == nil {

--- a/core/node/events/stream_cache_test.go
+++ b/core/node/events/stream_cache_test.go
@@ -102,7 +102,7 @@ func testStreamCacheViewEviction(t *testing.T, useBatchRegistration bool) {
 	streamCache.registerMiniBlocksBatched = useBatchRegistration
 
 	streamCache.cache.Range(func(key, value any) bool {
-		require.Fail("stream cache should be empty")
+		require.Fail("stream cache must be empty")
 		return true
 	})
 
@@ -151,15 +151,19 @@ func testStreamCacheViewEviction(t *testing.T, useBatchRegistration bool) {
 	require.Equal(0, streamWithoutLoadedView, "stream cache must have no unloaded streams")
 	require.Equal(1, streamWithLoadedViewCount, "stream cache must have one loaded stream")
 
-	// stream now has a subscriber and its view should not be evicted from cache
-	receiver := testStreamCacheViewEvictionSub{}
-	err = streamSync.Sub(ctx, streamView.SyncCookie(node.Wallet.Address), receiver)
-	require.NoError(err, "subscribing to stream")
+	// views of inactive stream must be dropped, even if there are subscribers
+	receiver := &testStreamCacheViewEvictionSub{}
+	syncCookie := streamView.SyncCookie(node.Wallet.Address)
+
+	err = streamSync.Sub(ctx, syncCookie, receiver)
+	require.NoError(err, "subscribe to stream")
+
 	time.Sleep(10 * time.Millisecond) // make sure we hit the cache expiration of 1 ms
 	ctxShort, cancelShort := context.WithTimeout(ctx, 25*time.Millisecond)
 	streamCache.cacheCleanup(ctxShort, time.Millisecond, time.Millisecond)
 	cancelShort()
 
+	// cache must have view dropped even there is a subscriber
 	streamWithoutLoadedView = 0
 	streamWithLoadedViewCount = 0
 	streamCache.cache.Range(func(key, value any) bool {
@@ -171,10 +175,10 @@ func testStreamCacheViewEviction(t *testing.T, useBatchRegistration bool) {
 		}
 		return true
 	})
-	require.Equal(0, streamWithoutLoadedView, "stream cache must have no unloaded streams")
-	require.Equal(1, streamWithLoadedViewCount, "stream cache must have one loaded stream")
+	require.Equal(1, streamWithoutLoadedView, "stream cache must have 1 unloaded streams")
+	require.Equal(0, streamWithLoadedViewCount, "stream cache must have no loaded stream")
 
-	// unsubscribe from stream and making it eligible to get dropped from cache
+	// unsubscribe from stream should not change which stream views are loaded/unloaded
 	streamSync.Unsub(receiver)
 
 	// no subscribers anymore so its view must be dropped from cache
@@ -194,8 +198,8 @@ func testStreamCacheViewEviction(t *testing.T, useBatchRegistration bool) {
 		}
 		return true
 	})
-	require.Equal(1, streamWithoutLoadedView, "stream cache must have no unloaded streams")
-	require.Equal(0, streamWithLoadedViewCount, "stream cache must have one loaded stream")
+	require.Equal(1, streamWithoutLoadedView, "stream cache must have 1 unloaded streams")
+	require.Equal(0, streamWithLoadedViewCount, "stream cache must have ne loaded stream")
 
 	// stream view must be loaded again in cache
 	_, _, err = streamCache.GetStream(ctx, streamID)
@@ -212,7 +216,7 @@ func testStreamCacheViewEviction(t *testing.T, useBatchRegistration bool) {
 		return true
 	})
 	require.Equal(0, streamWithoutLoadedView, "stream cache must have no unloaded streams")
-	require.Equal(1, streamWithLoadedViewCount, "stream cache must have one loaded stream")
+	require.Equal(1, streamWithLoadedViewCount, "stream cache must have 1 loaded stream")
 }
 
 func testCacheEvictionWithFilledMiniBlockPool(t *testing.T, useBatchRegistration bool) {
@@ -353,67 +357,24 @@ func testCacheEvictionWithFilledMiniBlockPool(t *testing.T, useBatchRegistration
 	require.Nil(loadedStream.(*streamImpl).view, "view loaded in cache")
 }
 
-type testStreamCacheViewEvictionSub struct{}
+type testStreamCacheViewEvictionSub struct {
+	receivedStreamAndCookies []*protocol.StreamAndCookie
+	receivedErrors           []error
+}
 
-func (testStreamCacheViewEvictionSub) OnUpdate(r *protocol.StreamAndCookie) {}
-func (testStreamCacheViewEvictionSub) OnSyncError(err error)                {}
+func (sub *testStreamCacheViewEvictionSub) OnUpdate(sac *protocol.StreamAndCookie) {
+	sub.receivedStreamAndCookies = append(sub.receivedStreamAndCookies, sac)
+}
+
+func (sub *testStreamCacheViewEvictionSub) OnSyncError(err error) {
+	sub.receivedErrors = append(sub.receivedErrors, err)
+}
 
 func testStreamMiniblockBatchProduction(t *testing.T, useBatchRegistration bool) {
 	var (
-		ctx, cancel     = test.NewTestContext()
-		require         = require.New(t)
-		streamsCount    = 10*MiniblockCandidateBatchSize - 1
-		allocateStreams = func(
-			btc *crypto.BlockchainTestContext,
-			count int,
-			node *crypto.Blockchain,
-			riverRegistry *registries.RiverRegistryContract,
-		) map[shared.StreamId]*protocol.Miniblock {
-			var (
-				genesisBlocks = make(map[shared.StreamId]*protocol.Miniblock)
-				lastPendingTx crypto.TransactionPoolPendingTransaction
-			)
-
-			for i := 0; i < count; i++ {
-				var (
-					nodes            = []common.Address{node.Wallet.Address}
-					streamID         = testutils.FakeStreamId(shared.STREAM_SPACE_BIN)
-					genesisMiniblock = MakeGenesisMiniblockForSpaceStream(t, node.Wallet, streamID)
-				)
-
-				genesisMiniblockBytes, err := proto.Marshal(genesisMiniblock)
-				require.NoError(err, "marshalling genesis miniblock")
-
-				pendingTx, err := node.TxPool.Submit(
-					ctx,
-					"AllocateStream",
-					func(opts *bind.TransactOpts) (*types.Transaction, error) {
-						return riverRegistry.StreamRegistry.AllocateStream(
-							opts,
-							streamID,
-							nodes,
-							[32]byte(genesisMiniblock.Header.Hash),
-							genesisMiniblockBytes,
-						)
-					},
-				)
-				require.NoError(err, "submit allocate stream tx")
-				lastPendingTx = pendingTx
-				genesisBlocks[streamID] = genesisMiniblock
-			}
-
-			for {
-				btc.Commit(ctx)
-				select {
-				case receipt := <-lastPendingTx.Wait():
-					require.Equal(crypto.TransactionResultSuccess, receipt.Status,
-						"allocate streams failed")
-					return genesisBlocks
-				case <-time.After(time.Second):
-					continue
-				}
-			}
-		}
+		ctx, cancel  = test.NewTestContext()
+		require      = require.New(t)
+		streamsCount = 10*MiniblockCandidateBatchSize - 1
 	)
 	defer cancel()
 
@@ -466,18 +427,19 @@ func testStreamMiniblockBatchProduction(t *testing.T, useBatchRegistration bool)
 	// btc.DeployerBlockchain.TxPool.SetOnSubmitHandler(nil)
 
 	var (
-		genesisBlocks     = allocateStreams(btc, streamsCount, node, riverRegistry)
+		genesisBlocks     = allocateStreams(t, ctx, btc, streamsCount, node, riverRegistry)
 		streamsWithEvents = make(map[shared.StreamId]int)
 	)
 
 	// add events to ~50% of the streams
 	for streamID, genesis := range genesisBlocks {
-		streamSync, _, err := streamCache.GetStream(ctx, streamID)
+		streamSync, err := streamCache.GetSyncStream(ctx, streamID)
 		require.NoError(err, "get stream")
 
 		// unload view for half of the streams
 		if streamID[1]%2 == 1 {
-			streamSync.(*streamImpl).tryCleanup(time.Duration(0))
+			ss := streamSync.(*streamImpl)
+			ss.tryCleanup(time.Duration(0))
 		}
 
 		// only add events to half of the streams
@@ -529,5 +491,221 @@ func testStreamMiniblockBatchProduction(t *testing.T, useBatchRegistration bool)
 		}
 
 		<-time.After(time.Second)
+	}
+}
+
+func TestStreamUnloadWithSubscribers(t *testing.T) {
+	var (
+		ctx, cancel  = test.NewTestContext()
+		require      = require.New(t)
+		streamsCount = 5
+		cleanUpCache = func(streamCache *streamCacheImpl, expOutcome bool) {
+			streamCache.cache.Range(func(key, streamVal any) bool {
+				stream := streamVal.(*streamImpl)
+				require.Equal(expOutcome, stream.tryCleanup(0), "stream cleanup")
+				return true
+			})
+		}
+		ensureAllViewsAreDropped = func(streamCache *streamCacheImpl) {
+			// make sure that for no view is loaded for any of the streams
+			streamCache.cache.Range(func(key, value any) bool {
+				stream := value.(*streamImpl)
+				require.Nil(stream.view, "stream view loaded")
+				return true
+			})
+		}
+	)
+	defer cancel()
+
+	btc, err := crypto.NewBlockchainTestContext(ctx, 1, true)
+	require.NoError(err, "instantiating blockchain test context")
+	defer btc.Close()
+
+	node := btc.GetBlockchain(ctx, 0)
+	pendingTx, err := btc.DeployerBlockchain.TxPool.Submit(
+		ctx,
+		"RegisterNode",
+		func(opts *bind.TransactOpts) (*types.Transaction, error) {
+			return btc.NodeRegistry.RegisterNode(opts, node.Wallet.Address, "http://node.local:1234", 2)
+		},
+	)
+
+	require.NoError(err, "register node")
+	receipt := <-pendingTx.Wait()
+	require.Equal(crypto.TransactionResultSuccess, receipt.Status, "register node transaction failed")
+
+	riverRegistry, err := registries.NewRiverRegistryContract(ctx, node, &config.ContractConfig{
+		Address: btc.RiverRegistryAddress,
+	})
+	require.NoError(err, "instantiating river registry contract")
+
+	pg := storage.NewTestPgStore(ctx)
+	defer pg.Close()
+
+	streamCache, err := NewStreamCache(ctx, &StreamCacheParams{
+		Storage:    pg.Storage,
+		Wallet:     node.Wallet,
+		Riverchain: node,
+		Registry:   riverRegistry,
+		StreamConfig: &config.StreamConfig{
+			CacheExpiration: 0, // disable cache expiration, done manually
+		},
+	}, node.InitialBlockNum, node.ChainMonitor)
+	require.NoError(err, "instantiating stream cache")
+
+	streamCache.registerMiniBlocksBatched = true
+
+	streamCache.cache.Range(func(key, value any) bool {
+		require.Fail("stream cache should be empty")
+		return true
+	})
+
+	// the stream cache uses the chain block production as a ticker to create new mini-blocks.
+	// after initialization take back control when to create new chain blocks.
+	// TODO: this handler is gone, refactor
+	// btc.DeployerBlockchain.TxPool.SetOnSubmitHandler(nil)
+
+	var (
+		genesisBlocks         = allocateStreams(t, ctx, btc, streamsCount, node, riverRegistry)
+		syncCookies           = make(map[shared.StreamId]*protocol.SyncCookie)
+		subscriptionReceivers = make(map[shared.StreamId]*testStreamCacheViewEvictionSub)
+		eventsReceived        = func(sub *testStreamCacheViewEvictionSub) int {
+			count := 0
+			for _, sac := range sub.receivedStreamAndCookies {
+				count += len(sac.Events)
+			}
+			return count
+		}
+	)
+
+	// obtain sync cookies for allocated streams
+	for streamID := range genesisBlocks {
+		// get sync cookies so we can start from somewhere
+		_, streamView, err := streamCache.GetStream(ctx, streamID)
+		require.NoError(err, "get stream")
+		syncCookies[streamID] = streamView.SyncCookie(node.Wallet.Address)
+	}
+
+	blockNum, err := node.GetBlockNumber(ctx)
+	require.NoError(err, "get block number")
+
+	// create fresh stream cache and subscribe
+	streamCache, err = NewStreamCache(ctx, &StreamCacheParams{
+		Storage:    pg.Storage,
+		Wallet:     node.Wallet,
+		Riverchain: node,
+		Registry:   riverRegistry,
+		StreamConfig: &config.StreamConfig{
+			CacheExpiration: 0, // disable cache expiration, done manually
+		},
+	}, blockNum, node.ChainMonitor)
+	require.NoError(err, "instantiating stream cache")
+
+	for streamID, syncCookie := range syncCookies {
+		streamSync, err := streamCache.GetSyncStream(ctx, streamID)
+		require.NoError(err, "get sync stream")
+		subscriptionReceivers[streamID] = new(testStreamCacheViewEvictionSub)
+		err = streamSync.Sub(ctx, syncCookie, subscriptionReceivers[streamID])
+		require.NoError(err, "sub stream")
+	}
+
+	// when subscribing to a stream the view is loaded to validate the request. It can be dropped afterward.
+	cleanUpCache(streamCache, true)
+	ensureAllViewsAreDropped(streamCache)
+
+	// add events to the first 2 streams and ensure that the receiver is notified even when the stream view is dropped.
+	var (
+		count                = 0
+		streamsWithEvents    = make(map[shared.StreamId]int)
+		streamsWithoutEvents = make(map[shared.StreamId]int)
+	)
+
+	for streamID, genesis := range genesisBlocks {
+		count++
+		if count < 2 {
+			streamSync, err := streamCache.GetSyncStream(ctx, streamID)
+			require.NoError(err, "get sync stream")
+			for i := 0; i < 1+int(streamID[3]%50); i++ {
+				addEvent(t, ctx, streamCache.params, streamSync,
+					fmt.Sprintf("msg# %d", i), common.BytesToHash(genesis.Header.Hash))
+			}
+			streamsWithEvents[streamID] = 1 + int(streamID[3]%50)
+		} else {
+			streamsWithoutEvents[streamID] = 0
+		}
+	}
+
+	// ensure that subscribers received events even when their view is dropped
+	for streamID, expectedEventCount := range streamsWithEvents {
+		subscriber := subscriptionReceivers[streamID]
+		gotEventCount := eventsReceived(subscriber)
+		require.Nilf(subscriber.receivedErrors, "subscriber received error: %s", subscriber.receivedErrors)
+		require.Equal(expectedEventCount, gotEventCount, "subscriber unexpected event count")
+	}
+
+	// make all mini-blocks to process all events in minipool
+	streamCache.onNewBlockBatch(ctx)
+
+	// ensure that streams can be dropped again
+	streamCache.cache.Range(func(streamID, streamVal any) bool {
+		stream := streamVal.(*streamImpl)
+		stream.tryCleanup(0)
+		return true
+	})
+
+	// make sure that all views are dropped
+	ensureAllViewsAreDropped(streamCache)
+}
+
+func allocateStreams(
+	t *testing.T,
+	ctx context.Context,
+	btc *crypto.BlockchainTestContext,
+	count int,
+	node *crypto.Blockchain,
+	riverRegistry *registries.RiverRegistryContract,
+) map[shared.StreamId]*protocol.Miniblock {
+	var (
+		require       = require.New(t)
+		genesisBlocks = make(map[shared.StreamId]*protocol.Miniblock)
+		lastPendingTx crypto.TransactionPoolPendingTransaction
+	)
+
+	for i := 0; i < count; i++ {
+		var (
+			nodes            = []common.Address{node.Wallet.Address}
+			streamID         = testutils.FakeStreamId(shared.STREAM_SPACE_BIN)
+			genesisMiniblock = MakeGenesisMiniblockForSpaceStream(t, node.Wallet, streamID)
+		)
+
+		genesisMiniblockBytes, err := proto.Marshal(genesisMiniblock)
+		require.NoError(err, "marshalling genesis miniblock")
+
+		pendingTx, err := node.TxPool.Submit(ctx, "AllocateStream",
+			func(opts *bind.TransactOpts) (*types.Transaction, error) {
+				return riverRegistry.StreamRegistry.AllocateStream(
+					opts,
+					streamID,
+					nodes,
+					[32]byte(genesisMiniblock.Header.Hash),
+					genesisMiniblockBytes,
+				)
+			},
+		)
+		require.NoError(err, "submit allocate stream tx")
+		lastPendingTx = pendingTx
+		genesisBlocks[streamID] = genesisMiniblock
+	}
+
+	for {
+		btc.Commit(ctx)
+		select {
+		case receipt := <-lastPendingTx.Wait():
+			require.Equal(crypto.TransactionResultSuccess, receipt.Status,
+				"allocate streams failed")
+			return genesisBlocks
+		case <-time.After(time.Second):
+			continue
+		}
 	}
 }

--- a/core/node/rpc/get_miniblocks.go
+++ b/core/node/rpc/get_miniblocks.go
@@ -34,7 +34,7 @@ func (s *Service) getMiniblocks(
 		return nil, err
 	}
 
-	stream, _, err := s.cache.GetStream(ctx, streamId)
+	stream, err := s.cache.GetSyncStream(ctx, streamId)
 	if err != nil {
 		return nil, err
 	}

--- a/core/node/rpc/info.go
+++ b/core/node/rpc/info.go
@@ -129,7 +129,7 @@ func (s *Service) debugInfoMakeMiniblock(
 		return nil, err
 	}
 	if nodes.IsLocal() {
-		stream, _, err := s.cache.GetStream(ctx, streamId)
+		stream, err := s.cache.GetSyncStream(ctx, streamId)
 		if err != nil {
 			return nil, err
 		}

--- a/core/node/rpc/node2node.go
+++ b/core/node/rpc/node2node.go
@@ -81,7 +81,7 @@ func (s *Service) newEventReceived(
 		return nil, err
 	}
 
-	stream, _, err := s.cache.GetStream(ctx, streamId)
+	stream, err := s.cache.GetSyncStream(ctx, streamId)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- [X] Adds a new method to the stream cache `GetSyncStream`. It loads the stream without loading its view. This view is not required for subscribing to the view.
- [X] Also unload the stream view for streams that not have received events within a configurable period but do have subscribers, e.g. cold streams.
- [X] Add metrics to monitor how many streams are loaded in the cache and how many of these streams have their view unloaded.