### PR TITLE
Move the build protobuf task in tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,6 +23,7 @@
         "CheckVersions",
         "FoundryUp",
         "YarnInstall",
+        "BuildProtobufs",
         "Stage 1",
       ],
       // Mark as the default build task so cmd/ctrl+shift+b will create them
@@ -48,7 +49,6 @@
       "label": "Stage 2",
       "dependsOn": [
         "CasablancaConfigureNodes",
-        "BuildProtobufs",
         "Stage 3"
       ],
       "group": {


### PR DESCRIPTION
this builds the code, which requires it to compile, but it was happening after we launch blockchains

if you had code errors, you would start blockchains, deploy contracts, then get the error, forcing you to start over. Fail fast instead.