### PR TITLE
Stop logging chain configuration too much

### DIFF
--- a/core/node/events/stream_cache.go
+++ b/core/node/events/stream_cache.go
@@ -508,7 +508,7 @@ func (s *streamCacheImpl) cleanupPollInterval(ctx context.Context) (bool, time.D
 		return true, defaultValue
 	}
 
-	log.Error("unable to retrieve stream cache poll interval, use default", "err", err)
+	log.Debug("unable to retrieve stream cache poll interval, use default", "err", err)
 	return true, defaultValue
 }
 


### PR DESCRIPTION
Only log when chain config is loaded/changed once.