### PR TITLE
sdk: check if navigator is defined

### DIFF
--- a/packages/sdk/src/persistenceStore.ts
+++ b/packages/sdk/src/persistenceStore.ts
@@ -203,7 +203,7 @@ export class PersistenceStore extends Dexie implements IPersistenceStore {
     }
 
     private requestPersistentStorage() {
-        if (navigator.storage && navigator.storage.persist) {
+        if (typeof navigator !== 'undefined' && navigator.storage && navigator.storage.persist) {
             navigator.storage
                 .persist()
                 .then((persisted) => {
@@ -218,7 +218,7 @@ export class PersistenceStore extends Dexie implements IPersistenceStore {
     }
 
     private logPersistenceStats() {
-        if (navigator.storage && navigator.storage.estimate) {
+        if (typeof navigator !== 'undefined' && navigator.storage && navigator.storage.estimate) {
             navigator.storage
                 .estimate()
                 .then((estimate) => {


### PR DESCRIPTION
This caused an error when running the code in node where `navigator` is not defined. 
The fix adds the check to ensure that the code runs without errors in all environments.