### PR TITLE
Banning fix plus test cases

### DIFF
--- a/core/node/auth/banning.go
+++ b/core/node/auth/banning.go
@@ -104,6 +104,11 @@ func NewBanning(
 		return nil, err
 	}
 
+	tokenContract, err := baseContracts.NewErc721aQueryable(spaceAddress, backend)
+	if err != nil {
+		return nil, err
+	}
+
 	// Default to 2s
 	negativeCacheTTL := 2 * time.Second
 	if cfg.NegativeEntitlementCacheTTLSeconds > 0 {
@@ -112,6 +117,7 @@ func NewBanning(
 
 	return &banning{
 		contract:           contract,
+		tokenContract:      tokenContract,
 		spaceAddress:       spaceAddress,
 		bannedAddressCache: NewBannedAddressCache(negativeCacheTTL),
 	}, nil

--- a/core/node/auth/banning_test.go
+++ b/core/node/auth/banning_test.go
@@ -1,0 +1,74 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBanningCache(t *testing.T) {
+	bannedAddressCache := NewBannedAddressCache(1 * time.Second)
+
+	require.Len(t, bannedAddressCache.bannedAddresses, 0)
+
+	start := time.Now()
+	isBanned, err := bannedAddressCache.IsBanned(
+		[]common.Address{common.HexToAddress("0x1")},
+		func() (map[common.Address]struct{}, error) {
+
+			return map[common.Address]struct{}{
+				common.HexToAddress("0x1"): {},
+			}, nil
+		},
+	)
+	end := time.Now()
+
+	require.NoError(t, err)
+	require.True(t, isBanned)
+	require.Len(t, bannedAddressCache.bannedAddresses, 1)
+
+	// Approximately validate the lastUpdated time
+	require.GreaterOrEqual(t, bannedAddressCache.lastUpdated, start)
+	require.GreaterOrEqual(t, end, bannedAddressCache.lastUpdated)
+
+	time.Sleep(1 * time.Second)
+
+	start = time.Now()
+	isBanned, err = bannedAddressCache.IsBanned(
+		[]common.Address{common.HexToAddress("0x1")},
+		func() (map[common.Address]struct{}, error) {
+
+			return map[common.Address]struct{}{
+				common.HexToAddress("0x2"): {},
+			}, nil
+		},
+	)
+	end = time.Now()
+	lastUpdated := bannedAddressCache.lastUpdated
+
+	require.NoError(t, err)
+	require.False(t, isBanned)
+	require.Len(t, bannedAddressCache.bannedAddresses, 1)
+	require.GreaterOrEqual(t, lastUpdated, start)
+	require.GreaterOrEqual(t, end, lastUpdated)
+
+	// cache should not be hit here, we will expect a false result
+	// Note: there is a possibility that this could flake if the tests were running slowly,
+	// but this is extremely unlikely.
+	isBanned, err = bannedAddressCache.IsBanned(
+		[]common.Address{common.HexToAddress("0x2")},
+		func() (map[common.Address]struct{}, error) {
+			return map[common.Address]struct{}{
+				common.HexToAddress("0x1"): {},
+			}, nil
+		},
+	)
+	// Previous onMiss cache value should be used here
+	require.True(t, isBanned)
+	require.NoError(t, err)
+	// Update time has not changed
+	require.Equal(t, lastUpdated, bannedAddressCache.lastUpdated)
+
+}

--- a/packages/sdk/src/channelsWithEntitlements.test.ts
+++ b/packages/sdk/src/channelsWithEntitlements.test.ts
@@ -144,7 +144,7 @@ async function expectUserCanJoinChannel(client: Client, channelId: string) {
 }
 
 describe('channelsWithEntitlements', () => {
-    test('userEntitlementPass', async () => {
+    test.skip('userEntitlementPass', async () => {
         const { alice, bob, channelId } = await setupChannelWithCustomRole(['alice'], NoopRuleData)
 
         // Validate alice can join the channel
@@ -157,7 +157,7 @@ describe('channelsWithEntitlements', () => {
         log('Done', Date.now() - doneStart)
     })
 
-    test('userEntitlementFail', async () => {
+    test.skip('userEntitlementFail', async () => {
         const { alice, bob, channelId } = await setupChannelWithCustomRole(['carol'], NoopRuleData)
 
         await expect(alice.joinStream(channelId!)).rejects.toThrow(/7:PERMISSION_DENIED/)
@@ -169,7 +169,27 @@ describe('channelsWithEntitlements', () => {
         log('Done', Date.now() - doneStart)
     })
 
-    test('userEntitlementPass - join as root, linked wallet whitelisted', async () => {
+    test('banned user cannot join', async () => {
+        const { alice, alicesWallet, bob, bobSpaceDapp, bobProvider, spaceId, channelId } =
+            await setupChannelWithCustomRole(['alice'], NoopRuleData)
+
+        const tx = await bobSpaceDapp.banWalletAddress(
+            spaceId,
+            alicesWallet.address,
+            bobProvider.wallet,
+        )
+        await tx.wait()
+
+        await expect(alice.joinStream(channelId!)).rejects.toThrow(/7:PERMISSION_DENIED/)
+
+        const doneStart = Date.now()
+        // kill the clients
+        await bob.stopSync()
+        await alice.stopSync()
+        log('Done', Date.now() - doneStart)
+    })
+
+    test.skip('userEntitlementPass - join as root, linked wallet whitelisted', async () => {
         const { alice, aliceSpaceDapp, aliceProvider, carolProvider, bob, channelId } =
             await setupChannelWithCustomRole(['carol'], NoopRuleData)
 
@@ -186,7 +206,7 @@ describe('channelsWithEntitlements', () => {
         log('Done', Date.now() - doneStart)
     })
 
-    test('userEntitlementPass - join as linked wallet, root wallet whitelisted', async () => {
+    test.skip('userEntitlementPass - join as linked wallet, root wallet whitelisted', async () => {
         const { alice, carolSpaceDapp, aliceProvider, carolProvider, bob, channelId } =
             await setupChannelWithCustomRole(['carol'], NoopRuleData)
 
@@ -203,7 +223,7 @@ describe('channelsWithEntitlements', () => {
         log('Done linked-wallet-whitelist', Date.now() - doneStart)
     })
 
-    test('oneNftGateJoinPass - join as root, asset in linked wallet', async () => {
+    test.skip('oneNftGateJoinPass - join as root, asset in linked wallet', async () => {
         const testNft1Address = await getContractAddress('TestNFT1')
         const {
             alice,
@@ -231,7 +251,7 @@ describe('channelsWithEntitlements', () => {
         log('Done', Date.now() - doneStart)
     })
 
-    test('oneNftGateJoinPass - join as linked wallet, asset in root wallet', async () => {
+    test.skip('oneNftGateJoinPass - join as linked wallet, asset in root wallet', async () => {
         const testNft1Address = await getContractAddress('TestNFT1')
         const {
             alice,
@@ -260,7 +280,7 @@ describe('channelsWithEntitlements', () => {
         log('Done', Date.now() - doneStart)
     })
 
-    test('oneNftGateJoinPass', async () => {
+    test.skip('oneNftGateJoinPass', async () => {
         const testNftAddress = await getContractAddress('TestNFT')
         const { alice, alicesWallet, bob, channelId } = await setupChannelWithCustomRole(
             [],
@@ -278,7 +298,7 @@ describe('channelsWithEntitlements', () => {
         await alice.stopSync()
     })
 
-    test('oneNftGateJoinFail', async () => {
+    test.skip('oneNftGateJoinFail', async () => {
         const testNft1Address = await getContractAddress('TestNFT1')
         const { alice, bob, channelId } = await setupChannelWithCustomRole(
             [],
@@ -293,7 +313,7 @@ describe('channelsWithEntitlements', () => {
         await alice.stopSync()
     })
 
-    test('twoNftGateJoinPass', async () => {
+    test.skip('twoNftGateJoinPass', async () => {
         const testNft1Address = await getContractAddress('TestNFT1')
         const testNft2Address = await getContractAddress('TestNFT2')
         const { alice, bob, alicesWallet, channelId } = await setupChannelWithCustomRole(
@@ -318,7 +338,7 @@ describe('channelsWithEntitlements', () => {
         log('Done', Date.now() - doneStart)
     })
 
-    test('twoNftGateJoinPass - acrossLinkedWallets', async () => {
+    test.skip('twoNftGateJoinPass - acrossLinkedWallets', async () => {
         const testNft1Address = await getContractAddress('TestNFT1')
         const testNft2Address = await getContractAddress('TestNFT2')
         const {
@@ -351,7 +371,7 @@ describe('channelsWithEntitlements', () => {
         log('Done', Date.now() - doneStart)
     })
 
-    test('twoNftGateJoinFail', async () => {
+    test.skip('twoNftGateJoinFail', async () => {
         const testNft1Address = await getContractAddress('TestNFT1')
         const testNft2Address = await getContractAddress('TestNFT2')
         const { alice, bob, alicesWallet, channelId } = await setupChannelWithCustomRole(
@@ -371,7 +391,7 @@ describe('channelsWithEntitlements', () => {
         await alice.stopSync()
     })
 
-    test('OrOfTwoNftGateJoinPass', async () => {
+    test.skip('OrOfTwoNftGateJoinPass', async () => {
         const testNft1Address = await getContractAddress('TestNFT1')
         const testNft2Address = await getContractAddress('TestNFT2')
         const { alice, bob, alicesWallet, channelId } = await setupChannelWithCustomRole(
@@ -392,7 +412,7 @@ describe('channelsWithEntitlements', () => {
         log('Done', Date.now() - doneStart)
     })
 
-    test('orOfTwoNftOrOneNftGateJoinPass', async () => {
+    test.skip('orOfTwoNftOrOneNftGateJoinPass', async () => {
         const testNft1Address = await getContractAddress('TestNFT1')
         const testNft2Address = await getContractAddress('TestNFT2')
         const testNft3Address = await getContractAddress('TestNFT3')
@@ -453,7 +473,7 @@ describe('channelsWithEntitlements', () => {
     })
 
     // Banning with entitlements — users need permission to ban other users.
-    test('adminsCanRedactChannelMessages', async () => {
+    test.skip('adminsCanRedactChannelMessages', async () => {
         // log('start adminsCanRedactChannelMessages')
         // // set up the web3 provider and spacedapp
         const {

--- a/packages/sdk/src/channelsWithEntitlements.test.ts
+++ b/packages/sdk/src/channelsWithEntitlements.test.ts
@@ -144,7 +144,7 @@ async function expectUserCanJoinChannel(client: Client, channelId: string) {
 }
 
 describe('channelsWithEntitlements', () => {
-    test.skip('userEntitlementPass', async () => {
+    test('userEntitlementPass', async () => {
         const { alice, bob, channelId } = await setupChannelWithCustomRole(['alice'], NoopRuleData)
 
         // Validate alice can join the channel
@@ -157,7 +157,7 @@ describe('channelsWithEntitlements', () => {
         log('Done', Date.now() - doneStart)
     })
 
-    test.skip('userEntitlementFail', async () => {
+    test('userEntitlementFail', async () => {
         const { alice, bob, channelId } = await setupChannelWithCustomRole(['carol'], NoopRuleData)
 
         await expect(alice.joinStream(channelId!)).rejects.toThrow(/7:PERMISSION_DENIED/)
@@ -189,7 +189,7 @@ describe('channelsWithEntitlements', () => {
         log('Done', Date.now() - doneStart)
     })
 
-    test.skip('userEntitlementPass - join as root, linked wallet whitelisted', async () => {
+    test('userEntitlementPass - join as root, linked wallet whitelisted', async () => {
         const { alice, aliceSpaceDapp, aliceProvider, carolProvider, bob, channelId } =
             await setupChannelWithCustomRole(['carol'], NoopRuleData)
 
@@ -206,7 +206,7 @@ describe('channelsWithEntitlements', () => {
         log('Done', Date.now() - doneStart)
     })
 
-    test.skip('userEntitlementPass - join as linked wallet, root wallet whitelisted', async () => {
+    test('userEntitlementPass - join as linked wallet, root wallet whitelisted', async () => {
         const { alice, carolSpaceDapp, aliceProvider, carolProvider, bob, channelId } =
             await setupChannelWithCustomRole(['carol'], NoopRuleData)
 
@@ -223,7 +223,7 @@ describe('channelsWithEntitlements', () => {
         log('Done linked-wallet-whitelist', Date.now() - doneStart)
     })
 
-    test.skip('oneNftGateJoinPass - join as root, asset in linked wallet', async () => {
+    test('oneNftGateJoinPass - join as root, asset in linked wallet', async () => {
         const testNft1Address = await getContractAddress('TestNFT1')
         const {
             alice,
@@ -251,7 +251,7 @@ describe('channelsWithEntitlements', () => {
         log('Done', Date.now() - doneStart)
     })
 
-    test.skip('oneNftGateJoinPass - join as linked wallet, asset in root wallet', async () => {
+    test('oneNftGateJoinPass - join as linked wallet, asset in root wallet', async () => {
         const testNft1Address = await getContractAddress('TestNFT1')
         const {
             alice,
@@ -280,7 +280,7 @@ describe('channelsWithEntitlements', () => {
         log('Done', Date.now() - doneStart)
     })
 
-    test.skip('oneNftGateJoinPass', async () => {
+    test('oneNftGateJoinPass', async () => {
         const testNftAddress = await getContractAddress('TestNFT')
         const { alice, alicesWallet, bob, channelId } = await setupChannelWithCustomRole(
             [],
@@ -298,7 +298,7 @@ describe('channelsWithEntitlements', () => {
         await alice.stopSync()
     })
 
-    test.skip('oneNftGateJoinFail', async () => {
+    test('oneNftGateJoinFail', async () => {
         const testNft1Address = await getContractAddress('TestNFT1')
         const { alice, bob, channelId } = await setupChannelWithCustomRole(
             [],
@@ -313,7 +313,7 @@ describe('channelsWithEntitlements', () => {
         await alice.stopSync()
     })
 
-    test.skip('twoNftGateJoinPass', async () => {
+    test('twoNftGateJoinPass', async () => {
         const testNft1Address = await getContractAddress('TestNFT1')
         const testNft2Address = await getContractAddress('TestNFT2')
         const { alice, bob, alicesWallet, channelId } = await setupChannelWithCustomRole(
@@ -338,7 +338,7 @@ describe('channelsWithEntitlements', () => {
         log('Done', Date.now() - doneStart)
     })
 
-    test.skip('twoNftGateJoinPass - acrossLinkedWallets', async () => {
+    test('twoNftGateJoinPass - acrossLinkedWallets', async () => {
         const testNft1Address = await getContractAddress('TestNFT1')
         const testNft2Address = await getContractAddress('TestNFT2')
         const {
@@ -371,7 +371,7 @@ describe('channelsWithEntitlements', () => {
         log('Done', Date.now() - doneStart)
     })
 
-    test.skip('twoNftGateJoinFail', async () => {
+    test('twoNftGateJoinFail', async () => {
         const testNft1Address = await getContractAddress('TestNFT1')
         const testNft2Address = await getContractAddress('TestNFT2')
         const { alice, bob, alicesWallet, channelId } = await setupChannelWithCustomRole(
@@ -391,7 +391,7 @@ describe('channelsWithEntitlements', () => {
         await alice.stopSync()
     })
 
-    test.skip('OrOfTwoNftGateJoinPass', async () => {
+    test('OrOfTwoNftGateJoinPass', async () => {
         const testNft1Address = await getContractAddress('TestNFT1')
         const testNft2Address = await getContractAddress('TestNFT2')
         const { alice, bob, alicesWallet, channelId } = await setupChannelWithCustomRole(
@@ -412,7 +412,7 @@ describe('channelsWithEntitlements', () => {
         log('Done', Date.now() - doneStart)
     })
 
-    test.skip('orOfTwoNftOrOneNftGateJoinPass', async () => {
+    test('orOfTwoNftOrOneNftGateJoinPass', async () => {
         const testNft1Address = await getContractAddress('TestNFT1')
         const testNft2Address = await getContractAddress('TestNFT2')
         const testNft3Address = await getContractAddress('TestNFT3')
@@ -473,7 +473,7 @@ describe('channelsWithEntitlements', () => {
     })
 
     // Banning with entitlements — users need permission to ban other users.
-    test.skip('adminsCanRedactChannelMessages', async () => {
+    test('adminsCanRedactChannelMessages', async () => {
         // log('start adminsCanRedactChannelMessages')
         // // set up the web3 provider and spacedapp
         const {


### PR DESCRIPTION
Some nil pointer exceptions showed up on omega because the banning interface token contract was not properly initialized. This was not showing up in test cases or on gamma because no one was banned anywhere entitlements were checked.

This PR fixes the bug and adds a test case to check for this specific scenario - a banned user should not be able to join a channel, and also banning checks should work when a user is banned. In addition, I added a sanity check test case to the simple cache used by the banning interface for better coverage.