### PR TITLE
Fix entitlement timing tests by loosening tolerance

### DIFF
--- a/core/xchain/entitlement/entitlement_test.go
+++ b/core/xchain/entitlement/entitlement_test.go
@@ -18,6 +18,8 @@ const (
 	fast = 10
 )
 
+var TimingThreshold = 20 * time.Millisecond
+
 var fastTrueCheck = CheckOperation{
 	OpType:          CHECK,
 	CheckType:       CheckOperationType(MOCK),
@@ -216,12 +218,13 @@ func TestAndOperation(t *testing.T) {
 		if result != tc.expected {
 			t.Errorf("evaluateAndOperation(%v) = %v; want %v", idx, result, tc.expected)
 		}
+		expectedDuration := time.Duration(tc.expectedTime) * time.Millisecond
 		if !areDurationsClose(
 			elapsedTime,
-			time.Duration(tc.expectedTime*int32(time.Millisecond)),
-			10*time.Millisecond,
+			expectedDuration,
+			TimingThreshold,
 		) {
-			t.Errorf("evaluateAndOperation(%v) took %v; want %v", idx, elapsedTime, time.Duration(tc.expectedTime))
+			t.Errorf("evaluateAndOperation(%v) took %v; want %v", idx, elapsedTime, expectedDuration)
 		}
 	}
 }
@@ -266,12 +269,13 @@ func TestOrOperation(t *testing.T) {
 		if result != tc.expected {
 			t.Errorf("evaluateOrOperation(%v) = %v; want %v", idx, result, tc.expected)
 		}
+		expectedDuration := time.Duration(tc.expectedTime) * time.Millisecond
 		if !areDurationsClose(
 			elapsedTime,
-			time.Duration(tc.expectedTime*int32(time.Millisecond)),
-			10*time.Millisecond,
+			expectedDuration,
+			TimingThreshold,
 		) {
-			t.Errorf("evaluateOrOperation(%v) took %v; want %v", idx, elapsedTime, time.Duration(tc.expectedTime))
+			t.Errorf("evaluateOrOperation(%v) took %v; want %v", idx, elapsedTime, expectedDuration)
 		}
 
 	}
@@ -310,16 +314,18 @@ func TestCheckOperation(t *testing.T) {
 		if result != tc.expected {
 			t.Errorf("evaluateCheckOperation result (%v) = %v; want %v", tc.a, result, tc.expected)
 		}
+		expectedDuration := time.Duration(tc.expectedTime) * time.Millisecond
+
 		if !areDurationsClose(
 			elapsedTime,
-			time.Duration(tc.expectedTime*int32(time.Millisecond)),
-			10*time.Millisecond,
+			expectedDuration,
+			TimingThreshold,
 		) {
 			t.Errorf(
 				"evaluateCheckOperation(%v) took %v; want %v",
 				fastFalseCheck,
 				elapsedTime,
-				time.Duration(tc.expectedTime),
+				expectedDuration,
 			)
 		}
 	}

--- a/core/xchain/entitlement/entitlement_test.go
+++ b/core/xchain/entitlement/entitlement_test.go
@@ -18,7 +18,7 @@ const (
 	fast = 10
 )
 
-var timingThreshold = 20 * time.Millisecond
+var timingThreshold = 50 * time.Millisecond
 
 var fastTrueCheck = CheckOperation{
 	OpType:          CHECK,

--- a/core/xchain/entitlement/entitlement_test.go
+++ b/core/xchain/entitlement/entitlement_test.go
@@ -18,7 +18,7 @@ const (
 	fast = 10
 )
 
-var TimingThreshold = 20 * time.Millisecond
+var timingThreshold = 20 * time.Millisecond
 
 var fastTrueCheck = CheckOperation{
 	OpType:          CHECK,
@@ -222,7 +222,7 @@ func TestAndOperation(t *testing.T) {
 		if !areDurationsClose(
 			elapsedTime,
 			expectedDuration,
-			TimingThreshold,
+			timingThreshold,
 		) {
 			t.Errorf("evaluateAndOperation(%v) took %v; want %v", idx, elapsedTime, expectedDuration)
 		}
@@ -273,7 +273,7 @@ func TestOrOperation(t *testing.T) {
 		if !areDurationsClose(
 			elapsedTime,
 			expectedDuration,
-			TimingThreshold,
+			timingThreshold,
 		) {
 			t.Errorf("evaluateOrOperation(%v) took %v; want %v", idx, elapsedTime, expectedDuration)
 		}
@@ -319,7 +319,7 @@ func TestCheckOperation(t *testing.T) {
 		if !areDurationsClose(
 			elapsedTime,
 			expectedDuration,
-			TimingThreshold,
+			timingThreshold,
 		) {
 			t.Errorf(
 				"evaluateCheckOperation(%v) took %v; want %v",


### PR DESCRIPTION
Also fix error messages to print the correct expected duration.