### PR TITLE
re-enable spaces.test.ts, fix logic in space observable

### DIFF
--- a/packages/sdk/src/sync-agent/spaces/models/space.ts
+++ b/packages/sdk/src/sync-agent/spaces/models/space.ts
@@ -108,6 +108,9 @@ export class Space extends PersistedObservable<SpaceModel> {
     }
 
     getChannel(channelId: string): Channel {
+        if (!this.data.channelIds.includes(channelId)) {
+            throw new Error(`channel ${channelId} not found in space ${this.data.id}`)
+        }
         if (!this.channels[channelId]) {
             this.channels[channelId] = new Channel(
                 channelId,
@@ -154,6 +157,8 @@ export class Space extends PersistedObservable<SpaceModel> {
                     this.spaceDapp,
                     this.store,
                 )
+            }
+            if (!this.data.channelIds.includes(channelId)) {
                 this.setData({ channelIds: [...this.data.channelIds, channelId] })
             }
         }

--- a/packages/sdk/src/sync-agent/spaces/spaces.test.ts
+++ b/packages/sdk/src/sync-agent/spaces/spaces.test.ts
@@ -11,8 +11,7 @@ describe('spaces.test.ts', () => {
     logger.log('start')
     const testUser = new Bot()
 
-    // TODO: looks like this test is broken
-    test.skip('create/leave/join space', async () => {
+    test('create/leave/join space', async () => {
         await testUser.fundWallet()
         const syncAgent = await testUser.makeSyncAgent()
         await syncAgent.start()


### PR DESCRIPTION
I got overzealous and set up the space to preload the default channel, but then forgot that it could get wiped out during initialization and used the wrong check when adding new channels. I think this is better.