### PR TITLE
core/node: add optel to connectrpc handlers

### DIFF
--- a/core/node/rpc/server.go
+++ b/core/node/rpc/server.go
@@ -14,12 +14,9 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"connectrpc.com/otelconnect"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/rs/cors"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
-
 	"github.com/river-build/river/core/config"
 	"github.com/river-build/river/core/node/auth"
 	. "github.com/river-build/river/core/node/base"
@@ -34,6 +31,9 @@ import (
 	"github.com/river-build/river/core/node/rpc/sync"
 	"github.com/river-build/river/core/node/storage"
 	"github.com/river-build/river/core/xchain/entitlement"
+	"github.com/rs/cors"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 )
 
 const (
@@ -571,6 +571,9 @@ func (s *Service) initHandlers() {
 	ii := []connect.Interceptor{}
 	if s.otelConnectIterceptor != nil {
 		ii = append(ii, s.otelConnectIterceptor)
+		if i, err := otelconnect.NewInterceptor(); err == nil {
+			ii = append(ii, i)
+		}
 	}
 	ii = append(ii, s.NewMetricsInterceptor())
 	ii = append(ii, NewTimeoutInterceptor(s.config.Network.RequestTimeout))


### PR DESCRIPTION
Enable https://connectrpc.com/docs/go/observability/#enabling-opentelemetry-for-connect

This gives more open-telemetry details information about requests/streams.