### PR TITLE
Bind all settins to env var, support old __ and new RIVER_

### DIFF
--- a/core/node/cmd/config_cmd.go
+++ b/core/node/cmd/config_cmd.go
@@ -10,9 +10,15 @@ import (
 )
 
 func init() {
-	cmd := &cobra.Command{
+	configCmd := &cobra.Command{
 		Use:   "config",
-		Short: "Print config",
+		Short: "Config inspection commands",
+	}
+	rootCmd.AddCommand(configCmd)
+
+	configCmd.AddCommand(&cobra.Command{
+		Use:   "print",
+		Short: "Print current config (sensitive fields are omitted)",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println("Viper settings:")
 			fmt.Println()
@@ -39,7 +45,15 @@ func init() {
 
 			fmt.Println(string(yamlData))
 		},
-	}
+	})
 
-	rootCmd.AddCommand(cmd)
+	configCmd.AddCommand(&cobra.Command{
+		Use:   "names",
+		Short: "Print environment variable names for all config settings",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, envVar := range canonicalConfigEnvVars {
+				fmt.Println(envVar)
+			}
+		},
+	})
 }

--- a/core/node/cmd/genkey_cmd.go
+++ b/core/node/cmd/genkey_cmd.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"os"
 
-	"github.com/river-build/river/core/node/config"
 	"github.com/river-build/river/core/node/crypto"
 
 	"github.com/spf13/cobra"
 )
 
-func genkey(cfg *config.Config, overwrite bool) error {
+func genkey(overwrite bool) error {
 	ctx := context.Background() // lint:ignore context.Background() is fine here
 
 	wallet, err := crypto.NewWallet(ctx)
@@ -46,7 +45,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return genkey(cmdConfig, overwrite)
+			return genkey(overwrite)
 		},
 	}
 	cmdGenKey.Flags().Bool("overwrite", false, "Overwrite existing key files")

--- a/core/node/cmd/root_cmd.go
+++ b/core/node/cmd/root_cmd.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
@@ -42,59 +43,84 @@ func Execute() {
 	}
 }
 
+var canonicalConfigEnvVars []string
+
+func bindViperKeys(varPrefix string, envPrefixSingle string, envPrefixDouble string, m map[string]interface{}, canonicalEnvVar *[]string) {
+	for k, v := range m {
+		subMap, ok := v.(map[string]interface{})
+		if ok {
+			upperK := strings.ToUpper(k)
+			bindViperKeys(varPrefix+k+".", envPrefixSingle+upperK+"_", envPrefixDouble+upperK+"__", subMap, canonicalEnvVar)
+		} else {
+			envName := strings.ToUpper(k)
+			canonical := "RIVER_" + envPrefixSingle + envName
+			*canonicalEnvVar = append(*canonicalEnvVar, canonical)
+			viper.BindEnv(varPrefix+k, canonical, envPrefixDouble+envName)
+		}
+	}
+}
+
 func initConfigAndLog() {
 	if configFile != "" {
 		viper.SetConfigFile(configFile)
-
-		// This is needed to allow for nested config values to be set via environment variables
-		// For example: METRICS__ENABLED=true, METRICS__PORT=8080
-		viper.SetEnvKeyReplacer(strings.NewReplacer(".", "__"))
-		viper.AutomaticEnv()
-
-		if err := viper.ReadInConfig(); err != nil {
-			fmt.Printf("Failed to read config file, file=%v, error=%v\n", configFile, err)
-		}
-
-		var (
-			configStruct config.Config
-			decodeHooks  = mapstructure.ComposeDecodeHookFunc(
-				config.DecodeAddressOrAddressFileHook(),
-				config.DecodeDurationHook(),
-			)
-		)
-
-		if err := viper.Unmarshal(&configStruct, viper.DecodeHook(decodeHooks)); err != nil {
-			fmt.Printf("Failed to unmarshal config, error=%v\n", err)
-		}
-
-		if configStruct.Log.Format == "" {
-			configStruct.Log.Format = "text"
-		}
-
-		if logLevel != "" {
-			configStruct.Log.Level = logLevel
-		}
-		if logFile != "default" {
-			if logFile != "none" {
-				configStruct.Log.File = logFile
-			} else {
-				configStruct.Log.File = ""
-			}
-		}
-		if logToConsole {
-			configStruct.Log.Console = true
-		}
-		if logNoColor {
-			configStruct.Log.NoColor = true
-		}
-		configStruct.Init()
-
-		// If loaded successfully, set the global config
-		cmdConfig = &configStruct
-		InitLogFromConfig(&cmdConfig.Log)
 	} else {
 		fmt.Println("No config file specified")
 	}
+
+	// This iterates over all possible keys in config.Config and binds evn vars to them
+	// For each key, there are two bound env vars:
+	// Mertics.Enabled <= RIVER_METRICS_ENABLED, METRICS__ENABLED
+	// With RIVER_METRICS_ENABLED being canonical and recommended.
+	// The double underscore version is for compatibility with older versions of the settings.
+	configMap := make(map[string]interface{})
+	err := mapstructure.Decode(config.Config{}, &configMap)
+	if err != nil {
+		panic(err)
+	}
+	bindViperKeys("", "", "", configMap, &canonicalConfigEnvVars)
+	slices.Sort(canonicalConfigEnvVars)
+
+	if err := viper.ReadInConfig(); err != nil {
+		fmt.Printf("Failed to read config file, file=%v, error=%v\n", configFile, err)
+	}
+
+	var (
+		configStruct config.Config
+		decodeHooks  = mapstructure.ComposeDecodeHookFunc(
+			config.DecodeAddressOrAddressFileHook(),
+			config.DecodeDurationHook(),
+		)
+	)
+
+	if err := viper.Unmarshal(&configStruct, viper.DecodeHook(decodeHooks)); err != nil {
+		fmt.Printf("Failed to unmarshal config, error=%v\n", err)
+	}
+
+	if configStruct.Log.Format == "" {
+		configStruct.Log.Format = "text"
+	}
+
+	if logLevel != "" {
+		configStruct.Log.Level = logLevel
+	}
+	if logFile != "default" {
+		if logFile != "none" {
+			configStruct.Log.File = logFile
+		} else {
+			configStruct.Log.File = ""
+		}
+	}
+	if logToConsole {
+		configStruct.Log.Console = true
+	}
+	if logNoColor {
+		configStruct.Log.NoColor = true
+	}
+	configStruct.Init()
+
+	// If loaded successfully, set the global config
+	cmdConfig = &configStruct
+	InitLogFromConfig(&cmdConfig.Log)
 }
 
 func init() {


### PR DESCRIPTION
also add `config names` cmd line command to print all possible env var names.