### PR TITLE
support pins in all related stream types

### DIFF
--- a/packages/sdk/src/streamStateView_Members.ts
+++ b/packages/sdk/src/streamStateView_Members.ts
@@ -399,8 +399,12 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
         const newPin = { creatorUserId, event } satisfies Pin
         this.pins.push(newPin)
         if (
-            event.remoteEvent.event.payload.case === 'channelPayload' &&
-            event.remoteEvent.event.payload.value.content.case === 'message'
+            (event.remoteEvent.event.payload.case === 'channelPayload' &&
+                event.remoteEvent.event.payload.value.content.case === 'message') ||
+            (event.remoteEvent.event.payload.case === 'dmChannelPayload' &&
+                event.remoteEvent.event.payload.value.content.case === 'message') ||
+            (event.remoteEvent.event.payload.case === 'gdmChannelPayload' &&
+                event.remoteEvent.event.payload.value.content.case === 'message')
         ) {
             this.decryptEvent(
                 'channelMessage',


### PR DESCRIPTION
if i'm not mistaken, we also need to check for dm+gdm channel payloads here since we now support pins in all 3 channel types — did not yet test this, just noticed it when going through the code :) 