### PR TITLE
remove nightly tag

### DIFF
--- a/scripts/publish-to-npm.sh
+++ b/scripts/publish-to-npm.sh
@@ -102,4 +102,4 @@ fi
 git pull --rebase
 
 # Publish the nightly version to npm
-npx lerna publish from-package --yes --no-private --force-publish --dist-tag nightly --tag-version-prefix "${VERSION_PREFIX}"
+npx lerna publish from-package --yes --no-private --force-publish --tag-version-prefix "${VERSION_PREFIX}"


### PR DESCRIPTION
Remove `nightly` tag from npm builds, such that consumers of sdk packages can pull in latest build below version 1.0.0 with `"^0.0.0"` in package.json.