### PR TITLE
UserOps IT test fix: Re-use existing method for creating entitlement struct for role updates

### DIFF
--- a/core/web3/src/v3/SpaceDapp.ts
+++ b/core/web3/src/v3/SpaceDapp.ts
@@ -15,7 +15,6 @@ import {
     UpdateChannelParams,
     UpdateRoleParams,
 } from '../ISpaceDapp'
-import { createRuleEntitlementStruct, createUserEntitlementStruct } from '../ConvertersEntitlements'
 
 import { IRolesBase } from './IRolesShim'
 import { Space } from './Space'

--- a/core/web3/src/v3/SpaceDapp.ts
+++ b/core/web3/src/v3/SpaceDapp.ts
@@ -915,26 +915,7 @@ export class SpaceDapp implements ISpaceDapp {
         space: Space,
         params: UpdateRoleParams,
     ): Promise<IRolesBase.CreateEntitlementStruct[]> {
-        const updatedEntitlements: IRolesBase.CreateEntitlementStruct[] = []
-        const [userEntitlement, ruleEntitlement] = await Promise.all([
-            space.findEntitlementByType(EntitlementModuleType.UserEntitlement),
-            space.findEntitlementByType(EntitlementModuleType.RuleEntitlement),
-        ])
-        if (params.users.length > 0 && userEntitlement?.address) {
-            const entitlementData = createUserEntitlementStruct(
-                userEntitlement.address,
-                params.users,
-            )
-            updatedEntitlements.push(entitlementData)
-        }
-        if (params.ruleData && ruleEntitlement?.address) {
-            const entitlementData = createRuleEntitlementStruct(
-                ruleEntitlement.address as `0x${string}`,
-                params.ruleData,
-            )
-            updatedEntitlements.push(entitlementData)
-        }
-        return updatedEntitlements
+        return createEntitlementStruct(space, params.users, params.ruleData);
     }
 
     public getSpaceAddress(receipt: ContractReceipt): string | undefined {

--- a/core/web3/src/v3/SpaceDapp.ts
+++ b/core/web3/src/v3/SpaceDapp.ts
@@ -915,7 +915,7 @@ export class SpaceDapp implements ISpaceDapp {
         space: Space,
         params: UpdateRoleParams,
     ): Promise<IRolesBase.CreateEntitlementStruct[]> {
-        return createEntitlementStruct(space, params.users, params.ruleData);
+        return createEntitlementStruct(space, params.users, params.ruleData)
     }
 
     public getSpaceAddress(receipt: ContractReceipt): string | undefined {


### PR DESCRIPTION
This is the same logic implemented in createEntitlementStruct and will now include the change to not create rule entitlements for empty rule datas, which is what was causing the userops role test to fail in harmony.