### PR TITLE
fix: check if process is defined

### DIFF
--- a/packages/sdk/src/riverConfig.ts
+++ b/packages/sdk/src/riverConfig.ts
@@ -11,12 +11,17 @@ import { isDefined } from './check'
 import { check } from '@river-build/dlog'
 
 function getEnvironmentId(): string {
-    return process.env.RIVER_ENV || 'local_single'
+    if (typeof process === 'object') {
+        return process.env.RIVER_ENV || 'local_single'
+    }
+    return 'local_single'
 }
 
 function getBaseRpcUrlForChain(chainId: number): string {
-    if (process.env.BASE_CHAIN_RPC_URL) {
-        return process.env.BASE_CHAIN_RPC_URL
+    if (typeof process === 'object') {
+        if (process.env.BASE_CHAIN_RPC_URL) {
+            return process.env.BASE_CHAIN_RPC_URL
+        }
     }
     switch (chainId) {
         case 31337:
@@ -29,8 +34,10 @@ function getBaseRpcUrlForChain(chainId: number): string {
 }
 
 function getRiverRpcUrlForChain(chainId: number): string {
-    if (process.env.RIVER_CHAIN_RPC_URL) {
-        return process.env.RIVER_CHAIN_RPC_URL
+    if (typeof process === 'object') {
+        if (process.env.RIVER_CHAIN_RPC_URL) {
+            return process.env.RIVER_CHAIN_RPC_URL
+        }
     }
     switch (chainId) {
         case 31338:


### PR DESCRIPTION
Now with the playground package, we're using those functions in places that doesn't even have `process.env`.
So we need to check if `process` is defined before accessing it, to avoid explosions.

Ideally, we want to remove those `process.env` calls in the sdk package, but that's something for other PR 