### PR TITLE
Client checks for entitlements before channel posts

### DIFF
--- a/packages/sdk/src/channelsWithEntitlements.test.ts
+++ b/packages/sdk/src/channelsWithEntitlements.test.ts
@@ -234,9 +234,8 @@ describe('channelsWithEntitlements', () => {
                 Permission.ReactReply,
             ])
 
-        console.log('alice', alice.userId, alicesWallet.address),
-            // Validate alice can join the channel
-            await expectUserCanJoinChannel(alice, aliceSpaceDapp, spaceId, channelId!)
+        // Validate alice can join the channel
+        await expectUserCanJoinChannel(alice, aliceSpaceDapp, spaceId, channelId!)
 
         const { eventId: refEventId } = await bob.sendMessage(channelId!, 'Hello, world!')
         // Reacting to Bob's message should be allowed.

--- a/packages/sdk/src/channelsWithEntitlements.test.ts
+++ b/packages/sdk/src/channelsWithEntitlements.test.ts
@@ -228,11 +228,11 @@ describe('channelsWithEntitlements', () => {
     })
 
     test('REACT-REPLY user can react, reply, cannot write', async () => {
-        const { alice, alicesWallet, bob, aliceSpaceDapp, spaceId, channelId } =
-            await setupChannelWithCustomRole(['alice'], NoopRuleData, [
-                Permission.Read,
-                Permission.ReactReply,
-            ])
+        const { alice, bob, aliceSpaceDapp, spaceId, channelId } = await setupChannelWithCustomRole(
+            ['alice'],
+            NoopRuleData,
+            [Permission.Read, Permission.ReactReply],
+        )
 
         // Validate alice can join the channel
         await expectUserCanJoinChannel(alice, aliceSpaceDapp, spaceId, channelId!)

--- a/packages/sdk/src/channelsWithEntitlements.test.ts
+++ b/packages/sdk/src/channelsWithEntitlements.test.ts
@@ -566,7 +566,7 @@ describe('channelsWithEntitlements', () => {
         await alice.stopSync()
     })
 
-    test('user booted on message post after entitlement loss', async () => {
+    test('user cannot post after entitlement loss', async () => {
         const testNftAddress = await getContractAddress('TestNFT')
         const { alice, alicesWallet, aliceSpaceDapp, bob, spaceId, channelId } =
             await setupChannelWithCustomRole([], getNftRuleData(testNftAddress), [
@@ -594,26 +594,13 @@ describe('channelsWithEntitlements', () => {
         // Wait 5 seconds for the positive auth cache to expire
         await new Promise((f) => setTimeout(f, 5000))
 
+        // Alice should not be able to post to the channel after losing entitlements.
+        // However she remains a member of the stream because this message is never sent by the
+        // client.
         await expect(
             alice.sendMessage(channelId!, 'Message after entitlement loss'),
         ).rejects.toThrow(/*not entitled to add message to channel*/)
 
-        // Alice's user stream should reflect that she is no longer a member of the channel.
-        // TODO why no linter complain with no await here?
-        const aliceUserStream = await alice.waitForStream(alice.userStreamId!)
-        await waitFor(() =>
-            expect(
-                aliceUserStream.view.userContent.isMember(channelId!, MembershipOp.SO_LEAVE),
-            ).toBeTruthy(),
-        )
-        await waitFor(() =>
-            expect(
-                channelStream.view.membershipContent.isMember(MembershipOp.SO_LEAVE, alice.userId),
-            ).toBeTruthy(),
-        )
-
-        // Alice cannot rejoin the stream.
-        await expectUserCannotJoinChannel(alice, aliceSpaceDapp, spaceId, channelId!)
 
         await bob.stopSync()
         await alice.stopSync()

--- a/packages/sdk/src/channelsWithEntitlements.test.ts
+++ b/packages/sdk/src/channelsWithEntitlements.test.ts
@@ -601,7 +601,6 @@ describe('channelsWithEntitlements', () => {
             alice.sendMessage(channelId!, 'Message after entitlement loss'),
         ).rejects.toThrow(/*not entitled to add message to channel*/)
 
-
         await bob.stopSync()
         await alice.stopSync()
     })

--- a/packages/sdk/src/channelsWithEntitlements.test.ts
+++ b/packages/sdk/src/channelsWithEntitlements.test.ts
@@ -596,7 +596,7 @@ describe('channelsWithEntitlements', () => {
 
         await expect(
             alice.sendMessage(channelId!, 'Message after entitlement loss'),
-        ).rejects.toThrow(/7:PERMISSION_DENIED/)
+        ).rejects.toThrow(/*not entitled to add message to channel*/)
 
         // Alice's user stream should reflect that she is no longer a member of the channel.
         // TODO why no linter complain with no await here?

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1202,7 +1202,7 @@ export class Client
 
         // For top level channel posts, channel message replies, and reactions, the client
         // checks for entitlements before sending the message.
-        var expectedPermissions: Permission[] = []
+        let expectedPermissions: Permission[] = []
         if (payload.payload.case === 'reaction') {
             expectedPermissions = [Permission.ReactReply, Permission.Write]
         } else if (payload.payload.case === 'post') {
@@ -1212,7 +1212,7 @@ export class Client
             }
         }
         if (expectedPermissions.length > 0) {
-            var isEntitled: boolean = false
+            let isEntitled = false
             for (const permission of expectedPermissions) {
                 isEntitled = await this.entitlementsDelegate.isEntitled(
                     stream.view.channelContent.spaceId,
@@ -1226,9 +1226,9 @@ export class Client
             }
             if (!isEntitled) {
                 throw new Error(
-                    'user is not entitled to add message to channel (expected one of ' +
-                        expectedPermissions +
-                        ')',
+                    `user is not entitled to add message to channel (expected one of [${expectedPermissions.join(
+                        ',',
+                    )}])`,
                 )
             }
         }

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1210,7 +1210,7 @@ export class Client
             // is a reply, a reaction, a self-redaction or an edit, it may have Write or ReactReply
             // permissions - any change to an existing message authored by the user is implicitly
             // permitted.
-            let expectedPermissions: Permission[] = [Permission.Write]
+            const expectedPermissions: Permission[] = [Permission.Write]
             if (payload.payload.case !== 'post' || payload.payload.value.threadId !== undefined) {
                 expectedPermissions.push(Permission.ReactReply)
             }

--- a/packages/sdk/src/streamStateView.ts
+++ b/packages/sdk/src/streamStateView.ts
@@ -136,7 +136,7 @@ export class StreamStateView implements IStreamStateView {
     get gdmChannelContent(): StreamStateView_GDMChannel {
         check(
             isDefined(this._gdmChannelContent),
-            `dmChannelContent not defined for ${this.contentKind}`,
+            `gdmChannelContent not defined for ${this.contentKind}`,
         )
         return this._gdmChannelContent
     }


### PR DESCRIPTION
The final step of react-reply "backend" support - the client self-filters invalid messages based on whether or not it has entitlements to post to the channel.