### PR TITLE
Refactor cache tests to use common helpers. Unify ChainMonitor start.

### DIFF
--- a/core/cmd/register_xchain_node_cmd.go
+++ b/core/cmd/register_xchain_node_cmd.go
@@ -84,13 +84,7 @@ func registerImpl(operatorKeyfile string, userConfirmationMessage string, regist
 	if err != nil {
 		return fmt.Errorf("unable to instantiate base chain client: %s", err)
 	}
-	go baseChain.ChainMonitor.RunWithBlockPeriod(
-		ctx,
-		baseChain.Client,
-		0,
-		time.Duration(cmdConfig.BaseChain.BlockTimeMs)*time.Millisecond,
-		metrics,
-	)
+	baseChain.StartChainMonitor(ctx)
 
 	checker, err := base.NewIEntitlementChecker(cmdConfig.GetEntitlementContractAddress(), baseChain.Client)
 	if err != nil {

--- a/core/node/crypto/testutil.go
+++ b/core/node/crypto/testutil.go
@@ -472,13 +472,7 @@ func makeTestBlockchain(
 		panic(err)
 	}
 
-	go bc.ChainMonitor.RunWithBlockPeriod(
-		ctx,
-		client,
-		bc.InitialBlockNum,
-		100*time.Millisecond,
-		infra.NewMetrics("", ""),
-	)
+	bc.StartChainMonitor(ctx)
 
 	return bc
 }

--- a/core/node/events/stream_cache_test.go
+++ b/core/node/events/stream_cache_test.go
@@ -6,20 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/river-build/river/core/config"
-	"github.com/river-build/river/core/node/base/test"
 	"github.com/river-build/river/core/node/crypto"
-	"github.com/river-build/river/core/node/infra"
 	"github.com/river-build/river/core/node/protocol"
-	"github.com/river-build/river/core/node/registries"
 	"github.com/river-build/river/core/node/shared"
-	"github.com/river-build/river/core/node/storage"
 	"github.com/river-build/river/core/node/testutils"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 )
 
 func TestStreamCacheViewEviction(t *testing.T) {
@@ -55,50 +47,14 @@ func DisabledTestStreamMiniblockBatchProduction(t *testing.T) {
 }
 
 func testStreamCacheViewEviction(t *testing.T, useBatchRegistration bool) {
-	var (
-		ctx, cancel = test.NewTestContext()
-		require     = require.New(t)
-	)
-	defer cancel()
-
-	btc, err := crypto.NewBlockchainTestContext(ctx, 1, true)
-	require.NoError(err, "instantiating blockchain test context")
-	defer btc.Close()
-
-	node := btc.GetBlockchain(ctx, 0)
-	node.StartChainMonitor(ctx)
-
-	pendingTx, err := btc.DeployerBlockchain.TxPool.Submit(
-		ctx,
-		"RegisterNode",
-		func(opts *bind.TransactOpts) (*types.Transaction, error) {
-			return btc.NodeRegistry.RegisterNode(opts, node.Wallet.Address, "http://node.local:1234", 2)
-		},
-	)
-	require.NoError(err, "register node")
-	receipt := <-pendingTx.Wait()
-	require.Equal(crypto.TransactionResultSuccess, receipt.Status, "register node transaction failed")
-
-	riverRegistry, err := registries.NewRiverRegistryContract(ctx, node, &config.ContractConfig{
-		Address: btc.RiverRegistryAddress,
-	})
-	require.NoError(err, "instantiating river registry contract")
-
-	pg := storage.NewTestPgStore(ctx)
-	defer pg.Close()
+	require := require.New(t)
+	ctx, tc := makeTestStreamParams(t, testParams{})
+	defer tc.closer()
 
 	// disable auto stream cache cleanup, do cleanup manually
-	btc.SetConfigValue(t, ctx, crypto.StreamCacheExpirationPollIntervalMsConfigKey, crypto.ABIEncodeUint64(0))
+	tc.bcTest.SetConfigValue(t, ctx, crypto.StreamCacheExpirationPollIntervalMsConfigKey, crypto.ABIEncodeUint64(0))
 
-	streamCache, err := NewStreamCache(ctx, &StreamCacheParams{
-		Storage:     pg.Storage,
-		Wallet:      node.Wallet,
-		RiverChain:  node,
-		Registry:    riverRegistry,
-		ChainConfig: btc.OnChainConfig,
-	}, 0, chainMonitor, infra.NewMetrics("", ""))
-	require.NoError(err, "instantiating stream cache")
-
+	streamCache := tc.initCache(ctx)
 	streamCache.registerMiniBlocksBatched = useBatchRegistration
 
 	streamCache.cache.Range(func(key, value any) bool {
@@ -106,32 +62,11 @@ func testStreamCacheViewEviction(t *testing.T, useBatchRegistration bool) {
 		return true
 	})
 
-	var (
-		nodes            = []common.Address{node.Wallet.Address}
-		streamID         = testutils.FakeStreamId(shared.STREAM_SPACE_BIN)
-		genesisMiniblock = MakeGenesisMiniblockForSpaceStream(t, node.Wallet, streamID)
-	)
+	node := tc.getBC()
+	streamID := testutils.FakeStreamId(shared.STREAM_SPACE_BIN)
+	_, genesisMiniblock := makeTestSpaceStream(t, node.Wallet, streamID, nil)
 
-	genesisMiniblockBytes, err := proto.Marshal(genesisMiniblock)
-	require.NoError(err, "marshalling genesis miniblock")
-
-	pendingTx, err = node.TxPool.Submit(
-		ctx,
-		"AllocateStream",
-		func(opts *bind.TransactOpts) (*types.Transaction, error) {
-			return riverRegistry.StreamRegistry.AllocateStream(
-				opts,
-				streamID,
-				nodes,
-				[32]byte(genesisMiniblock.Header.Hash),
-				genesisMiniblockBytes,
-			)
-		},
-	)
-
-	require.NoError(err, "allocate stream")
-	receipt = <-pendingTx.Wait()
-	require.Equal(crypto.TransactionResultSuccess, receipt.Status, "allocate stream transaction failed")
+	require.NoError(tc.createStreamNoCache(ctx, streamID, genesisMiniblock))
 
 	streamSync, streamView, err := streamCache.GetStream(ctx, streamID)
 	require.NoError(err, "loading stream record")
@@ -220,87 +155,26 @@ func testStreamCacheViewEviction(t *testing.T, useBatchRegistration bool) {
 }
 
 func testCacheEvictionWithFilledMiniBlockPool(t *testing.T, useBatchRegistration bool) {
-	var (
-		ctx, cancel  = test.NewTestContext()
-		require      = require.New(t)
-		chainMonitor = crypto.NewChainMonitor()
-	)
-	defer cancel()
-
-	btc, err := crypto.NewBlockchainTestContext(ctx, 1, true)
-	require.NoError(err, "instantiating blockchain test context")
-	defer btc.Close()
-
-	go chainMonitor.RunWithBlockPeriod(ctx, btc.Client(), 0, 10*time.Millisecond, infra.NewMetrics("", ""))
-
-	node := btc.GetBlockchain(ctx, 0)
-
-	pendingTx, err := btc.DeployerBlockchain.TxPool.Submit(
-		ctx,
-		"RegisterNode",
-		func(opts *bind.TransactOpts) (*types.Transaction, error) {
-			return btc.NodeRegistry.RegisterNode(opts, node.Wallet.Address, "http://node.local:1234", 2)
-		},
-	)
-	require.NoError(err, "register node")
-	receipt := <-pendingTx.Wait()
-	require.Equal(crypto.TransactionResultSuccess, receipt.Status, "register node transaction failed")
+	require := require.New(t)
+	ctx, tc := makeTestStreamParams(t, testParams{})
+	defer tc.closer()
 
 	// disable auto stream cache cleanup, do cleanup manually
-	btc.SetConfigValue(t, ctx, crypto.StreamCacheExpirationPollIntervalMsConfigKey, crypto.ABIEncodeUint64(0))
+	tc.bcTest.SetConfigValue(t, ctx, crypto.StreamCacheExpirationPollIntervalMsConfigKey, crypto.ABIEncodeUint64(0))
 
-	riverRegistry, err := registries.NewRiverRegistryContract(ctx, node, &config.ContractConfig{
-		Address: btc.RiverRegistryAddress,
-	})
-	require.NoError(err, "instantiating river registry contract")
-
-	pg := storage.NewTestPgStore(ctx)
-	defer pg.Close()
-
-	streamCacheParams := &StreamCacheParams{
-		Storage:     pg.Storage,
-		Wallet:      node.Wallet,
-		RiverChain:  node,
-		Registry:    riverRegistry,
-		ChainConfig: btc.OnChainConfig,
-	}
-
-	streamCache, err := NewStreamCache(ctx, streamCacheParams, 0, chainMonitor, infra.NewMetrics("", ""))
-	require.NoError(err, "instantiating stream cache")
-
+	streamCache := tc.initCache(ctx)
 	streamCache.registerMiniBlocksBatched = useBatchRegistration
 
 	streamCache.cache.Range(func(key, value any) bool {
-		require.Fail("stream cache should be empty")
+		require.Fail("stream cache must be empty")
 		return true
 	})
 
-	var (
-		nodes            = []common.Address{node.Wallet.Address}
-		streamID         = testutils.FakeStreamId(shared.STREAM_SPACE_BIN)
-		genesisMiniblock = MakeGenesisMiniblockForSpaceStream(t, node.Wallet, streamID)
-	)
+	node := tc.getBC()
+	streamID := testutils.FakeStreamId(shared.STREAM_SPACE_BIN)
+	_, genesisMiniblock := makeTestSpaceStream(t, node.Wallet, streamID, nil)
 
-	genesisMiniblockBytes, err := proto.Marshal(genesisMiniblock)
-	require.NoError(err, "marshalling genesis miniblock")
-
-	pendingTx, err = node.TxPool.Submit(
-		ctx,
-		"AllocateStream",
-		func(opts *bind.TransactOpts) (*types.Transaction, error) {
-			return riverRegistry.StreamRegistry.AllocateStream(
-				opts,
-				streamID,
-				nodes,
-				[32]byte(genesisMiniblock.Header.Hash),
-				genesisMiniblockBytes,
-			)
-		},
-	)
-
-	require.NoError(err, "allocate stream")
-	receipt = <-pendingTx.Wait()
-	require.Equal(crypto.TransactionResultSuccess, receipt.Status, "allocate stream transaction failed")
+	require.NoError(tc.createStreamNoCache(ctx, streamID, genesisMiniblock))
 
 	streamSync, _, err := streamCache.GetStream(ctx, streamID)
 	require.NoError(err, "loading stream record")
@@ -333,7 +207,7 @@ func testCacheEvictionWithFilledMiniBlockPool(t *testing.T, useBatchRegistration
 	require.NoError(err, "make miniblock")
 
 	// add event to stream with unloaded view, view should be loaded in cache and minipool must contain event
-	addEvent(t, ctx, streamCacheParams, streamSync, "payload", common.BytesToHash(genesisMiniblock.Header.Hash))
+	addEvent(t, ctx, tc.params, streamSync, "payload", common.BytesToHash(genesisMiniblock.Header.Hash))
 
 	// with event in minipool ensure that view isn't evicted from cache
 	time.Sleep(10 * time.Millisecond) // make sure we hit the cache expiration of 1 ms
@@ -372,53 +246,19 @@ func (sub *testStreamCacheViewEvictionSub) OnSyncError(err error) {
 }
 
 func testStreamMiniblockBatchProduction(t *testing.T, useBatchRegistration bool) {
-	var (
-		ctx, cancel  = test.NewTestContext()
-		require      = require.New(t)
-		streamsCount = 10*MiniblockCandidateBatchSize - 1
-	)
-	defer cancel()
-
-	btc, err := crypto.NewBlockchainTestContext(ctx, 1, true)
-	require.NoError(err, "instantiating blockchain test context")
-	defer btc.Close()
-
-	node := btc.GetBlockchain(ctx, 0)
-	pendingTx, err := btc.DeployerBlockchain.TxPool.Submit(
-		ctx,
-		"RegisterNode",
-		func(opts *bind.TransactOpts) (*types.Transaction, error) {
-			return btc.NodeRegistry.RegisterNode(opts, node.Wallet.Address, "http://node.local:1234", 2)
-		},
-	)
-	require.NoError(err, "register node")
-	receipt := <-pendingTx.Wait()
-	require.Equal(crypto.TransactionResultSuccess, receipt.Status, "register node transaction failed")
+	require := require.New(t)
+	ctx, tc := makeTestStreamParams(t, testParams{})
+	defer tc.closer()
+	btc := tc.bcTest
 
 	// disable auto stream cache cleanup, do cleanup manually
-	btc.SetConfigValue(t, ctx, crypto.StreamCacheExpirationPollIntervalMsConfigKey, crypto.ABIEncodeUint64(0))
+	tc.bcTest.SetConfigValue(t, ctx, crypto.StreamCacheExpirationPollIntervalMsConfigKey, crypto.ABIEncodeUint64(0))
 
-	riverRegistry, err := registries.NewRiverRegistryContract(ctx, node, &config.ContractConfig{
-		Address: btc.RiverRegistryAddress,
-	})
-	require.NoError(err, "instantiating river registry contract")
-
-	pg := storage.NewTestPgStore(ctx)
-	defer pg.Close()
-
-	streamCache, err := NewStreamCache(ctx, &StreamCacheParams{
-		Storage:     pg.Storage,
-		Wallet:      node.Wallet,
-		RiverChain:  node,
-		Registry:    riverRegistry,
-		ChainConfig: btc.OnChainConfig,
-	}, node.InitialBlockNum, node.ChainMonitor, infra.NewMetrics("", ""))
-	require.NoError(err, "instantiating stream cache")
-
+	streamCache := tc.initCache(ctx)
 	streamCache.registerMiniBlocksBatched = useBatchRegistration
 
 	streamCache.cache.Range(func(key, value any) bool {
-		require.Fail("stream cache should be empty")
+		require.Fail("stream cache must be empty")
 		return true
 	})
 
@@ -426,11 +266,9 @@ func testStreamMiniblockBatchProduction(t *testing.T, useBatchRegistration bool)
 	// after initialization take back control when to create new chain blocks.
 	// TODO: this handler is gone, refactor
 	// btc.DeployerBlockchain.TxPool.SetOnSubmitHandler(nil)
-
-	var (
-		genesisBlocks     = allocateStreams(t, ctx, btc, streamsCount, node, riverRegistry)
-		streamsWithEvents = make(map[shared.StreamId]int)
-	)
+	streamsCount := 10*MiniblockCandidateBatchSize - 1
+	genesisBlocks := allocateStreams(t, ctx, tc, streamsCount)
+	streamsWithEvents := make(map[shared.StreamId]int)
 
 	// add events to ~50% of the streams
 	for streamID, genesis := range genesisBlocks {
@@ -471,7 +309,7 @@ func testStreamMiniblockBatchProduction(t *testing.T, useBatchRegistration bool)
 				gotStreamEventsCount = 0
 			)
 
-			syncCookie := view.SyncCookie(node.Wallet.Address)
+			syncCookie := view.SyncCookie(tc.getBC().Wallet.Address)
 			require.NotNil(syncCookie, "sync cookie")
 
 			miniblocks, _, err := stream.GetMiniblocks(ctx, 0, syncCookie.MinipoolGen)
@@ -496,9 +334,22 @@ func testStreamMiniblockBatchProduction(t *testing.T, useBatchRegistration bool)
 }
 
 func TestStreamUnloadWithSubscribers(t *testing.T) {
+	require := require.New(t)
+	ctx, tc := makeTestStreamParams(t, testParams{})
+	defer tc.closer()
+
+	// disable auto stream cache cleanup, do cleanup manually
+	tc.bcTest.SetConfigValue(t, ctx, crypto.StreamCacheExpirationPollIntervalMsConfigKey, crypto.ABIEncodeUint64(0))
+
+	streamCache := tc.initCache(ctx)
+	streamCache.registerMiniBlocksBatched = true
+
+	streamCache.cache.Range(func(key, value any) bool {
+		require.Fail("stream cache must be empty")
+		return true
+	})
+
 	var (
-		ctx, cancel  = test.NewTestContext()
-		require      = require.New(t)
 		streamsCount = 5
 		cleanUpCache = func(streamCache *streamCacheImpl, expOutcome bool) {
 			streamCache.cache.Range(func(key, streamVal any) bool {
@@ -516,51 +367,6 @@ func TestStreamUnloadWithSubscribers(t *testing.T) {
 			})
 		}
 	)
-	defer cancel()
-
-	btc, err := crypto.NewBlockchainTestContext(ctx, 1, true)
-	require.NoError(err, "instantiating blockchain test context")
-	defer btc.Close()
-
-	node := btc.GetBlockchain(ctx, 0)
-	pendingTx, err := btc.DeployerBlockchain.TxPool.Submit(
-		ctx,
-		"RegisterNode",
-		func(opts *bind.TransactOpts) (*types.Transaction, error) {
-			return btc.NodeRegistry.RegisterNode(opts, node.Wallet.Address, "http://node.local:1234", 2)
-		},
-	)
-
-	require.NoError(err, "register node")
-	receipt := <-pendingTx.Wait()
-	require.Equal(crypto.TransactionResultSuccess, receipt.Status, "register node transaction failed")
-
-	// disable auto stream cache cleanup, do cleanup manually
-	btc.SetConfigValue(t, ctx, crypto.StreamCacheExpirationPollIntervalMsConfigKey, crypto.ABIEncodeUint64(0))
-
-	riverRegistry, err := registries.NewRiverRegistryContract(ctx, node, &config.ContractConfig{
-		Address: btc.RiverRegistryAddress,
-	})
-	require.NoError(err, "instantiating river registry contract")
-
-	pg := storage.NewTestPgStore(ctx)
-	defer pg.Close()
-
-	streamCache, err := NewStreamCache(ctx, &StreamCacheParams{
-		Storage:     pg.Storage,
-		Wallet:      node.Wallet,
-		RiverChain:  node,
-		Registry:    riverRegistry,
-		ChainConfig: btc.OnChainConfig,
-	}, node.InitialBlockNum, node.ChainMonitor, infra.NewMetrics("", ""))
-	require.NoError(err, "instantiating stream cache")
-
-	streamCache.registerMiniBlocksBatched = true
-
-	streamCache.cache.Range(func(key, value any) bool {
-		require.Fail("stream cache should be empty")
-		return true
-	})
 
 	// the stream cache uses the chain block production as a ticker to create new mini-blocks.
 	// after initialization take back control when to create new chain blocks.
@@ -568,7 +374,8 @@ func TestStreamUnloadWithSubscribers(t *testing.T) {
 	// btc.DeployerBlockchain.TxPool.SetOnSubmitHandler(nil)
 
 	var (
-		genesisBlocks         = allocateStreams(t, ctx, btc, streamsCount, node, riverRegistry)
+		node                  = tc.getBC()
+		genesisBlocks         = allocateStreams(t, ctx, tc, streamsCount)
 		syncCookies           = make(map[shared.StreamId]*protocol.SyncCookie)
 		subscriptionReceivers = make(map[shared.StreamId]*testStreamCacheViewEvictionSub)
 		eventsReceived        = func(sub *testStreamCacheViewEvictionSub) int {
@@ -590,16 +397,12 @@ func TestStreamUnloadWithSubscribers(t *testing.T) {
 
 	blockNum, err := node.GetBlockNumber(ctx)
 	require.NoError(err, "get block number")
+	tc.params.AppliedBlockNum = blockNum
 
 	// create fresh stream cache and subscribe
-	streamCache, err = NewStreamCache(ctx, &StreamCacheParams{
-		Storage:     pg.Storage,
-		Wallet:      node.Wallet,
-		RiverChain:  node,
-		Registry:    riverRegistry,
-		ChainConfig: btc.OnChainConfig,
-	}, blockNum, node.ChainMonitor, infra.NewMetrics("", ""))
+	streamCache, err = NewStreamCache(ctx, tc.params)
 	require.NoError(err, "instantiating stream cache")
+	streamCache.registerMiniBlocksBatched = true
 
 	for streamID, syncCookie := range syncCookies {
 		streamSync, err := streamCache.GetSyncStream(ctx, streamID)
@@ -660,52 +463,21 @@ func TestStreamUnloadWithSubscribers(t *testing.T) {
 func allocateStreams(
 	t *testing.T,
 	ctx context.Context,
-	btc *crypto.BlockchainTestContext,
+	tt *testContext,
 	count int,
-	node *crypto.Blockchain,
-	riverRegistry *registries.RiverRegistryContract,
 ) map[shared.StreamId]*protocol.Miniblock {
 	var (
 		require       = require.New(t)
 		genesisBlocks = make(map[shared.StreamId]*protocol.Miniblock)
-		lastPendingTx crypto.TransactionPoolPendingTransaction
 	)
 
 	for i := 0; i < count; i++ {
-		var (
-			nodes            = []common.Address{node.Wallet.Address}
-			streamID         = testutils.FakeStreamId(shared.STREAM_SPACE_BIN)
-			genesisMiniblock = MakeGenesisMiniblockForSpaceStream(t, node.Wallet, streamID)
-		)
-
-		genesisMiniblockBytes, err := proto.Marshal(genesisMiniblock)
-		require.NoError(err, "marshalling genesis miniblock")
-
-		pendingTx, err := node.TxPool.Submit(ctx, "AllocateStream",
-			func(opts *bind.TransactOpts) (*types.Transaction, error) {
-				return riverRegistry.StreamRegistry.AllocateStream(
-					opts,
-					streamID,
-					nodes,
-					[32]byte(genesisMiniblock.Header.Hash),
-					genesisMiniblockBytes,
-				)
-			},
-		)
-		require.NoError(err, "submit allocate stream tx")
-		lastPendingTx = pendingTx
-		genesisBlocks[streamID] = genesisMiniblock
+		streamID := testutils.FakeStreamId(shared.STREAM_SPACE_BIN)
+		mb := MakeGenesisMiniblockForSpaceStream(t, tt.getBC().Wallet, streamID)
+		err := tt.createStreamNoCache(ctx, streamID, mb)
+		require.NoError(err, "create stream")
+		genesisBlocks[streamID] = mb
 	}
 
-	for {
-		btc.Commit(ctx)
-		select {
-		case receipt := <-lastPendingTx.Wait():
-			require.Equal(crypto.TransactionResultSuccess, receipt.Status,
-				"allocate streams failed")
-			return genesisBlocks
-		case <-time.After(time.Second):
-			continue
-		}
-	}
+	return genesisBlocks
 }

--- a/core/node/events/stream_cache_test.go
+++ b/core/node/events/stream_cache_test.go
@@ -58,9 +58,8 @@ func DisabledTestStreamMiniblockBatchProduction(t *testing.T) {
 
 func testStreamCacheViewEviction(t *testing.T, useBatchRegistration bool) {
 	var (
-		ctx, cancel  = test.NewTestContext()
-		require      = require.New(t)
-		chainMonitor = crypto.NewChainMonitor()
+		ctx, cancel = test.NewTestContext()
+		require     = require.New(t)
 	)
 	defer cancel()
 
@@ -68,9 +67,8 @@ func testStreamCacheViewEviction(t *testing.T, useBatchRegistration bool) {
 	require.NoError(err, "instantiating blockchain test context")
 	defer btc.Close()
 
-	go chainMonitor.RunWithBlockPeriod(ctx, btc.Client(), 0, 10*time.Millisecond, infra.NewMetrics("", ""))
-
 	node := btc.GetBlockchain(ctx, 0)
+	node.StartChainMonitor(ctx)
 
 	pendingTx, err := btc.DeployerBlockchain.TxPool.Submit(
 		ctx,

--- a/core/node/events/stream_test.go
+++ b/core/node/events/stream_test.go
@@ -85,6 +85,7 @@ func mbTest(
 ) {
 	ctx, tt := makeTestStreamParams(t, testParams{replFactor: 1})
 	defer tt.closer()
+	_ = tt.initCache(ctx)
 	require := require.New(t)
 
 	spaceStreamId := testutils.FakeStreamId(STREAM_SPACE_BIN)

--- a/core/node/events/stream_viewstate_space_test.go
+++ b/core/node/events/stream_viewstate_space_test.go
@@ -190,10 +190,11 @@ func leaveChannel_T(
 }
 
 func TestSpaceViewState(t *testing.T) {
-	ctx, tt := makeTestStreamCache(t, testParams{
+	ctx, tt := makeTestStreamParams(t, testParams{
 		defaultMinEventsPerSnapshot: 2,
 	})
 	defer tt.closer()
+	_ = tt.initCache(ctx)
 
 	user1Wallet, _ := crypto.NewWallet(ctx)
 	user2Wallet, _ := crypto.NewWallet(ctx)
@@ -278,11 +279,12 @@ func spaceViewStateTest_CheckUserJoined(
 }
 
 func TestChannelViewState_JoinedMembers(t *testing.T) {
-	ctx, tt := makeTestStreamCache(t, testParams{
+	ctx, tt := makeTestStreamParams(t, testParams{
 		replFactor:                  1,
 		defaultMinEventsPerSnapshot: 2,
 	})
 	defer tt.closer()
+	_ = tt.initCache(ctx)
 
 	userWallet, _ := crypto.NewWallet(ctx)
 	aliceWallet, _ := crypto.NewWallet(ctx)
@@ -337,11 +339,12 @@ func TestChannelViewState_JoinedMembers(t *testing.T) {
 }
 
 func TestChannelViewState_RemainingMembers(t *testing.T) {
-	ctx, tt := makeTestStreamCache(t, testParams{
+	ctx, tt := makeTestStreamParams(t, testParams{
 		replFactor:                  1,
 		defaultMinEventsPerSnapshot: 2,
 	})
 	defer tt.closer()
+	_ = tt.initCache(ctx)
 
 	userWallet, _ := crypto.NewWallet(ctx)
 	aliceWallet, _ := crypto.NewWallet(ctx)

--- a/core/node/events/util_test.go
+++ b/core/node/events/util_test.go
@@ -33,6 +33,8 @@ type testParams struct {
 	defaultMinEventsPerSnapshot   int
 }
 
+// makeTestStreamParams creates a test context with a blockchain and a stream registry for stream cahe tests.
+// It doesn't create a stream cache itself. Call initCache to create a stream cache.
 func makeTestStreamParams(t *testing.T, p testParams) (context.Context, *testContext) {
 	ctx, cancel := test.NewTestContext()
 	btc, err := crypto.NewBlockchainTestContext(ctx, 1, true)
@@ -46,6 +48,7 @@ func makeTestStreamParams(t *testing.T, p testParams) (context.Context, *testCon
 	}
 
 	bc := btc.GetBlockchain(ctx, 0)
+	bc.StartChainMonitor(ctx)
 
 	pg := storage.NewTestPgStore(ctx)
 
@@ -67,23 +70,20 @@ func makeTestStreamParams(t *testing.T, p testParams) (context.Context, *testCon
 	sr := NewStreamRegistry(bc.Wallet.Address, nr, registry, btc.OnChainConfig)
 
 	params := &StreamCacheParams{
-		Storage:     pg.Storage,
-		Wallet:      bc.Wallet,
-		RiverChain:  bc,
-		Registry:    registry,
-		ChainConfig: btc.OnChainConfig,
-	}
-
-	cache, err := NewStreamCache(ctx, params, blockNumber, bc.ChainMonitor, infra.NewMetrics("", ""))
-	if err != nil {
-		panic(err)
+		Storage:         pg.Storage,
+		Wallet:          bc.Wallet,
+		RiverChain:      bc,
+		Registry:        registry,
+		ChainConfig:     btc.OnChainConfig,
+		AppliedBlockNum: blockNumber,
+		ChainMonitor:    bc.ChainMonitor,
+		Metrics:         infra.NewMetrics("", ""),
 	}
 
 	return ctx,
 		&testContext{
 			bcTest:         btc,
 			params:         params,
-			cache:          cache,
 			streamRegistry: sr,
 			closer: func() {
 				btc.Close()
@@ -123,25 +123,28 @@ func setOnChainStreamConfig(t *testing.T, ctx context.Context, btc *crypto.Block
 	}
 }
 
-func makeTestStreamCache(t *testing.T, p testParams) (context.Context, *testContext) {
-	ctx, testContext := makeTestStreamParams(t, p)
-
-	bc := testContext.bcTest.GetBlockchain(ctx, 0)
-
-	blockNumber, err := bc.GetBlockNumber(ctx)
+func (tt *testContext) initCache(ctx context.Context) *streamCacheImpl {
+	streamCache, err := NewStreamCache(ctx, tt.params)
 	if err != nil {
-		testContext.closer()
 		panic(err)
 	}
+	tt.cache = streamCache
+	return streamCache
+}
 
-	streamCache, err := NewStreamCache(ctx, testContext.params, blockNumber, bc.ChainMonitor, infra.NewMetrics("", ""))
+func (tt *testContext) createStreamNoCache(
+	ctx context.Context,
+	streamId StreamId,
+	genesisMiniblock *Miniblock,
+) error {
+	mbBytes, err := proto.Marshal(genesisMiniblock)
 	if err != nil {
-		testContext.closer()
-		panic(err)
+		return err
 	}
-	testContext.cache = streamCache
 
-	return ctx, testContext
+	_, err = tt.streamRegistry.AllocateStream(ctx, streamId, common.BytesToHash(
+		genesisMiniblock.Header.Hash), mbBytes)
+	return err
 }
 
 func (tt *testContext) createStream(
@@ -149,16 +152,13 @@ func (tt *testContext) createStream(
 	streamId StreamId,
 	genesisMiniblock *Miniblock,
 ) (SyncStream, StreamView, error) {
-	mbBytes, err := proto.Marshal(genesisMiniblock)
+	err := tt.createStreamNoCache(ctx, streamId, genesisMiniblock)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	_, err = tt.streamRegistry.AllocateStream(ctx, streamId, common.BytesToHash(
-		genesisMiniblock.Header.Hash), mbBytes)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	return tt.cache.CreateStream(ctx, streamId)
+}
+
+func (tt *testContext) getBC() *crypto.Blockchain {
+	return tt.params.RiverChain
 }

--- a/core/node/rpc/archive.go
+++ b/core/node/rpc/archive.go
@@ -51,13 +51,7 @@ func (s *Service) startArchiveMode(once bool) error {
 		return AsRiverError(err).Message("Failed to init archiver").LogError(s.defaultLogger)
 	}
 
-	go s.riverChain.ChainMonitor.RunWithBlockPeriod(
-		s.serverCtx,
-		s.riverChain.Client,
-		s.riverChain.InitialBlockNum,
-		time.Duration(s.riverChain.Config.BlockTimeMs)*time.Millisecond,
-		s.metrics,
-	)
+	s.riverChain.StartChainMonitor(s.serverCtx)
 
 	s.registerDebugHandlers(s.config.EnableDebugEndpoints)
 

--- a/core/node/rpc/info_mode.go
+++ b/core/node/rpc/info_mode.go
@@ -37,13 +37,7 @@ func (s *Service) startInfoMode() error {
 		return AsRiverError(err).Message("Failed to run http server").LogError(s.defaultLogger)
 	}
 
-	go s.riverChain.ChainMonitor.RunWithBlockPeriod(
-		s.serverCtx,
-		s.riverChain.Client,
-		s.riverChain.InitialBlockNum,
-		time.Duration(s.riverChain.Config.BlockTimeMs)*time.Millisecond,
-		s.metrics,
-	)
+	s.riverChain.StartChainMonitor(s.serverCtx)
 
 	s.registerDebugHandlers(s.config.EnableDebugEndpoints)
 

--- a/core/node/rpc/server.go
+++ b/core/node/rpc/server.go
@@ -135,13 +135,7 @@ func (s *Service) start() error {
 		return AsRiverError(err).Message("Failed to init cache and sync").LogError(s.defaultLogger)
 	}
 
-	go s.riverChain.ChainMonitor.RunWithBlockPeriod(
-		s.serverCtx,
-		s.riverChain.Client,
-		s.riverChain.InitialBlockNum,
-		time.Duration(s.riverChain.Config.BlockTimeMs)*time.Millisecond,
-		s.metrics,
-	)
+	s.riverChain.StartChainMonitor(s.serverCtx)
 
 	s.initHandlers()
 
@@ -490,15 +484,15 @@ func (s *Service) initCacheAndSync() error {
 	s.cache, err = events.NewStreamCache(
 		s.serverCtx,
 		&events.StreamCacheParams{
-			Storage:     s.storage,
-			Wallet:      s.wallet,
-			RiverChain:  s.riverChain,
-			Registry:    s.registryContract,
-			ChainConfig: s.chainConfig,
+			Storage:         s.storage,
+			Wallet:          s.wallet,
+			RiverChain:      s.riverChain,
+			Registry:        s.registryContract,
+			ChainConfig:     s.chainConfig,
+			AppliedBlockNum: s.riverChain.InitialBlockNum,
+			ChainMonitor:    s.riverChain.ChainMonitor,
+			Metrics:         s.metrics,
 		},
-		s.riverChain.InitialBlockNum,
-		s.riverChain.ChainMonitor,
-		s.metrics,
 	)
 	if err != nil {
 		return err

--- a/core/xchain/client_simulator/client_simulator.go
+++ b/core/xchain/client_simulator/client_simulator.go
@@ -255,13 +255,7 @@ func New(
 		if err != nil {
 			return nil, err
 		}
-		go baseChain.ChainMonitor.RunWithBlockPeriod(
-			ctx,
-			baseChain.Client,
-			baseChain.InitialBlockNum,
-			time.Duration(cfg.BaseChain.BlockTimeMs)*time.Millisecond,
-			metrics,
-		)
+		baseChain.StartChainMonitor(ctx)
 	}
 
 	decoder, err := node_crypto.NewEVMErrorDecoder(deploy.MockEntitlementGatedMetaData, base.IEntitlementCheckerMetaData)

--- a/core/xchain/server/server.go
+++ b/core/xchain/server/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log/slog"
 	"math/big"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/river-build/river/core/config"
@@ -145,13 +144,7 @@ func New(
 		}
 
 		log.Info("Start processing entitlement check requests", "startBlock", baseChain.InitialBlockNum)
-		go baseChain.ChainMonitor.RunWithBlockPeriod(
-			ctx,
-			baseChain.Client,
-			baseChain.InitialBlockNum,
-			time.Duration(cfg.BaseChain.BlockTimeMs)*time.Millisecond,
-			metrics,
-		)
+		baseChain.StartChainMonitor(ctx)
 	}
 
 	decoder, err := crypto.NewEVMErrorDecoder(


### PR DESCRIPTION
This should fix node registration race in some go tests and make them more stable.