### PR TITLE
changing spaceOwner function shim name: getNumTotalMemberships->getNumTotalSpaces

### DIFF
--- a/packages/web3/src/v3/SpaceOwner.ts
+++ b/packages/web3/src/v3/SpaceOwner.ts
@@ -24,7 +24,7 @@ export class SpaceOwner {
         )
     }
 
-    public async getNumTotalMemberships(): Promise<ethers.BigNumber> {
+    public async getNumTotalSpaces(): Promise<ethers.BigNumber> {
         return this.erc721A.read.totalSupply()
     }
 }


### PR DESCRIPTION
i had accidentally named this shim getter function `getNumTotalMemberships`, though the real name should have been `getNumTotalSpaces`