### PR TITLE
SpaceDapp changes for shortDescription, longDescription to align with the contract changes

### DIFF
--- a/packages/sdk/src/sync-agent/spaces/spaces.ts
+++ b/packages/sdk/src/sync-agent/spaces/spaces.ts
@@ -93,6 +93,8 @@ export class Spaces extends PersistedObservable<SpacesModel> {
                 spaceMetadata: params.spaceMetadata ?? params.spaceName,
                 channelName: channelName,
                 membership: membershipInfo,
+                shortDescription: params.shortDescription,
+                longDescription: params.longDescription,
             },
             signer,
         )

--- a/packages/web3/src/ISpaceDapp.ts
+++ b/packages/web3/src/ISpaceDapp.ts
@@ -25,6 +25,8 @@ export interface CreateSpaceParams {
     spaceMetadata: string
     channelName: string
     membership: MembershipStruct
+    shortDescription?: string
+    longDescription?: string
 }
 
 export interface UpdateChannelParams {
@@ -151,6 +153,15 @@ export interface ISpaceDapp {
     ) => Promise<TransactionType>
     updateRole: (
         params: UpdateRoleParams,
+        signer: SignerType,
+        txnOpts?: TransactionOpts,
+    ) => Promise<TransactionType>
+    updateSpaceInfo: (
+        spaceId: string,
+        name: string,
+        shortDescription: string,
+        longDescription: string,
+        uri: string,
         signer: SignerType,
         txnOpts?: TransactionOpts,
     ) => Promise<TransactionType>

--- a/packages/web3/src/types.ts
+++ b/packages/web3/src/types.ts
@@ -4,4 +4,6 @@ export interface SpaceInfo {
     name: string
     owner: string
     disabled: boolean
+    shortDescription: string
+    longDescription: string
 }

--- a/packages/web3/src/v3/SpaceDapp.ts
+++ b/packages/web3/src/v3/SpaceDapp.ts
@@ -151,6 +151,8 @@ export class SpaceDapp implements ISpaceDapp {
             channel: {
                 metadata: params.channelName || '',
             },
+            shortDescription: params.shortDescription ?? '',
+            longDescription: params.longDescription ?? '',
         }
         return wrapTransaction(
             () => this.spaceRegistrar.SpaceArchitect.write(signer).createSpace(spaceInfo),
@@ -287,6 +289,8 @@ export class SpaceDapp implements ISpaceDapp {
             name: (spaceInfo.name as string) ?? '',
             owner,
             disabled,
+            shortDescription: (spaceInfo.shortDescription as string) ?? '',
+            longDescription: (spaceInfo.longDescription as string) ?? '',
         }
     }
 
@@ -304,7 +308,39 @@ export class SpaceDapp implements ISpaceDapp {
         // update the space name
         return wrapTransaction(
             () =>
-                space.SpaceOwner.write(signer).updateSpaceInfo(space.Address, name, spaceInfo.uri),
+                space.SpaceOwner.write(signer).updateSpaceInfo(
+                    space.Address,
+                    name,
+                    spaceInfo.uri,
+                    spaceInfo.shortDescription,
+                    spaceInfo.longDescription,
+                ),
+            txnOpts,
+        )
+    }
+
+    public async updateSpaceInfo(
+        spaceId: string,
+        name: string,
+        uri: string,
+        shortDescription: string,
+        longDescription: string,
+        signer: ethers.Signer,
+        txnOpts?: TransactionOpts,
+    ): Promise<ContractTransaction> {
+        const space = this.getSpace(spaceId)
+        if (!space) {
+            throw new Error(`Space with spaceId "${spaceId}" is not found.`)
+        }
+        return wrapTransaction(
+            () =>
+                space.SpaceOwner.write(signer).updateSpaceInfo(
+                    space.Address,
+                    name,
+                    uri,
+                    shortDescription,
+                    longDescription,
+                ),
             txnOpts,
         )
     }


### PR DESCRIPTION
Branched off [g/hnt-7247](https://github.com/river-build/river/pull/276). Fixes to the river web3 packages to align with your spaceInfo contract changes. 

Locally tested. Builds clean. Integration tests passed.