### PR TITLE
Add a pause to fix flaky getstreamex forwarding test.

### DIFF
--- a/core/node/rpc/service_test.go
+++ b/core/node/rpc/service_test.go
@@ -976,7 +976,7 @@ func TestForwardingWithRetries(t *testing.T) {
 			// committing the stream's genesis miniblock to storage yet. We use the info request to force the making of
 			// a miniblock for this stream, but these streams are replicated and the debug make miniblock call only
 			// operates on a local node. This means that the GetStreamEx request may occasionally return an empty
-			// stream, so we retry until we get the expected result.
+			// stream on a node that hasn't caught up to the latest state, so we retry until we get the expected result.
 			require.Eventually(
 				t,
 				func() bool {

--- a/core/node/rpc/service_test.go
+++ b/core/node/rpc/service_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/river-build/river/core/node/crypto"
 	"github.com/river-build/river/core/node/dlog"
@@ -1015,6 +1016,13 @@ func TestForwardingWithRetries(t *testing.T) {
 				}))
 				require.NoError(t, err)
 			}
+
+			// Note: The GetStreamEx implementation bypasses the stream cache, which fetches miniblocks from the
+			// registry if none are present in the local cache, and hits storage directly. This means that sometimes
+			// quorum will be achieved and the createUser call will return when a node may not have received the miniblock,
+			// and we could occasionally end up with a stream response that does not contain the genesis miniblock.
+			// This is why we sleep for a bit before making the stream requests.
+			time.Sleep(2 * time.Second)
 
 			// Shut down replicationfactor - 1 nodes. All streams should still be available, but many
 			// stream requests should result in at least some retries.


### PR DESCRIPTION
I think inserting a short sleep will fix the flaky getstreamex forwarding test, but if it happens again I will disable it.