### PR TITLE
core: reduce redundant checking of pending payment status in tx pool

### DIFF
--- a/core/node/crypto/chain_txpool.go
+++ b/core/node/crypto/chain_txpool.go
@@ -226,8 +226,10 @@ func NewTransactionPoolWithPolicies(
 		walletBalance:                walletBalance.With(curryLabels),
 	}
 
-	chainMonitor.OnBlock(txPool.OnBlock)
-	chainMonitor.OnHeader(txPool.OnHeader)
+	chainMonitor.OnHeader(func(ctx context.Context, head *types.Header) {
+		go txPool.CheckPendingTransactions(ctx, head)
+	})
+	chainMonitor.OnHeader(txPool.Balance)
 
 	return txPool, nil
 }
@@ -370,7 +372,7 @@ func (r *transactionPool) Submit(
 	return pendingTx, nil
 }
 
-func (r *transactionPool) OnHeader(ctx context.Context, _ *types.Header) {
+func (r *transactionPool) Balance(ctx context.Context, _ *types.Header) {
 	if time.Since(r.walletBalanceLastTimeChecked) < time.Minute {
 		return
 	}
@@ -386,14 +388,13 @@ func (r *transactionPool) OnHeader(ctx context.Context, _ *types.Header) {
 	r.walletBalanceLastTimeChecked = time.Now()
 }
 
-func (r *transactionPool) OnBlock(ctx context.Context, blockNumber BlockNumber) {
+func (r *transactionPool) CheckPendingTransactions(ctx context.Context, head *types.Header) {
 	log := dlog.FromCtx(ctx).With("chain", r.chainID)
 
-	r.mu.Lock()
-	// if !r.mu.TryLock() {
-	// 	log.Debug("unable to claim tx pool lock")
-	// 	return
-	// }
+	if !r.mu.TryLock() {
+		log.Debug("unable to claim tx pool lock")
+		return
+	}
 	defer r.mu.Unlock()
 
 	if r.firstPendingTx == nil {
@@ -456,17 +457,8 @@ func (r *transactionPool) OnBlock(ctx context.Context, blockNumber BlockNumber) 
 		}
 	}
 
-	var head *types.Header
 	// replace transactions that are eligible for it
 	for pendingTx := r.firstPendingTx; pendingTx != nil; pendingTx = pendingTx.next {
-		if head == nil {
-			// replace transactions that are eligible for it
-			head, err = r.client.HeaderByNumber(ctx, blockNumber.AsBigInt())
-			if err != nil {
-				log.Error("unable to retrieve chain head", "err", err)
-				return
-			}
-		}
 		if r.replacePolicy.Eligible(head, pendingTx.lastSubmit, pendingTx.tx) {
 			pendingTx.txOpts.GasPrice, pendingTx.txOpts.GasFeeCap, pendingTx.txOpts.GasTipCap = r.pricePolicy.Reprice(
 				head, pendingTx.tx)


### PR DESCRIPTION
Currently the tx pool registers an callback for every block in the chain monitor. This callbacks checks which pending transactions are included in the chain. If the chain monitor grabs a chain segment with >1 blocks it will still execute the callback for all intermediate blocks which is not necessary.

This change converts the tx pool to use OnHeader. The chain monitor calls OnHeader only for the latest head that it fetched and not for any intermediate blocks. This reduces extra work/rpc calls. In addition it now executes this callback in the background and guards it with a `mutex.TryLock` construction to prevent the logic to run in parallel. This prevents the chain monitor to get blocked when it takes a long time to process pending transactions.