### PR TITLE
make sure we share keys first in stress tests

### DIFF
--- a/packages/stress/src/mode/chat/joinChat.ts
+++ b/packages/stress/src/mode/chat/joinChat.ts
@@ -83,6 +83,9 @@ export async function joinChat(client: StressClient, cfg: ChatConfig) {
             await client.streamsClient.joinStream(channelId)
             await client.streamsClient.waitForStream(channelId)
         }
+        await client.streamsClient.cryptoBackend?.ensureOutboundSession(channelId, {
+            awaitInitialShareSession: true,
+        })
         await client.sendMessage(
             channelId,
             `${makeSillyMessage({ maxWords: 2 })}! ${cfg.sessionId}`,


### PR DESCRIPTION
seeing lots of undecrypted messages in the stress channel
this really slows things down, but will help everybody else