### PR TITLE
handle case where a new miniblock contains a snapshot

### DIFF
--- a/packages/sdk/src/syncedStream.ts
+++ b/packages/sdk/src/syncedStream.ts
@@ -182,9 +182,14 @@ export class SyncedStream extends Stream {
             .map((e) => e.remoteEvent)
             .filter(isDefined)
 
+        const lastSnapshotMiniblockNum =
+            miniblock.header.snapshot !== undefined
+                ? miniblock.header.miniblockNum
+                : miniblock.header.prevSnapshotMiniblockNum
+
         const cachedSyncedStream = new PersistedSyncedStream({
             syncCookie: syncCookie,
-            lastSnapshotMiniblockNum: miniblock.header.prevSnapshotMiniblockNum,
+            lastSnapshotMiniblockNum: lastSnapshotMiniblockNum,
             minipoolEvents: minipoolEvents,
             lastMiniblockNum: miniblock.header.miniblockNum,
         })


### PR DESCRIPTION
When receiving a new miniblock, we should save:
- a reference to the miniblock containing the latest snapshot
- a reference to the latest miniblock

If a newly generated miniblock contains a snapshot, we incorrectly store a reference to its `prevSnapshotMiniblockNum`, which points to the 2nd-to-latest snapshot instead of the latest.