### PR TITLE
core: copy cmd and config packages in dockerfile

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -11,6 +11,8 @@ ARG VER_COMMIT=commit_unset
 
 # Prepare build environment
 WORKDIR /build
+COPY cmd cmd
+COPY config config
 COPY node node
 COPY xchain xchain
 COPY go.* .


### PR DESCRIPTION
In a recent code restructuring effort the docker build broke due to packages not being copied. This change adds these missing packages.