### PR TITLE
Enable extra /debug endpoints by default, add settings per endpoint

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -55,6 +55,14 @@ func GetDefaultConfig() *Config {
 		Archive: ArchiveConfig{
 			PrintStatsPeriod: 10 * time.Second,
 		},
+		DebugEndpoints: DebugEndpointsConfig{
+			Cache:           true,
+			Memory:          true,
+			PProf:           false,
+			Stacks:          true,
+			StacksMaxSizeKb: 5 * 1024,
+			TxPool:          true,
+		},
 	}
 }
 
@@ -149,8 +157,11 @@ type Config struct {
 	// EnableTestAPIs enables additional APIs used for testing.
 	EnableTestAPIs bool
 
-	// Enables go profiler, gc and so on enpoints on /debug
+	// EnableDebugEndpoints is a legacy setting, enables all debug endpoints.
+	// Per endpoint configuration is in DebugEndpoints.
 	EnableDebugEndpoints bool
+
+	DebugEndpoints DebugEndpointsConfig
 }
 
 type TLSConfig struct {
@@ -328,6 +339,15 @@ type MetricsConfig struct {
 
 	// Interface to use with the port above. Usually left empty to bind to all interfaces.
 	Interface string
+}
+
+type DebugEndpointsConfig struct {
+	Cache           bool
+	Memory          bool
+	PProf           bool
+	Stacks          bool
+	StacksMaxSizeKb int
+	TxPool          bool
 }
 
 func (ac *ArchiveConfig) GetReadMiniblocksSize() uint64 {

--- a/core/node/events/stream.go
+++ b/core/node/events/stream.go
@@ -392,6 +392,7 @@ func (s *streamImpl) addEventImpl(ctx context.Context, event *ParsedEvent) error
 		return err
 	}
 
+
 	prevSyncCookie := s.view.SyncCookie(s.params.Wallet.Address)
 	s.view = newSV
 	newSyncCookie := s.view.SyncCookie(s.params.Wallet.Address)

--- a/core/node/rpc/archive.go
+++ b/core/node/rpc/archive.go
@@ -53,7 +53,7 @@ func (s *Service) startArchiveMode(once bool) error {
 
 	s.riverChain.StartChainMonitor(s.serverCtx)
 
-	s.registerDebugHandlers(s.config.EnableDebugEndpoints)
+	s.registerDebugHandlers(s.config.EnableDebugEndpoints, s.config.DebugEndpoints)
 
 	s.SetStatus("OK")
 

--- a/core/node/rpc/info_mode.go
+++ b/core/node/rpc/info_mode.go
@@ -39,7 +39,7 @@ func (s *Service) startInfoMode() error {
 
 	s.riverChain.StartChainMonitor(s.serverCtx)
 
-	s.registerDebugHandlers(s.config.EnableDebugEndpoints)
+	s.registerDebugHandlers(s.config.EnableDebugEndpoints, s.config.DebugEndpoints)
 
 	s.SetStatus("OK")
 

--- a/core/node/rpc/server.go
+++ b/core/node/rpc/server.go
@@ -582,7 +582,7 @@ func (s *Service) initHandlers() {
 	nodeServicePattern, nodeServiceHandler := protocolconnect.NewNodeToNodeHandler(s, interceptors)
 	s.mux.Handle(nodeServicePattern, newHttpHandler(nodeServiceHandler, s.defaultLogger))
 
-	s.registerDebugHandlers(s.config.EnableDebugEndpoints)
+	s.registerDebugHandlers(s.config.EnableDebugEndpoints, s.config.DebugEndpoints)
 }
 
 // StartServer starts the server with the given configuration.


### PR DESCRIPTION
pprof is disabled by default.
text-only endpoints are enabled.