### PR TITLE
adding .proto source files as a package dependency to core/proto

### DIFF
--- a/core/proto/package.json
+++ b/core/proto/package.json
@@ -22,7 +22,8 @@
     "dependencies": {
         "@bufbuild/protobuf": "^1.9.0",
         "@connectrpc/connect": "^1.4.0",
-        "@connectrpc/connect-web": "^1.4.0"
+        "@connectrpc/connect-web": "^1.4.0",
+        "@river-build/proto-source": "workspace:^"
     },
     "devDependencies": {
         "@bufbuild/buf": "^1.32.0",

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     },
     "workspaces": [
         "core/*",
+        "protocol",
         "packages/*",
         "contracts"
     ]

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "@river-build/proto-source",
+    "packageManager": "yarn@3.8.0"
+}

--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,7 @@
         "build": {
             // note: output globs are relative to each package's `package.json`
             // (and not the monorepo root
-            "outputs": ["dist/**", "build/**", "out/**", "!core/proto/dist/**"],
+            "outputs": ["dist/**", "build/**", "out/**"],
             "cache": true,
             "dependsOn": ["^build"]
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2408,6 +2408,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@river-build/proto-source@workspace:^, @river-build/proto-source@workspace:protocol":
+  version: 0.0.0-use.local
+  resolution: "@river-build/proto-source@workspace:protocol"
+  languageName: unknown
+  linkType: soft
+
 "@river-build/proto@workspace:^, @river-build/proto@workspace:core/proto":
   version: 0.0.0-use.local
   resolution: "@river-build/proto@workspace:core/proto"
@@ -2418,6 +2424,7 @@ __metadata:
     "@connectrpc/connect": ^1.4.0
     "@connectrpc/connect-web": ^1.4.0
     "@connectrpc/protoc-gen-connect-es": ^1.4.0
+    "@river-build/proto-source": "workspace:^"
     "@types/jest": ^29.5.3
     jest: ^29.6.2
     jest-extended: ^4.0.1


### PR DESCRIPTION
This PR is part 1 of a series of small PRs to fix the turbo cache, along with a few other recently introduced issues.

- Turns the river/protocol directory into an npm package, so that @river/proto can explicitly depend on it while building. this will ensure proper caching for turbo build