### PR TITLE
BaseRegistry helper function to connect base nodes to their operators

### DIFF
--- a/packages/web3/src/v3/BaseRegistry.ts
+++ b/packages/web3/src/v3/BaseRegistry.ts
@@ -91,22 +91,21 @@ export class BaseRegistry {
 
     public async getNodesWithOperators(): Promise<BaseNodeWithOperator[]> {
         const operators = await this.getOperators()
-        const nodePromises = operators.map((operator) =>
+        const nodesByOperatorPromises = operators.map((operator) =>
             this.entitlementChecker.read.getNodesByOperator(operator.operatorAddress),
         )
-        const nodes = await Promise.all(nodePromises)
-        const operatorsWitNodes = operators.map((operator, index) => ({
+        const nodesByOperator = await Promise.all(nodesByOperatorPromises)
+        const operatorsWithNodes = operators.map((operator, index) => ({
             operator,
-            nodes: nodes[index],
+            nodes: nodesByOperator[index],
         }))
 
-        const nodesWithOperators = operatorsWitNodes.reduce(
-            (acc: BaseNodeWithOperator[], { operator, nodes }) => {
-                const nodesWithOperator = nodes.map((node) => ({ node, operator }))
-                return acc.concat(nodesWithOperator)
-            },
-            [],
-        )
+        const nodesWithOperators: BaseNodeWithOperator[] = []
+        operatorsWithNodes.forEach(({ operator, nodes }) => {
+            nodes.forEach((node) => {
+                nodesWithOperators.push({ node, operator })
+            })
+        })
 
         return nodesWithOperators
     }


### PR DESCRIPTION
Part of the on-chain metrics requirements is to help with detecting discrepancies between nodes and operators on Base vs River.

RiverRegistry's INodeRegistry facet's `getAllNodes()` makes it easy to query the operator of a given node, since `operator` is part of the `Node` struct. However nodes are expressed as addresses only on Base, and we're required to dispatch additional queries to connect the node to its operator.

This PR introduces a new helper function to BaseRegistry. This helper function streamlines this process of getting all nodes along with their operators. We can now use its output to dig into the discrepancies between River and Base.