### PR TITLE
code: set default max chunk count for media streams to 50

### DIFF
--- a/core/node/crypto/config.go
+++ b/core/node/crypto/config.go
@@ -23,8 +23,11 @@ import (
 )
 
 var (
+	// StreamMediaMaxChunkCountConfigKey defines the maximum number chunks of data a media stream can contain.
 	StreamMediaMaxChunkCountConfigKey = newChainKeyImpl(
-		"stream.media.maxChunkCount", uint64Type, 10)
+		"stream.media.maxChunkCount", uint64Type, 50)
+	// StreamMediaMaxChunkSizeConfigKey defines the maximum size of a data chunk that is allowed to be added to a media
+	// stream in a single event.
 	StreamMediaMaxChunkSizeConfigKey = newChainKeyImpl(
 		"stream.media.maxChunkSize", uint64Type, 500000)
 	StreamRecencyConstraintsAgeSecConfigKey = newChainKeyImpl(


### PR DESCRIPTION
HNT-6524, increases the max number of chunks to 50 that can be added to a media stream to support media files up to 25mb. It leaves the max chunk size to 0.5mb to prevent events from getting big.