### PR TITLE
Add stop method to RPC transport to shutdown interval logger

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -250,6 +250,7 @@ export class Client
         await this.decryptionExtensions?.stop()
         await this.syncedStreamsExtensions?.stop()
         await this.stopSync()
+        this.rpcClient.stop()
     }
 
     getSizeOfEncryptedСontentQueue(): number {

--- a/packages/sdk/src/unauthenticatedClient.ts
+++ b/packages/sdk/src/unauthenticatedClient.ts
@@ -35,6 +35,10 @@ export class UnauthenticatedClient {
         this.logCall('new UnauthenticatedClient')
     }
 
+    public stop() {
+        this.rpcClient.stop()
+    }
+
     async userExists(userId: string): Promise<boolean> {
         const userStreamId = makeUserStreamId(userId)
         this.logCall('userExists', userId)


### PR DESCRIPTION
DRAFT - Another change will be needed on the harmony side to shutdown the unauthenticated client as well.

This logger keeps running after shutdown without this. At least two loggers are running in my client.