### PR TITLE
SpaceDapp: use getJoinSpacePrice as membershipPrice in getMembershipInfo

### DIFF
--- a/packages/web3/src/v3/SpaceDapp.ts
+++ b/packages/web3/src/v3/SpaceDapp.ts
@@ -1130,7 +1130,7 @@ export class SpaceDapp implements ISpaceDapp {
         }
         const [price, limit, currency, feeRecipient, duration, totalSupply, pricingModule] =
             await Promise.all([
-                space.Membership.read.getMembershipPrice(),
+                this.getJoinSpacePrice(spaceId),
                 space.Membership.read.getMembershipLimit(),
                 space.Membership.read.getMembershipCurrency(),
                 space.Ownable.read.owner(),


### PR DESCRIPTION
The getMembershipPrice always returns the current price of the membership, regardless of prepaid seats.
However, if a space has any prepaid seats left, a user won't be charged this price.
When grabbing this price via getMembershipInfo, I think it makes more sense to return the price considering prepaid seats. Easier to reason about at the UI level - a user sees 0, they'll pay 0.

Alternatively I can just call getJoinSpacePrice where appropriate for UI.