### PR TITLE
Set lastAccessedTime when initializing streams

### DIFF
--- a/core/node/events/stream_cache.go
+++ b/core/node/events/stream_cache.go
@@ -94,6 +94,7 @@ func NewStreamCache(
 				params:   params,
 				streamId: stream.StreamId,
 				nodes:    nodes,
+				lastAccessedTime: time.Now(),
 			})
 		}
 	}


### PR DESCRIPTION
Is this necessary? It seems like the cache will get flushed imediately if not, but maybe i missed something.