### PR TITLE
Stress tests - add a small number of new random clients every run

### DIFF
--- a/packages/stress/src/mode/chat/root_chat.ts
+++ b/packages/stress/src/mode/chat/root_chat.ts
@@ -48,6 +48,9 @@ function getChatConfig(opts: { processIndex: number; rootWallet: Wallet }): Chat
 
     const allWallets = generateWalletsFromSeed(opts.rootWallet.mnemonic.phrase, 0, clientsCount)
     const wallets = allWallets.slice(clientStartIndex, clientEndIndex)
+    const randomClientsCount = process.env.RANDOM_CLIENTS_COUNT
+        ? parseInt(process.env.RANDOM_CLIENTS_COUNT)
+        : 5
     if (clientStartIndex >= clientEndIndex) {
         throw new Error('clientStartIndex >= clientEndIndex')
     }
@@ -64,6 +67,7 @@ function getChatConfig(opts: { processIndex: number; rootWallet: Wallet }): Chat
         announceChannelId,
         channelIds,
         allWallets,
+        randomClientsCount,
         randomClients: [],
         localClients: {
             startIndex: clientStartIndex,
@@ -73,7 +77,7 @@ function getChatConfig(opts: { processIndex: number; rootWallet: Wallet }): Chat
         startedAtMs,
         waitForSpaceMembershipTimeoutMs: Math.max(duration * 1000, 20000),
         waitForChannelDecryptionTimeoutMs: Math.max(duration * 1000, 20000),
-    }
+    } satisfies ChatConfig
 }
 
 /*
@@ -102,7 +106,11 @@ export async function startStressChat(opts: {
     )
 
     if (chatConfig.processIndex === 0) {
-        for (let i = chatConfig.clientsCount; i < chatConfig.clientsCount + 5; i++) {
+        for (
+            let i = chatConfig.clientsCount;
+            i < chatConfig.clientsCount + chatConfig.randomClientsCount;
+            i++
+        ) {
             const rc = await makeStressClient(opts.config, i, ethers.Wallet.createRandom())
             chatConfig.randomClients.push(rc)
         }

--- a/packages/stress/src/mode/chat/types.ts
+++ b/packages/stress/src/mode/chat/types.ts
@@ -14,6 +14,7 @@ export interface ChatConfig {
     announceChannelId: string
     channelIds: string[]
     allWallets: Wallet[]
+    randomClientsCount: number
     randomClients: StressClient[]
     localClients: {
         startIndex: number

--- a/packages/stress/src/mode/chat/types.ts
+++ b/packages/stress/src/mode/chat/types.ts
@@ -1,4 +1,5 @@
 import { Wallet } from 'ethers'
+import { StressClient } from '../../utils/stressClient'
 
 export interface ChatConfig {
     containerIndex: number
@@ -13,6 +14,7 @@ export interface ChatConfig {
     announceChannelId: string
     channelIds: string[]
     allWallets: Wallet[]
+    randomClients: StressClient[]
     localClients: {
         startIndex: number
         endIndex: number

--- a/packages/stress/src/start.test.ts
+++ b/packages/stress/src/start.test.ts
@@ -26,12 +26,15 @@ describe('run.test.ts', () => {
         })
 
         const clientsCount = 2
+        const randomClientsCount = 1
+        const totalClients = clientsCount + randomClientsCount
 
         // set some env props
         process.env.SESSION_ID = genShortId()
         process.env.STRESS_DURATION = '10'
         process.env.CLIENTS_PER_PROCESS = clientsCount.toString()
         process.env.CLIENTS_COUNT = clientsCount.toString()
+        process.env.RANDOM_CLIENTS_COUNT = randomClientsCount.toString()
         process.env.SPACE_ID = setup.spaceId
         process.env.CHANNEL_IDS = setup.channelIds[0].toString() // only run one channel
         process.env.CONTAINER_INDEX = '0'
@@ -50,7 +53,7 @@ describe('run.test.ts', () => {
             const value = result.summary.checkinCounts[key]
             logger.log('checkinCounts key', key, value)
             expect(value).toBeDefined()
-            expect(value[clientsCount.toString()]).toBe(clientsCount)
+            expect(value[totalClients.toString()]).toBe(totalClients)
         }
     })
 })


### PR DESCRIPTION
To test minting, and initializing user streams

Ran into a bug with wil, wanted to make for certian this path wasn’t broken (it wasn’t)