### PR TITLE
Disable flaky forwarding test

### DIFF
--- a/core/node/rpc/service_test.go
+++ b/core/node/rpc/service_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/river-build/river/core/node/crypto"
 	"github.com/river-build/river/core/node/dlog"
@@ -969,34 +968,34 @@ func TestForwardingWithRetries(t *testing.T) {
 			require.NotNil(t, resp)
 			require.Equal(t, streamId[:], resp.Msg.Stream.NextSyncCookie.StreamId)
 		},
-		"GetStreamEx": func(t *testing.T, ctx context.Context, client protocolconnect.StreamServiceClient, streamId StreamId) {
-			// Note: the GetStreamEx implementation bypasses the stream cache, which fetches miniblocks from the
-			// registry if none are yet present in the local cache. The stream creation flow returns when a quorum of
-			// nodes terminates the stream creation call successfully, meaning that some nodes may not have finished
-			// committing the stream's genesis miniblock to storage yet. We use the info request to force the making of
-			// a miniblock for this stream, but these streams are replicated and the debug make miniblock call only
-			// operates on a local node. This means that the GetStreamEx request may occasionally return an empty
-			// stream on a node that hasn't caught up to the latest state, so we retry until we get the expected result.
-			require.Eventually(
-				t,
-				func() bool {
-					resp, err := client.GetStreamEx(ctx, connect.NewRequest(&protocol.GetStreamExRequest{
-						StreamId: streamId[:],
-					}))
-					require.NoError(t, err)
+		// "GetStreamEx": func(t *testing.T, ctx context.Context, client protocolconnect.StreamServiceClient, streamId StreamId) {
+		// 	// Note: the GetStreamEx implementation bypasses the stream cache, which fetches miniblocks from the
+		// 	// registry if none are yet present in the local cache. The stream creation flow returns when a quorum of
+		// 	// nodes terminates the stream creation call successfully, meaning that some nodes may not have finished
+		// 	// committing the stream's genesis miniblock to storage yet. We use the info request to force the making of
+		// 	// a miniblock for this stream, but these streams are replicated and the debug make miniblock call only
+		// 	// operates on a local node. This means that the GetStreamEx request may occasionally return an empty
+		// 	// stream on a node that hasn't caught up to the latest state, so we retry until we get the expected result.
+		// 	require.Eventually(
+		// 		t,
+		// 		func() bool {
+		// 			resp, err := client.GetStreamEx(ctx, connect.NewRequest(&protocol.GetStreamExRequest{
+		// 				StreamId: streamId[:],
+		// 			}))
+		// 			require.NoError(t, err)
 
-					// Read messages
-					msgs := make([]*protocol.GetStreamExResponse, 0)
-					for resp.Receive() {
-						msgs = append(msgs, resp.Msg())
-					}
-					require.NoError(t, resp.Err())
-					return len(msgs) == 2
-				},
-				10*time.Second,
-				100*time.Millisecond,
-			)
-		},
+		// 			// Read messages
+		// 			msgs := make([]*protocol.GetStreamExResponse, 0)
+		// 			for resp.Receive() {
+		// 				msgs = append(msgs, resp.Msg())
+		// 			}
+		// 			require.NoError(t, resp.Err())
+		// 			return len(msgs) == 2
+		// 		},
+		// 		10*time.Second,
+		// 		100*time.Millisecond,
+		// 	)
+		// },
 	}
 
 	for testName, requester := range tests {


### PR DESCRIPTION
Adding an Eventually condition with 10s did not fix - I'm wondering if there's an issue aside from the known issue of miniblock consistency, but we don't actually use GetStreamEx right now and fixing it is not as high priority as channel gating work, see https://linear.app/hnt-labs/issue/HNT-7329/fix-getstreamex-endpoint-go-test for follow-up task

I'm disabling this test to give @texuf some relief.