### PR TITLE
Put back in make-config.sh

### DIFF
--- a/packages/generated/scripts/make-config.sh
+++ b/packages/generated/scripts/make-config.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")"
+cd ..
+
+node ./scripts/make-config.js


### PR DESCRIPTION
kerem removed it here https://github.com/river-build/river/commit/7ca785024ff6cb5814d12750398138b28f471b00
i use it in harmony in different places, it’s still useful