### PR TITLE
Add support to subscribe to historical and future chain events

### DIFF
--- a/core/node/crypto/blockchain.go
+++ b/core/node/crypto/blockchain.go
@@ -2,15 +2,13 @@ package crypto
 
 import (
 	"context"
-	"math/big"
-	"time"
-
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/river-build/river/core/config"
 	. "github.com/river-build/river/core/node/base"
 	"github.com/river-build/river/core/node/infra"
 	. "github.com/river-build/river/core/node/protocol"
+	"math/big"
 )
 
 // BlockchainClient is an interface that covers common functionality
@@ -119,14 +117,6 @@ func NewBlockchainWithClient(
 		InitialBlockNum: initialBlockNum,
 		ChainMonitor:    monitor,
 	}
-
-	go monitor.RunWithBlockPeriod(
-		ctx,
-		client,
-		initialBlockNum,
-		time.Duration(cfg.BlockTimeMs)*time.Millisecond,
-		metrics,
-	)
 
 	if wallet != nil {
 		bc.Wallet = wallet

--- a/core/node/crypto/blockchain.go
+++ b/core/node/crypto/blockchain.go
@@ -130,7 +130,8 @@ func NewBlockchainWithClient(
 
 	if wallet != nil {
 		bc.Wallet = wallet
-		bc.TxPool, err = NewTransactionPoolWithPoliciesFromConfig(ctx, cfg, bc.Client, wallet, bc.ChainMonitor, metrics)
+		bc.TxPool, err = NewTransactionPoolWithPoliciesFromConfig(
+			ctx, cfg, bc.Client, wallet, bc.ChainMonitor, initialBlockNum, metrics)
 		if err != nil {
 			return nil, err
 		}

--- a/core/node/crypto/blockchain_test.go
+++ b/core/node/crypto/blockchain_test.go
@@ -228,11 +228,11 @@ func TestBlockchainMultiMonitor(t *testing.T) {
 
 	// ensure that all chain monitor capture the node added event
 	deployer.ChainMonitor.OnContractWithTopicsEvent(
-		tc.RiverRegistryAddress, [][]common.Hash{{nodeAddedTopic}}, bindLogCallback)
+		0, tc.RiverRegistryAddress, [][]common.Hash{{nodeAddedTopic}}, bindLogCallback)
 	chain0.ChainMonitor.OnContractWithTopicsEvent(
-		tc.RiverRegistryAddress, [][]common.Hash{{nodeAddedTopic}}, bindLogCallback)
+		0, tc.RiverRegistryAddress, [][]common.Hash{{nodeAddedTopic}}, bindLogCallback)
 	chain1.ChainMonitor.OnContractWithTopicsEvent(
-		tc.RiverRegistryAddress, [][]common.Hash{{nodeAddedTopic}}, bindLogCallback)
+		0, tc.RiverRegistryAddress, [][]common.Hash{{nodeAddedTopic}}, bindLogCallback)
 
 	// register node that triggers the above registered callbacks
 	pendingTx, err := deployer.TxPool.Submit(ctx, "", func(opts *bind.TransactOpts) (*types.Transaction, error) {

--- a/core/node/crypto/chain_monitor.go
+++ b/core/node/crypto/chain_monitor.go
@@ -27,13 +27,13 @@ type (
 		)
 		// OnHeader adds a callback that is when a new header is received.
 		// Note: it is not guaranteed to be called for every new header!
-		OnHeader(cb OnChainNewHeader)
+		OnHeader(from BlockNumber, cb OnChainNewHeader)
 		// OnBlock adds a callback that is called for each new block
-		OnBlock(cb OnChainNewBlock)
+		OnBlock(from BlockNumber, cb OnChainNewBlock)
 		// OnAllEvents matches all events for all contracts, e.g. all chain events.
-		OnAllEvents(cb OnChainEventCallback)
+		OnAllEvents(from BlockNumber, cb OnChainEventCallback)
 		// OnContractEvent matches all events created by the contract on the given address.
-		OnContractEvent(addr common.Address, cb OnChainEventCallback)
+		OnContractEvent(from BlockNumber, addr common.Address, cb OnChainEventCallback)
 		// OnContractWithTopicsEvent matches events created by the contract on the given
 		OnContractWithTopicsEvent(from BlockNumber, addr common.Address, topics [][]common.Hash, cb OnChainEventCallback)
 		// OnStopped calls cb after the chain monitor stopped monitoring the chain
@@ -57,8 +57,10 @@ type (
 	OnChainMonitorStoppedCallback = func(context.Context)
 
 	chainMonitor struct {
-		muBuilder sync.Mutex
-		builder   chainMonitorBuilder
+		mu               sync.Mutex
+		builder          chainMonitorBuilder
+		fromBlock        *big.Int
+		fromBlockVersion uint64
 	}
 
 	// ChainMonitorPollInterval determines the next poll interval for the chain monitor
@@ -106,28 +108,47 @@ func (p *defaultChainMonitorPollIntervalCalculator) Interval(
 	return max(p.blockPeriod-took, 0)
 }
 
-func (ecm *chainMonitor) OnHeader(cb OnChainNewHeader) {
-	ecm.muBuilder.Lock()
-	defer ecm.muBuilder.Unlock()
-	ecm.builder.OnHeader(cb)
+// setFromBlock must be called with ecm.mu locked.
+func (ecm *chainMonitor) setFromBlock(processed *big.Int) {
+	ecm.setFromBlockOnModified(ecm.fromBlockVersion+1, processed)
 }
 
-func (ecm *chainMonitor) OnBlock(cb OnChainNewBlock) {
-	ecm.muBuilder.Lock()
-	defer ecm.muBuilder.Unlock()
-	ecm.builder.OnBlock(cb)
+// setFromBlockOnModified must be called with ecm.mu locked.
+func (ecm *chainMonitor) setFromBlockOnModified(version uint64, processed *big.Int) {
+	if ecm.fromBlock == nil || ecm.fromBlockVersion == version {
+		ecm.fromBlock = processed
+	} else if ecm.fromBlock.Cmp(processed) > 0 && version > ecm.fromBlockVersion {
+		ecm.fromBlock = processed
+	}
+	ecm.fromBlockVersion++
 }
 
-func (ecm *chainMonitor) OnAllEvents(cb OnChainEventCallback) {
-	ecm.muBuilder.Lock()
-	defer ecm.muBuilder.Unlock()
-	ecm.builder.OnAllEvents(cb)
+func (ecm *chainMonitor) OnHeader(from BlockNumber, cb OnChainNewHeader) {
+	ecm.mu.Lock()
+	defer ecm.mu.Unlock()
+	ecm.builder.OnHeader(from, cb)
+	ecm.setFromBlock(from.AsBigInt())
 }
 
-func (ecm *chainMonitor) OnContractEvent(addr common.Address, cb OnChainEventCallback) {
-	ecm.muBuilder.Lock()
-	defer ecm.muBuilder.Unlock()
-	ecm.builder.OnContractEvent(addr, cb)
+func (ecm *chainMonitor) OnBlock(from BlockNumber, cb OnChainNewBlock) {
+	ecm.mu.Lock()
+	defer ecm.mu.Unlock()
+	ecm.builder.OnBlock(from, cb)
+	ecm.setFromBlock(from.AsBigInt())
+}
+
+func (ecm *chainMonitor) OnAllEvents(from BlockNumber, cb OnChainEventCallback) {
+	ecm.mu.Lock()
+	defer ecm.mu.Unlock()
+	ecm.builder.OnAllEvents(from, cb)
+	ecm.setFromBlock(from.AsBigInt())
+}
+
+func (ecm *chainMonitor) OnContractEvent(from BlockNumber, addr common.Address, cb OnChainEventCallback) {
+	ecm.mu.Lock()
+	defer ecm.mu.Unlock()
+	ecm.builder.OnContractEvent(from, addr, cb)
+	ecm.setFromBlock(from.AsBigInt())
 }
 
 func (ecm *chainMonitor) OnContractWithTopicsEvent(
@@ -136,14 +157,15 @@ func (ecm *chainMonitor) OnContractWithTopicsEvent(
 	topics [][]common.Hash,
 	cb OnChainEventCallback,
 ) {
-	ecm.muBuilder.Lock()
-	defer ecm.muBuilder.Unlock()
+	ecm.mu.Lock()
+	defer ecm.mu.Unlock()
 	ecm.builder.OnContractWithTopicsEvent(from, addr, topics, cb)
+	ecm.setFromBlock(from.AsBigInt())
 }
 
 func (ecm *chainMonitor) OnStopped(cb OnChainMonitorStoppedCallback) {
-	ecm.muBuilder.Lock()
-	defer ecm.muBuilder.Unlock()
+	ecm.mu.Lock()
+	defer ecm.mu.Unlock()
 	ecm.builder.OnChainMonitorStopped(cb)
 }
 
@@ -190,7 +212,6 @@ func (ecm *chainMonitor) RunWithBlockPeriod(
 	var (
 		log                   = dlog.FromCtx(ctx)
 		one                   = big.NewInt(1)
-		fromBlock             = initialBlock.AsBigInt()
 		lastProcessed         *big.Int
 		pollInterval          = time.Duration(0)
 		poll                  = NewChainMonitorPollIntervalCalculator(blockPeriod, 30*time.Second)
@@ -212,11 +233,13 @@ func (ecm *chainMonitor) RunWithBlockPeriod(
 		return
 	}
 
+	ecm.mu.Lock()
+	ecm.setFromBlock(initialBlock.AsBigInt())
+	ecm.mu.Unlock()
+
 	log.Debug("chain monitor started", "blockPeriod", blockPeriod, "fromBlock", initialBlock)
 
 	for {
-		// log.Debug("chain monitor iteration", "pollInterval", pollInterval)
-
 		pollIntervalCounter.Inc()
 
 		select {
@@ -230,6 +253,7 @@ func (ecm *chainMonitor) RunWithBlockPeriod(
 
 		case <-time.After(pollInterval):
 			start := time.Now()
+
 			head, err := client.HeaderByNumber(ctx, nil)
 			if err != nil {
 				log.Warn("chain monitor is unable to retrieve chain head", "error", err)
@@ -256,18 +280,21 @@ func (ecm *chainMonitor) RunWithBlockPeriod(
 				callbacksExecuted   sync.WaitGroup
 			)
 
+			ecm.mu.Lock()
+			fromBlock := ecm.fromBlock
+			fromBlockVersion := ecm.fromBlockVersion
+			ecm.mu.Unlock()
+
 			// ensure that the search range isn't too big because RPC providers
 			// often have limitations on the block range and/or response size.
-			if head.Number.Uint64()-fromBlock.Uint64() > 25 {
+			if head.Number.Cmp(fromBlock) > 0 && head.Number.Uint64()-fromBlock.Uint64() > 25 {
 				moreBlocksAvailable = true
 				toBlock.SetUint64(fromBlock.Uint64() + 25)
 			}
 
-			ecm.muBuilder.Lock()
+			ecm.mu.Lock()
 			query := ecm.builder.Query()
 			query.FromBlock, query.ToBlock = fromBlock, toBlock
-
-			// log.Debug("chain monitor block range", "from", query.FromBlock, "to", query.ToBlock)
 
 			if len(ecm.builder.blockCallbacks) > 0 {
 				for i := query.FromBlock.Uint64(); i <= query.ToBlock.Uint64(); i++ {
@@ -280,7 +307,7 @@ func (ecm *chainMonitor) RunWithBlockPeriod(
 				if err != nil {
 					log.Warn("unable to retrieve logs", "error", err)
 					pollInterval = poll.Interval(time.Since(start), false, true)
-					ecm.muBuilder.Unlock()
+					ecm.mu.Unlock()
 					continue
 				}
 				receivedEventsCounter.Add(float64(len(collectedLogs)))
@@ -315,10 +342,10 @@ func (ecm *chainMonitor) RunWithBlockPeriod(
 			}
 
 			callbacksExecuted.Wait()
-			ecm.muBuilder.Unlock()
 
 			// from and toBlocks are inclusive, start at the next block on next iteration
-			fromBlock = new(big.Int).Add(query.ToBlock, one)
+			ecm.setFromBlockOnModified(fromBlockVersion, new(big.Int).Add(query.ToBlock, one))
+			ecm.mu.Unlock()
 			pollInterval = poll.Interval(time.Since(start), moreBlocksAvailable, false)
 			lastProcessed = toBlock
 

--- a/core/node/crypto/chain_monitor.go
+++ b/core/node/crypto/chain_monitor.go
@@ -110,11 +110,11 @@ func (p *defaultChainMonitorPollIntervalCalculator) Interval(
 
 // setFromBlock must be called with ecm.mu locked.
 func (ecm *chainMonitor) setFromBlock(processed *big.Int) {
-	ecm.setFromBlockOnModified(ecm.fromBlockVersion+1, processed)
+	ecm.setFromBlockVersioned(ecm.fromBlockVersion+1, processed)
 }
 
-// setFromBlockOnModified must be called with ecm.mu locked.
-func (ecm *chainMonitor) setFromBlockOnModified(version uint64, processed *big.Int) {
+// setFromBlockVersioned must be called with ecm.mu locked.
+func (ecm *chainMonitor) setFromBlockVersioned(version uint64, processed *big.Int) {
 	if ecm.fromBlock == nil || ecm.fromBlockVersion == version {
 		ecm.fromBlock = processed
 	} else if ecm.fromBlock.Cmp(processed) > 0 && version > ecm.fromBlockVersion {
@@ -342,7 +342,7 @@ func (ecm *chainMonitor) RunWithBlockPeriod(
 			callbacksExecuted.Wait()
 
 			// from and toBlocks are inclusive, start at the next block on next iteration
-			ecm.setFromBlockOnModified(fromBlockVersion, new(big.Int).Add(query.ToBlock, one))
+			ecm.setFromBlockVersioned(fromBlockVersion, new(big.Int).Add(query.ToBlock, one))
 			ecm.mu.Unlock()
 			pollInterval = poll.Interval(time.Since(start), moreBlocksAvailable, false)
 			lastProcessed = toBlock

--- a/core/node/crypto/chain_monitor.go
+++ b/core/node/crypto/chain_monitor.go
@@ -27,9 +27,9 @@ type (
 		)
 		// OnHeader adds a callback that is when a new header is received.
 		// Note: it is not guaranteed to be called for every new header!
-		OnHeader(from BlockNumber, cb OnChainNewHeader)
+		OnHeader(cb OnChainNewHeader)
 		// OnBlock adds a callback that is called for each new block
-		OnBlock(from BlockNumber, cb OnChainNewBlock)
+		OnBlock(cb OnChainNewBlock)
 		// OnAllEvents matches all events for all contracts, e.g. all chain events.
 		OnAllEvents(from BlockNumber, cb OnChainEventCallback)
 		// OnContractEvent matches all events created by the contract on the given address.
@@ -123,18 +123,16 @@ func (ecm *chainMonitor) setFromBlockOnModified(version uint64, processed *big.I
 	ecm.fromBlockVersion++
 }
 
-func (ecm *chainMonitor) OnHeader(from BlockNumber, cb OnChainNewHeader) {
+func (ecm *chainMonitor) OnHeader(cb OnChainNewHeader) {
 	ecm.mu.Lock()
 	defer ecm.mu.Unlock()
-	ecm.builder.OnHeader(from, cb)
-	ecm.setFromBlock(from.AsBigInt())
+	ecm.builder.OnHeader(cb)
 }
 
-func (ecm *chainMonitor) OnBlock(from BlockNumber, cb OnChainNewBlock) {
+func (ecm *chainMonitor) OnBlock(cb OnChainNewBlock) {
 	ecm.mu.Lock()
 	defer ecm.mu.Unlock()
-	ecm.builder.OnBlock(from, cb)
-	ecm.setFromBlock(from.AsBigInt())
+	ecm.builder.OnBlock(cb)
 }
 
 func (ecm *chainMonitor) OnAllEvents(from BlockNumber, cb OnChainEventCallback) {

--- a/core/node/crypto/chain_monitor.go
+++ b/core/node/crypto/chain_monitor.go
@@ -35,7 +35,7 @@ type (
 		// OnContractEvent matches all events created by the contract on the given address.
 		OnContractEvent(addr common.Address, cb OnChainEventCallback)
 		// OnContractWithTopicsEvent matches events created by the contract on the given
-		OnContractWithTopicsEvent(addr common.Address, topics [][]common.Hash, cb OnChainEventCallback)
+		OnContractWithTopicsEvent(from BlockNumber, addr common.Address, topics [][]common.Hash, cb OnChainEventCallback)
 		// OnStopped calls cb after the chain monitor stopped monitoring the chain
 		OnStopped(cb OnChainMonitorStoppedCallback)
 	}
@@ -131,13 +131,14 @@ func (ecm *chainMonitor) OnContractEvent(addr common.Address, cb OnChainEventCal
 }
 
 func (ecm *chainMonitor) OnContractWithTopicsEvent(
+	from BlockNumber,
 	addr common.Address,
 	topics [][]common.Hash,
 	cb OnChainEventCallback,
 ) {
 	ecm.muBuilder.Lock()
 	defer ecm.muBuilder.Unlock()
-	ecm.builder.OnContractWithTopicsEvent(addr, topics, cb)
+	ecm.builder.OnContractWithTopicsEvent(from, addr, topics, cb)
 }
 
 func (ecm *chainMonitor) OnStopped(cb OnChainMonitorStoppedCallback) {

--- a/core/node/crypto/chain_monitor_builder.go
+++ b/core/node/crypto/chain_monitor_builder.go
@@ -40,13 +40,13 @@ func (lfb *chainMonitorBuilder) Query() ethereum.FilterQuery {
 	return query
 }
 
-func (lfb *chainMonitorBuilder) OnHeader(from BlockNumber, cb OnChainNewHeader) {
-	lfb.headerCallbacks = append(lfb.headerCallbacks, &chainHeaderCallback{handler: cb, fromBlock: from})
+func (lfb *chainMonitorBuilder) OnHeader(cb OnChainNewHeader) {
+	lfb.headerCallbacks = append(lfb.headerCallbacks, &chainHeaderCallback{handler: cb})
 	lfb.dirty = true
 }
 
-func (lfb *chainMonitorBuilder) OnBlock(from BlockNumber, cb OnChainNewBlock) {
-	lfb.blockCallbacks = append(lfb.blockCallbacks, &chainBlockCallback{handler: cb, fromBlock: from})
+func (lfb *chainMonitorBuilder) OnBlock(cb OnChainNewBlock) {
+	lfb.blockCallbacks = append(lfb.blockCallbacks, &chainBlockCallback{handler: cb})
 	lfb.dirty = true
 }
 

--- a/core/node/crypto/chain_monitor_builder.go
+++ b/core/node/crypto/chain_monitor_builder.go
@@ -40,23 +40,26 @@ func (lfb *chainMonitorBuilder) Query() ethereum.FilterQuery {
 	return query
 }
 
-func (lfb *chainMonitorBuilder) OnHeader(cb OnChainNewHeader) {
-	lfb.headerCallbacks = append(lfb.headerCallbacks, &chainHeaderCallback{handler: cb})
+func (lfb *chainMonitorBuilder) OnHeader(from BlockNumber, cb OnChainNewHeader) {
+	lfb.headerCallbacks = append(lfb.headerCallbacks, &chainHeaderCallback{handler: cb, fromBlock: from})
 	lfb.dirty = true
 }
 
-func (lfb *chainMonitorBuilder) OnBlock(cb OnChainNewBlock) {
-	lfb.blockCallbacks = append(lfb.blockCallbacks, &chainBlockCallback{handler: cb})
+func (lfb *chainMonitorBuilder) OnBlock(from BlockNumber, cb OnChainNewBlock) {
+	lfb.blockCallbacks = append(lfb.blockCallbacks, &chainBlockCallback{handler: cb, fromBlock: from})
 	lfb.dirty = true
 }
 
-func (lfb *chainMonitorBuilder) OnAllEvents(cb OnChainEventCallback) {
-	lfb.eventCallbacks = append(lfb.eventCallbacks, &chainEventCallback{handler: cb, logProcessed: false})
+func (lfb *chainMonitorBuilder) OnAllEvents(from BlockNumber, cb OnChainEventCallback) {
+	lfb.eventCallbacks = append(lfb.eventCallbacks, &chainEventCallback{handler: cb, logProcessed: false, fromBlock: from})
 	lfb.dirty = true
 }
 
-func (lfb *chainMonitorBuilder) OnContractEvent(addr common.Address, cb OnChainEventCallback) {
-	lfb.eventCallbacks = append(lfb.eventCallbacks, &chainEventCallback{handler: cb, address: &addr, logProcessed: false})
+func (lfb *chainMonitorBuilder) OnContractEvent(from BlockNumber, addr common.Address, cb OnChainEventCallback) {
+	lfb.eventCallbacks = append(
+		lfb.eventCallbacks,
+		&chainEventCallback{handler: cb, address: &addr, logProcessed: false, fromBlock: from},
+	)
 	lfb.dirty = true
 }
 
@@ -89,6 +92,7 @@ type chainEventCallback struct {
 	lastProcessedBlock    uint64
 	lastProcessedTxIndex  uint
 	lastProcessedLogIndex uint
+	fromBlock             BlockNumber
 }
 
 // alreadyProcessed returns an indication if cb already processed the given log.

--- a/core/node/crypto/chain_monitor_test.go
+++ b/core/node/crypto/chain_monitor_test.go
@@ -34,7 +34,7 @@ func TestChainMonitorBlocks(t *testing.T) {
 		}
 	)
 
-	tc.DeployerBlockchain.ChainMonitor.OnBlock(0, onBlockCallback)
+	tc.DeployerBlockchain.ChainMonitor.OnBlock(onBlockCallback)
 
 	var prev uint64
 	for i := 0; i < 5; i++ {
@@ -175,7 +175,7 @@ func TestChainMonitorEvents(t *testing.T) {
 		addrs = []common.Address{tc.Wallets[0].Address}
 	)
 
-	tc.DeployerBlockchain.ChainMonitor.OnBlock(owner.InitialBlockNum+1, onBlockCallback)
+	tc.DeployerBlockchain.ChainMonitor.OnBlock(onBlockCallback)
 	tc.DeployerBlockchain.ChainMonitor.OnAllEvents(owner.InitialBlockNum+1, allEventCallback)
 	tc.DeployerBlockchain.ChainMonitor.OnContractEvent(owner.InitialBlockNum+1, tc.RiverRegistryAddress, contractEventCallback)
 	tc.DeployerBlockchain.ChainMonitor.OnContractWithTopicsEvent(
@@ -225,6 +225,273 @@ func TestChainMonitorEvents(t *testing.T) {
 	<-onMonitorStoppedCount // if the on stop callback isn't called this will time out
 }
 
+func TestContractAllEventsFromFuture(t *testing.T) {
+	require := require.New(t)
+	ctx, cancel := test.NewTestContext()
+	defer cancel()
+
+	tc, err := crypto.NewBlockchainTestContext(ctx, 0, false)
+	require.NoError(err)
+	defer tc.Close()
+
+	var (
+		owner                                         = tc.DeployerBlockchain
+		chainMonitor                                  = tc.DeployerBlockchain.ChainMonitor
+		nodeCount                                     = 5
+		contractWithTopicsEventCallbackCapturedEvents = make(chan types.Log, nodeCount)
+		contractWithTopicsEventCallback               = func(ctx context.Context, event types.Log) {
+			contractWithTopicsEventCallbackCapturedEvents <- event
+		}
+		futureContractEventsCallbackCapturedEvents = make(chan types.Log, nodeCount)
+		futureContractEventsCallback               = func(ctx context.Context, event types.Log) {
+			futureContractEventsCallbackCapturedEvents <- event
+		}
+		nodeRegistryABI, _ = abi.JSON(strings.NewReader(contracts.NodeRegistryV1MetaData.ABI))
+		readCapturedEvents = func(captured <-chan types.Log) []types.Log {
+			var logs []types.Log
+			for i := 0; i < nodeCount; i++ {
+				logs = append(logs, <-captured)
+			}
+			return logs
+		}
+	)
+
+	chainMonitor.OnContractWithTopicsEvent(
+		0,
+		tc.RiverRegistryAddress,
+		[][]common.Hash{{nodeRegistryABI.Events["NodeAdded"].ID}},
+		contractWithTopicsEventCallback,
+	)
+
+	// register several nodes
+	var (
+		pendingTx     crypto.TransactionPoolPendingTransaction
+		nodeAddresses = make([]common.Address, nodeCount)
+	)
+	for i := range nodeCount {
+		wallet, err := crypto.NewWallet(ctx)
+		require.NoError(err, "new wallet")
+		nodeAddresses[i] = wallet.Address
+		pendingTx, err = owner.TxPool.Submit(
+			ctx,
+			"RegisterNode",
+			func(opts *bind.TransactOpts) (*types.Transaction, error) {
+				return tc.NodeRegistry.RegisterNode(
+					opts,
+					wallet.Address,
+					fmt.Sprintf("https://node%d.river.test", i),
+					contracts.NodeStatus_NotInitialized,
+				)
+			},
+		)
+		require.NoError(err, "register node")
+	}
+
+	require.NoError(err)
+
+	// generate some blocks
+	N := 5
+	for i := 0; i < N; i++ {
+		tc.Commit(ctx)
+	}
+
+	receipt := <-pendingTx.Wait()
+	require.Equal(crypto.TransactionResultSuccess, receipt.Status)
+
+	var (
+		events                  = readCapturedEvents(contractWithTopicsEventCallbackCapturedEvents)
+		lastRegisteredNodeEvent = events[nodeCount-1]
+	)
+
+	require.Equal(nodeCount, len(events), "unexpected NodeAdded logs count")
+
+	// generate extra blocks to ensure that the chain monitor is past the existing set of blocks and needs to look at
+	// historical blocks to find the NodeAdded events.
+	for i := 0; i < N; i++ {
+		tc.Commit(ctx)
+	}
+
+	for {
+		blockNum := tc.BlockNum(ctx)
+		if blockNum.AsUint64() > lastRegisteredNodeEvent.BlockNumber {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// register a callback for the NodeAdded event on a future block.
+	// Ensure that historicalContractAllEventsCallback and historicalContractEventsCallback receive all node added
+	// events from the past.
+	futureBlockNum := 2 + tc.BlockNum(ctx)
+	chainMonitor.OnAllEvents(futureBlockNum, futureContractEventsCallback)
+
+	// mine some blocks to get past the future block
+	for {
+		time.Sleep(10 * time.Millisecond)
+		tc.Commit(ctx)
+		if tc.BlockNum(ctx).AsUint64() > futureBlockNum.AsUint64() {
+			break
+		}
+	}
+
+	// ensure that futureContractEventsCallback receives new node added events
+	for i := range nodeCount {
+		wallet, err := crypto.NewWallet(ctx)
+		require.NoError(err, "new wallet")
+		nodeAddresses[i] = wallet.Address
+		pendingTx, err = owner.TxPool.Submit(
+			ctx,
+			"RegisterNode",
+			func(opts *bind.TransactOpts) (*types.Transaction, error) {
+				return tc.NodeRegistry.RegisterNode(
+					opts,
+					wallet.Address,
+					fmt.Sprintf("https://node%d.river.test", i),
+					contracts.NodeStatus_NotInitialized,
+				)
+			},
+		)
+		require.NoError(err, "register node")
+	}
+
+	for i := 0; i < N; i++ {
+		tc.Commit(ctx)
+	}
+
+	receipt = <-pendingTx.Wait()
+	require.Equal(crypto.TransactionResultSuccess, receipt.Status)
+
+	// ensure that historicalContractWithTopicsEventCallback received old NodeAdded events
+	futureEvents := readCapturedEvents(futureContractEventsCallbackCapturedEvents)
+
+	// make sure we received the node added events after the future block
+	require.Equal(nodeCount, len(futureEvents), "unexpected NodeAdded logs count")
+}
+
+func TestContractAllEventsFromPast(t *testing.T) {
+	require := require.New(t)
+	ctx, cancel := test.NewTestContext()
+	defer cancel()
+
+	tc, err := crypto.NewBlockchainTestContext(ctx, 0, false)
+	require.NoError(err)
+	defer tc.Close()
+
+	var (
+		owner                                         = tc.DeployerBlockchain
+		chainMonitor                                  = tc.DeployerBlockchain.ChainMonitor
+		nodeCount                                     = 5
+		contractWithTopicsEventCallbackCapturedEvents = make(chan types.Log, nodeCount)
+		contractWithTopicsEventCallback               = func(ctx context.Context, event types.Log) {
+			contractWithTopicsEventCallbackCapturedEvents <- event
+		}
+		historicalContractAllEventsCallbackCapturedEvents = make(chan types.Log, nodeCount)
+		historicalContractAllEventsCallback               = func(ctx context.Context, event types.Log) {
+			historicalContractAllEventsCallbackCapturedEvents <- event
+		}
+		historicalContractEventsCallbackCapturedEvents = make(chan types.Log, nodeCount)
+		historicalContractEventsCallback               = func(ctx context.Context, event types.Log) {
+			historicalContractEventsCallbackCapturedEvents <- event
+		}
+		nodeRegistryABI, _ = abi.JSON(strings.NewReader(contracts.NodeRegistryV1MetaData.ABI))
+		readCapturedEvents = func(captured <-chan types.Log) []types.Log {
+			var logs []types.Log
+			for i := 0; i < nodeCount; i++ {
+				logs = append(logs, <-captured)
+			}
+			return logs
+		}
+	)
+
+	chainMonitor.OnContractWithTopicsEvent(
+		0,
+		tc.RiverRegistryAddress,
+		[][]common.Hash{{nodeRegistryABI.Events["NodeAdded"].ID}},
+		contractWithTopicsEventCallback,
+	)
+
+	// register several nodes
+	var (
+		pendingTx     crypto.TransactionPoolPendingTransaction
+		nodeAddresses = make([]common.Address, nodeCount)
+	)
+	for i := range nodeCount {
+		wallet, err := crypto.NewWallet(ctx)
+		require.NoError(err, "new wallet")
+		nodeAddresses[i] = wallet.Address
+		pendingTx, err = owner.TxPool.Submit(
+			ctx,
+			"RegisterNode",
+			func(opts *bind.TransactOpts) (*types.Transaction, error) {
+				return tc.NodeRegistry.RegisterNode(
+					opts,
+					wallet.Address,
+					fmt.Sprintf("https://node%d.river.test", i),
+					contracts.NodeStatus_NotInitialized,
+				)
+			},
+		)
+		require.NoError(err, "register node")
+	}
+
+	require.NoError(err)
+
+	// generate some blocks
+	N := 5
+	for i := 0; i < N; i++ {
+		tc.Commit(ctx)
+	}
+
+	receipt := <-pendingTx.Wait()
+	require.Equal(crypto.TransactionResultSuccess, receipt.Status)
+
+	var (
+		events                   = readCapturedEvents(contractWithTopicsEventCallbackCapturedEvents)
+		firstRegisteredNodeEvent = events[0]
+		lastRegisteredNodeEvent  = events[nodeCount-1]
+	)
+
+	require.Equal(nodeCount, len(events), "unexpected NodeAdded logs count")
+
+	// generate extra blocks to ensure that the chain monitor is past the existing set of blocks and needs to look at
+	// historical blocks to find the NodeAdded events.
+	for i := 0; i < N; i++ {
+		tc.Commit(ctx)
+	}
+
+	for {
+		blockNum := tc.BlockNum(ctx)
+		if blockNum.AsUint64() > lastRegisteredNodeEvent.BlockNumber {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// register a callback for the NodeAdded event on an old block.
+	// Ensure that historicalContractAllEventsCallback and historicalContractEventsCallback receive all node added
+	// events from the past.
+	chainMonitor.OnAllEvents(
+		crypto.BlockNumber(firstRegisteredNodeEvent.BlockNumber),
+		historicalContractAllEventsCallback,
+	)
+
+	chainMonitor.OnContractEvent(
+		crypto.BlockNumber(firstRegisteredNodeEvent.BlockNumber),
+		tc.RiverRegistryAddress,
+		historicalContractEventsCallback,
+	)
+
+	// ensure that historicalContractWithTopicsEventCallback received old NodeAdded events
+	historicalAllEvents := readCapturedEvents(historicalContractAllEventsCallbackCapturedEvents)
+	historicalContractEvents := readCapturedEvents(historicalContractEventsCallbackCapturedEvents)
+
+	// make sure all logs match and that contractWithTopicsEventCallback didn't receive the same logs again
+	require.Equal(nodeCount, len(historicalAllEvents), "unexpected NodeAdded logs count")
+	require.EqualValues(events, historicalContractEvents, "unexpected logs")
+	require.Equal(nodeCount, len(historicalAllEvents), "unexpected NodeAdded logs count")
+	require.EqualValues(events, historicalContractEvents, "unexpected logs")
+}
+
 func TestContractEventsWithTopicsFromPast(t *testing.T) {
 	require := require.New(t)
 	ctx, cancel := test.NewTestContext()
@@ -271,7 +538,7 @@ func TestContractEventsWithTopicsFromPast(t *testing.T) {
 	for i := range nodeCount {
 		wallet, err := crypto.NewWallet(ctx)
 		require.NoError(err, "new wallet")
-		nodeAddresses[0] = wallet.Address
+		nodeAddresses[i] = wallet.Address
 		pendingTx, err = owner.TxPool.Submit(
 			ctx,
 			"RegisterNode",

--- a/core/node/crypto/chain_monitor_test.go
+++ b/core/node/crypto/chain_monitor_test.go
@@ -319,9 +319,6 @@ func TestContractAllEventsFromFuture(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	// register a callback for the NodeAdded event on a future block.
-	// Ensure that historicalContractAllEventsCallback and historicalContractEventsCallback receive all node added
-	// events from the past.
 	futureBlockNum := 2 + tc.BlockNum(ctx)
 	chainMonitor.OnAllEvents(futureBlockNum, futureContractEventsCallback)
 
@@ -361,7 +358,7 @@ func TestContractAllEventsFromFuture(t *testing.T) {
 	receipt = <-pendingTx.Wait()
 	require.Equal(crypto.TransactionResultSuccess, receipt.Status)
 
-	// ensure that historicalContractWithTopicsEventCallback received old NodeAdded events
+	// ensure that futureContractEventsCallbackCapturedEvents received old NodeAdded events
 	futureEvents := readCapturedEvents(futureContractEventsCallbackCapturedEvents)
 
 	// make sure we received the node added events after the future block

--- a/core/node/crypto/chain_monitor_test.go
+++ b/core/node/crypto/chain_monitor_test.go
@@ -179,6 +179,7 @@ func TestChainMonitorEvents(t *testing.T) {
 	tc.DeployerBlockchain.ChainMonitor.OnAllEvents(allEventCallback)
 	tc.DeployerBlockchain.ChainMonitor.OnContractEvent(tc.RiverRegistryAddress, contractEventCallback)
 	tc.DeployerBlockchain.ChainMonitor.OnContractWithTopicsEvent(
+		0,
 		tc.RiverRegistryAddress,
 		[][]common.Hash{{nodeRegistryABI.Events["NodeAdded"].ID}},
 		contractWithTopicsEventCallback,

--- a/core/node/crypto/chain_txpool.go
+++ b/core/node/crypto/chain_txpool.go
@@ -228,8 +228,8 @@ func NewTransactionPoolWithPolicies(
 		walletBalance:                walletBalance.With(curryLabels),
 	}
 
-	chainMonitor.OnBlock(initialBlockNumber+1, txPool.OnBlock)
-	chainMonitor.OnHeader(initialBlockNumber+1, txPool.OnHeader)
+	chainMonitor.OnBlock(txPool.OnBlock)
+	chainMonitor.OnHeader(txPool.OnHeader)
 
 	return txPool, nil
 }

--- a/core/node/crypto/chain_txpool.go
+++ b/core/node/crypto/chain_txpool.go
@@ -120,6 +120,7 @@ func NewTransactionPoolWithPoliciesFromConfig(
 	riverClient BlockchainClient,
 	wallet *Wallet,
 	chainMonitor ChainMonitor,
+	initialBlockNumber BlockNumber,
 	metrics infra.MetricsFactory,
 ) (*transactionPool, error) {
 	if cfg.BlockTimeMs <= 0 {
@@ -141,7 +142,7 @@ func NewTransactionPoolWithPoliciesFromConfig(
 	)
 
 	return NewTransactionPoolWithPolicies(
-		ctx, riverClient, wallet, replacementPolicy, pricePolicy, chainMonitor, metrics)
+		ctx, riverClient, wallet, replacementPolicy, pricePolicy, chainMonitor, initialBlockNumber, metrics)
 }
 
 // NewTransactionPoolWithPolicies creates an in-memory transaction pool that tracks transactions that are submitted
@@ -156,6 +157,7 @@ func NewTransactionPoolWithPolicies(
 	replacePolicy TransactionPoolReplacePolicy,
 	pricePolicy TransactionPricePolicy,
 	chainMonitor ChainMonitor,
+	initialBlockNumber BlockNumber,
 	metrics infra.MetricsFactory,
 ) (*transactionPool, error) {
 	chainID, err := client.ChainID(ctx)
@@ -226,8 +228,8 @@ func NewTransactionPoolWithPolicies(
 		walletBalance:                walletBalance.With(curryLabels),
 	}
 
-	chainMonitor.OnBlock(txPool.OnBlock)
-	chainMonitor.OnHeader(txPool.OnHeader)
+	chainMonitor.OnBlock(initialBlockNumber+1, txPool.OnBlock)
+	chainMonitor.OnHeader(initialBlockNumber+1, txPool.OnHeader)
 
 	return txPool, nil
 }

--- a/core/node/crypto/chain_txpool_test.go
+++ b/core/node/crypto/chain_txpool_test.go
@@ -38,6 +38,7 @@ func TestNewTransactionPoolWithReplaceTx(t *testing.T) {
 		resubmitPolicy,
 		repricePolicy,
 		tc.DeployerBlockchain.ChainMonitor,
+		tc.DeployerBlockchain.InitialBlockNum,
 		infra.NewMetrics("", ""),
 	)
 	require.NoError(err, "unable to construct transaction pool")

--- a/core/node/crypto/config.go
+++ b/core/node/crypto/config.go
@@ -215,7 +215,7 @@ func NewOnChainConfig(
 	cfg.loadMissing(ctx, appliedBlockNum.AsUint64())
 
 	// on block sets the current block number that is used to determine the active configuration setting.
-	chainMonitor.OnBlock(cfg.onBlock)
+	chainMonitor.OnBlock(appliedBlockNum+1, cfg.onBlock)
 
 	cfgABI, err := contracts.RiverConfigV1MetaData.GetAbi()
 	if err != nil {

--- a/core/node/crypto/config.go
+++ b/core/node/crypto/config.go
@@ -225,7 +225,7 @@ func NewOnChainConfig(
 	// each time configuration stored on chain changed the ConfigurationChanged event is raised.
 	// Register a callback that updates the in-memory configuration when this happens.
 	chainMonitor.OnContractWithTopicsEvent(
-		riverRegistry, [][]common.Hash{{cfgABI.Events["ConfigurationChanged"].ID}}, cfg.onConfigChanged)
+		appliedBlockNum+1, riverRegistry, [][]common.Hash{{cfgABI.Events["ConfigurationChanged"].ID}}, cfg.onConfigChanged)
 
 	return cfg, nil
 }

--- a/core/node/crypto/config.go
+++ b/core/node/crypto/config.go
@@ -215,7 +215,7 @@ func NewOnChainConfig(
 	cfg.loadMissing(ctx, appliedBlockNum.AsUint64())
 
 	// on block sets the current block number that is used to determine the active configuration setting.
-	chainMonitor.OnBlock(appliedBlockNum+1, cfg.onBlock)
+	chainMonitor.OnBlock(cfg.onBlock)
 
 	cfgABI, err := contracts.RiverConfigV1MetaData.GetAbi()
 	if err != nil {

--- a/core/node/crypto/testutil.go
+++ b/core/node/crypto/testutil.go
@@ -467,6 +467,14 @@ func makeTestBlockchain(
 		panic(err)
 	}
 
+	go bc.ChainMonitor.RunWithBlockPeriod(
+		ctx,
+		client,
+		bc.InitialBlockNum,
+		100*time.Millisecond,
+		infra.NewMetrics("", ""),
+	)
+
 	return bc
 }
 

--- a/core/node/events/stream_cache.go
+++ b/core/node/events/stream_cache.go
@@ -113,7 +113,7 @@ func NewStreamCache(
 
 	// TODO: setup monitor for stream updates and update records accordingly.
 
-	chainMonitor.OnBlock(func(ctx context.Context, _ crypto.BlockNumber) { s.OnNewBlock(ctx) })
+	chainMonitor.OnBlock(appliedBlockNum+1, func(ctx context.Context, _ crypto.BlockNumber) { s.OnNewBlock(ctx) })
 
 	go s.runCacheCleanup(ctx)
 

--- a/core/node/events/stream_cache.go
+++ b/core/node/events/stream_cache.go
@@ -113,7 +113,7 @@ func NewStreamCache(
 
 	// TODO: setup monitor for stream updates and update records accordingly.
 
-	chainMonitor.OnBlock(appliedBlockNum+1, func(ctx context.Context, _ crypto.BlockNumber) { s.OnNewBlock(ctx) })
+	chainMonitor.OnBlock(func(ctx context.Context, _ crypto.BlockNumber) { s.OnNewBlock(ctx) })
 
 	go s.runCacheCleanup(ctx)
 

--- a/core/node/nodes/node_registry.go
+++ b/core/node/nodes/node_registry.go
@@ -83,21 +83,25 @@ func LoadNodeRegistry(
 	}
 
 	chainMonitor.OnContractWithTopicsEvent(
+		appliedBlockNum+1,
 		contract.Address,
 		[][]common.Hash{{contract.NodeRegistryAbi.Events["NodeAdded"].ID}},
 		ret.OnNodeAdded,
 	)
 	chainMonitor.OnContractWithTopicsEvent(
+		appliedBlockNum+1,
 		contract.Address,
 		[][]common.Hash{{contract.NodeRegistryAbi.Events["NodeRemoved"].ID}},
 		ret.OnNodeRemoved,
 	)
 	chainMonitor.OnContractWithTopicsEvent(
+		appliedBlockNum+1,
 		contract.Address,
 		[][]common.Hash{{contract.NodeRegistryAbi.Events["NodeStatusUpdated"].ID}},
 		ret.OnNodeStatusUpdated,
 	)
 	chainMonitor.OnContractWithTopicsEvent(
+		appliedBlockNum+1,
 		contract.Address,
 		[][]common.Hash{{contract.NodeRegistryAbi.Events["NodeUrlUpdated"].ID}},
 		ret.OnNodeUrlUpdated,

--- a/core/node/registries/river_registry_contract.go
+++ b/core/node/registries/river_registry_contract.go
@@ -576,8 +576,8 @@ func (c *RiverRegistryContract) OnStreamEvent(
 	lastMiniblockUpdated func(ctx context.Context, event *contracts.StreamRegistryV1StreamLastMiniblockUpdated),
 	placementUpdated func(ctx context.Context, event *contracts.StreamRegistryV1StreamPlacementUpdated),
 ) error {
-	// TODO: modify ChainMonitor to accept block number in each subscription call
 	c.Blockchain.ChainMonitor.OnContractWithTopicsEvent(
+		startBlockNumInclusive,
 		c.Address,
 		c.StreamEventTopics,
 		func(ctx context.Context, log types.Log) {

--- a/core/xchain/client_simulator/client_simulator.go
+++ b/core/xchain/client_simulator/client_simulator.go
@@ -286,6 +286,7 @@ func (cs *clientSimulator) Stop() {
 
 func (cs *clientSimulator) Start(ctx context.Context) {
 	cs.baseChain.ChainMonitor.OnContractWithTopicsEvent(
+		0,
 		cs.cfg.GetTestEntitlementContractAddress(),
 		[][]common.Hash{{cs.entitlementGatedABI.Events["EntitlementCheckResultPosted"].ID}},
 		func(ctx context.Context, event types.Log) {
@@ -298,6 +299,7 @@ func (cs *clientSimulator) Start(ctx context.Context) {
 		Info("check requested topics", "topics", cs.checkerABI.Events["EntitlementCheckRequested"].ID)
 
 	cs.baseChain.ChainMonitor.OnContractWithTopicsEvent(
+		0,
 		cs.cfg.GetEntitlementContractAddress(),
 		[][]common.Hash{{cs.checkerABI.Events["EntitlementCheckRequested"].ID}},
 		func(ctx context.Context, event types.Log) {

--- a/core/xchain/server/server.go
+++ b/core/xchain/server/server.go
@@ -274,7 +274,7 @@ func (x *xchain) Run(ctx context.Context) {
 
 	// register callback for Base EntitlementCheckRequested events
 	x.baseChain.ChainMonitor.OnContractWithTopicsEvent(
-		0,
+		x.baseChain.InitialBlockNum,
 		entitlementAddress,
 		[][]common.Hash{{x.checkerABI.Events["EntitlementCheckRequested"].ID}},
 		onEntitlementCheckRequestedCallback)

--- a/core/xchain/server/server.go
+++ b/core/xchain/server/server.go
@@ -274,6 +274,7 @@ func (x *xchain) Run(ctx context.Context) {
 
 	// register callback for Base EntitlementCheckRequested events
 	x.baseChain.ChainMonitor.OnContractWithTopicsEvent(
+		0,
 		entitlementAddress,
 		[][]common.Hash{{x.checkerABI.Events["EntitlementCheckRequested"].ID}},
 		onEntitlementCheckRequestedCallback)


### PR DESCRIPTION
This is the successor of https://github.com/river-build/river/pull/184 that was reverted due to a problem with the block range when retrieving logs. The issue was introduced in a refactoring a while ago that caused the chain monitor to be started twice. With support to subscribe on historical blocks the logic to determine the next block range to poll became more complex. Due to a race condition that was caused by running the same monitor twice it could calculate an invalid block range that caused the rpc get_logs call to fail. The chain monitor never recovered from this and kept on looping on the same invalid range. During unittests the monitor wasn't started twice and therefore the problem wasn't detected.

This is fixed by not starting the blockchain monitor twice. During analysis the implementation to calculate the block range was also simplified. This can also be the explaining for increased rpc provider usage.

