### PR TITLE
Add ability to just pass in river config environment id

### DIFF
--- a/packages/sdk/src/riverConfig.ts
+++ b/packages/sdk/src/riverConfig.ts
@@ -94,8 +94,8 @@ export function makeBaseChainConfig(environmentId?: string) {
 
 export type RiverConfig = ReturnType<typeof makeRiverConfig>
 
-export function makeRiverConfig() {
-    const environmentId = getEnvironmentId()
+export function makeRiverConfig(inEnvironmentId?: string) {
+    const environmentId = inEnvironmentId ?? getEnvironmentId()
     const config = {
         environmentId,
         base: makeBaseChainConfig(environmentId),


### PR DESCRIPTION
walking through code with wil and kerem made this seem like a better option than magically picking it up from env in some cases