### PR TITLE
adding explicit test cases for getStreamsOnNode()

### DIFF
--- a/contracts/test/river/registry/stream/StreamRegistry.t.sol
+++ b/contracts/test/river/registry/stream/StreamRegistry.t.sol
@@ -9,7 +9,8 @@ import {IOwnableBase} from "contracts/src/diamond/facets/ownable/IERC173.sol";
 import {RiverRegistryBaseSetup} from "contracts/test/river/registry/RiverRegistryBaseSetup.t.sol";
 
 contract StreamRegistryTest is RiverRegistryBaseSetup, IOwnableBase {
-  string url = "https://node.com";
+  string url1 = "https://node1.com";
+  string url2 = "https://node2.com";
 
   // =============================================================
   //                        allocateStream
@@ -17,14 +18,16 @@ contract StreamRegistryTest is RiverRegistryBaseSetup, IOwnableBase {
 
   function test_streamCount(
     address nodeOperator,
-    address node
+    address node1,
+    address node2
   )
     external
     givenNodeOperatorIsApproved(nodeOperator)
-    givenNodeIsRegistered(nodeOperator, node, url)
+    givenNodeIsRegistered(nodeOperator, node1, url1)
+    givenNodeIsRegistered(nodeOperator, node2, url2)
   {
     address[] memory nodes = new address[](1);
-    nodes[0] = node;
+    nodes[0] = node1;
     bytes memory genesisMiniblock = abi.encodePacked("genesisMiniblock");
     bytes32 streamIdOne = 0x0000000000000000000000000000000000000000000000000000000000000001;
     bytes32 streamIdTwo = 0x0000000000000000000000000000000000000000000000000000000000000002;
@@ -32,7 +35,7 @@ contract StreamRegistryTest is RiverRegistryBaseSetup, IOwnableBase {
 
     assertEq(streamRegistry.getStreamCount(), 0);
 
-    vm.prank(node);
+    vm.prank(node1);
     streamRegistry.allocateStream(
       streamIdOne,
       nodes,
@@ -42,7 +45,9 @@ contract StreamRegistryTest is RiverRegistryBaseSetup, IOwnableBase {
 
     assertEq(streamRegistry.getStreamCount(), 1);
 
-    vm.prank(node);
+    nodes[0] = node2;
+
+    vm.prank(node2);
     streamRegistry.allocateStream(
       streamIdTwo,
       nodes,
@@ -59,7 +64,7 @@ contract StreamRegistryTest is RiverRegistryBaseSetup, IOwnableBase {
   )
     external
     givenNodeOperatorIsApproved(nodeOperator)
-    givenNodeIsRegistered(nodeOperator, node, url)
+    givenNodeIsRegistered(nodeOperator, node, url1)
   {
     address[] memory nodes = new address[](1);
     nodes[0] = node;
@@ -88,6 +93,6 @@ contract StreamRegistryTest is RiverRegistryBaseSetup, IOwnableBase {
       genesisMiniblock
     );
 
-    assertEq(streamRegistry.getStreamCountOnNode(node), 3);
+    assertEq(streamRegistry.getStreamCountOnNode(node), 2);
   }
 }

--- a/contracts/test/river/registry/stream/StreamRegistry.t.sol
+++ b/contracts/test/river/registry/stream/StreamRegistry.t.sol
@@ -15,7 +15,7 @@ contract StreamRegistryTest is RiverRegistryBaseSetup, IOwnableBase {
   //                        allocateStream
   // =============================================================
 
-  function test_streamCountOnNode(
+  function test_streamCount(
     address nodeOperator,
     address node
   )
@@ -51,5 +51,43 @@ contract StreamRegistryTest is RiverRegistryBaseSetup, IOwnableBase {
     );
 
     assertEq(streamRegistry.getStreamCount(), 2);
+  }
+
+  function test_streamCountOnNode(
+    address nodeOperator,
+    address node
+  )
+    external
+    givenNodeOperatorIsApproved(nodeOperator)
+    givenNodeIsRegistered(nodeOperator, node, url)
+  {
+    address[] memory nodes = new address[](1);
+    nodes[0] = node;
+    bytes memory genesisMiniblock = abi.encodePacked("genesisMiniblock");
+    bytes32 streamIdOne = 0x0000000000000000000000000000000000000000000000000000000000000001;
+    bytes32 streamIdTwo = 0x0000000000000000000000000000000000000000000000000000000000000002;
+    bytes32 genesisMiniblockHash = 0;
+
+    assertEq(streamRegistry.getStreamCountOnNode(node), 0);
+
+    vm.prank(node);
+    streamRegistry.allocateStream(
+      streamIdOne,
+      nodes,
+      genesisMiniblockHash,
+      genesisMiniblock
+    );
+
+    assertEq(streamRegistry.getStreamCountOnNode(node), 1);
+
+    vm.prank(node);
+    streamRegistry.allocateStream(
+      streamIdTwo,
+      nodes,
+      genesisMiniblockHash,
+      genesisMiniblock
+    );
+
+    assertEq(streamRegistry.getStreamCountOnNode(node), 3);
   }
 }


### PR DESCRIPTION
`test_streamCountOnNode` was only testing `getStreamCount`. this pr adds a new test case just for getStreamsOnNode(). i'm also extending the getStreamCount() test to involve multiple nodes