### PR TITLE
node/rpc/sync: set sync message buffer size to old value

### DIFF
--- a/core/node/rpc/sync/client/syncer_set.go
+++ b/core/node/rpc/sync/client/syncer_set.go
@@ -89,7 +89,7 @@ func NewSyncers(
 	var (
 		syncers         = make(map[common.Address]StreamsSyncer)
 		streamID2Syncer = make(map[StreamId]StreamsSyncer)
-		messages        = make(chan *SyncStreamsResponse, 128)
+		messages        = make(chan *SyncStreamsResponse, 256)
 	)
 
 	// instantiate background syncers for sync operation

--- a/core/node/rpc/sync/operation.go
+++ b/core/node/rpc/sync/operation.go
@@ -72,7 +72,7 @@ func NewStreamsSyncOperation(
 		cancel:          cancel,
 		SyncID:          GenNanoid(),
 		thisNodeAddress: node,
-		commands:        make(chan *subCommand),
+		commands:        make(chan *subCommand, 64),
 		streamCache:     streamCache,
 		nodeRegistry:    nodeRegistry,
 	}, nil


### PR DESCRIPTION
The old sync stream implementation used a buffer of 256 messages. This capacity was lowered to 128 and might cause issues when clients start syncing and are retrieving a lot of events.