### PR TITLE
sending ci alerts to the RIVER_CI_ALERTS slack group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -898,5 +898,5 @@ jobs:
                   SLACK_USERNAME: 'CI'
                   SLACK_ICON_EMOJI: ':boom:'
                   SLACK_COLOR: '#FF0000'
-                  SLACK_MESSAGE: 'CI Failure on ${{ github.repository }} ${{ vars.GOALIE_SLACK_GROUP_ID}}'
+                  SLACK_MESSAGE: 'CI Failure on ${{ github.repository }} ${{ vars.RIVER_CI_ALERTS_SLACK_GROUP_ID }}'
                   SLACK_LINK_NAMES: true


### PR DESCRIPTION
This PR sends notifications to the new `@river-ci-alerts` slack group, instead of `@infra-goalie`. I'm adding @bas-vk @brianathere @clemire @texuf and @sergekh2 to this new group. Feel free to remove yourself from the group if you don't wish to get notified on ci failures. 