### PR TITLE
Update token struct used for test cases to use local base chain id

### DIFF
--- a/core/web3/src/entitlement.ts
+++ b/core/web3/src/entitlement.ts
@@ -526,7 +526,7 @@ export function createExternalTokenStruct(addresses: Address[]) {
         return NoopRuleData
     }
     const defaultChain = addresses.map((address) => ({
-        chainId: 1n,
+        chainId: 31337n,
         address: address,
         type: CheckOperationType.ERC20 as const,
     }))

--- a/core/web3/src/entitlement.ts
+++ b/core/web3/src/entitlement.ts
@@ -537,15 +537,19 @@ export function createExternalTokenStruct(
     return createOperationsTree(defaultChain)
 }
 
-export function createExternalNFTStruct(addresses: Address[]) {
+export function createExternalNFTStruct(
+    addresses: Address[],
+    checkOptions?: (Partial<Omit<ContractCheckOperation, 'address'>>),
+) {
     if (addresses.length === 0) {
         return NoopRuleData
     }
     const defaultChain = addresses.map((address) => ({
         // Anvil chain id
-        chainId: 31337n,
+        chainId: checkOptions?.chainId ?? 31337n,
         address: address,
-        type: CheckOperationType.ERC721 as const,
+        type: checkOptions?.type ?? CheckOperationType.ERC721 as const,
+        threshold: checkOptions?.threshold ?? BigInt(1),
     }))
     return createOperationsTree(defaultChain)
 }

--- a/core/web3/src/entitlement.ts
+++ b/core/web3/src/entitlement.ts
@@ -523,7 +523,7 @@ export async function evaluateTree(
 // checks for testing.
 export function createExternalTokenStruct(
     addresses: Address[],
-    checkOptions?: (Partial<Omit<ContractCheckOperation, 'address'>>),
+    checkOptions?: Partial<Omit<ContractCheckOperation, 'address'>>,
 ) {
     if (addresses.length === 0) {
         return NoopRuleData
@@ -531,7 +531,7 @@ export function createExternalTokenStruct(
     const defaultChain = addresses.map((address) => ({
         chainId: checkOptions?.chainId ?? 1n,
         address: address,
-        type: checkOptions?.type ?? CheckOperationType.ERC20 as const,
+        type: checkOptions?.type ?? (CheckOperationType.ERC20 as const),
         threshold: checkOptions?.threshold ?? BigInt(1),
     }))
     return createOperationsTree(defaultChain)
@@ -539,7 +539,7 @@ export function createExternalTokenStruct(
 
 export function createExternalNFTStruct(
     addresses: Address[],
-    checkOptions?: (Partial<Omit<ContractCheckOperation, 'address'>>),
+    checkOptions?: Partial<Omit<ContractCheckOperation, 'address'>>,
 ) {
     if (addresses.length === 0) {
         return NoopRuleData
@@ -548,7 +548,7 @@ export function createExternalNFTStruct(
         // Anvil chain id
         chainId: checkOptions?.chainId ?? 31337n,
         address: address,
-        type: checkOptions?.type ?? CheckOperationType.ERC721 as const,
+        type: checkOptions?.type ?? (CheckOperationType.ERC721 as const),
         threshold: checkOptions?.threshold ?? BigInt(1),
     }))
     return createOperationsTree(defaultChain)

--- a/core/web3/src/entitlement.ts
+++ b/core/web3/src/entitlement.ts
@@ -521,14 +521,18 @@ export async function evaluateTree(
 
 // These two methods are used to create a rule data struct for an external token or NFT
 // checks for testing.
-export function createExternalTokenStruct(addresses: Address[]) {
+export function createExternalTokenStruct(
+    addresses: Address[],
+    checkOptions?: (Partial<Omit<ContractCheckOperation, 'address'>>),
+) {
     if (addresses.length === 0) {
         return NoopRuleData
     }
     const defaultChain = addresses.map((address) => ({
-        chainId: 31337n,
+        chainId: checkOptions?.chainId ?? 1n,
         address: address,
-        type: CheckOperationType.ERC20 as const,
+        type: checkOptions?.type ?? CheckOperationType.ERC20 as const,
+        threshold: checkOptions?.threshold ?? BigInt(1),
     }))
     return createOperationsTree(defaultChain)
 }


### PR DESCRIPTION
These test cases broken when I moved entitlement evaluation to stream node for channels, I am updating this to use local base chain id so I can re-enable the tests in harmony.