### PR TITLE
Default new stress test clients to 0

### DIFF
--- a/packages/stress/src/mode/chat/root_chat.ts
+++ b/packages/stress/src/mode/chat/root_chat.ts
@@ -50,7 +50,7 @@ function getChatConfig(opts: { processIndex: number; rootWallet: Wallet }): Chat
     const wallets = allWallets.slice(clientStartIndex, clientEndIndex)
     const randomClientsCount = process.env.RANDOM_CLIENTS_COUNT
         ? parseInt(process.env.RANDOM_CLIENTS_COUNT)
-        : 5
+        : 0
     if (clientStartIndex >= clientEndIndex) {
         throw new Error('clientStartIndex >= clientEndIndex')
     }


### PR DESCRIPTION
Until we have a plan that doesn’t involve adding 5 users to our channel every hour, or until we can support that!