### PR TITLE
Remove channel booting on message write

### DIFF
--- a/core/node/rules/can_add_event.go
+++ b/core/node/rules/can_add_event.go
@@ -196,8 +196,7 @@ func (params *aeParams) canAddChannelPayload(payload *StreamEvent_ChannelPayload
 		return aeBuilder().
 			check(params.creatorIsMember).
 			requireChainAuth(params.channelMessageWriteEntitlements).
-			requireChainAuth(params.channelMessageReactReplyEntitlements).
-			onChainAuthFailure(params.onEntitlementFailureForUserEvent)
+			requireChainAuth(params.channelMessageReactReplyEntitlements)
 	case *ChannelPayload_Redaction_:
 		return aeBuilder().
 			check(params.creatorIsMember).

--- a/packages/sdk/src/channelsWithEntitlements.test.ts
+++ b/packages/sdk/src/channelsWithEntitlements.test.ts
@@ -255,7 +255,6 @@ describe('channelsWithEntitlements', () => {
         ).toResolve()
 
         // Top-level post currently allowed.
-        // TODO: after client is updated to reject unpermitted self-posts, this should reject.
         await expect(
             alice.sendMessage(channelId!, 'Hello, world!'),
         ).rejects.toThrow(/*not entitled to add message to channel*/)


### PR DESCRIPTION
I'm removing the stream node feature to boot users after losing permission to write to channels for two reasons:
- the client now self-audits and does not send unpermitted messages, so we're unlikely to hit this code path anymore from good actors
- the implementation was wrong - a user should be booted if they lose read entitlements, not write entitlements. a user often loses both at the same time, but we weren't checking here to make sure they did in fact lose the read entitlements. however, since good clients don't even send writes anymore once the entitlement is lost, i think it doesn't make sense to fix this.