### PR TITLE
Revert "core/node/rpc: Use x/http2.Server instead of http.Server"

### DIFF
--- a/core/node/rpc/server.go
+++ b/core/node/rpc/server.go
@@ -16,6 +16,10 @@ import (
 	"connectrpc.com/connect"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/cors"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+
 	"github.com/river-build/river/core/config"
 	"github.com/river-build/river/core/node/auth"
 	. "github.com/river-build/river/core/node/base"
@@ -30,9 +34,6 @@ import (
 	"github.com/river-build/river/core/node/rpc/sync"
 	"github.com/river-build/river/core/node/storage"
 	"github.com/river-build/river/core/xchain/entitlement"
-	"github.com/rs/cors"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 )
 
 const (
@@ -443,13 +444,6 @@ func (s *Service) runHttpServer() error {
 			if err != nil {
 				return err
 			}
-		}
-
-		// ensure that x/http2 is used
-		// https://github.com/golang/go/issues/42534
-		err = http2.ConfigureServer(s.httpServer, nil)
-		if err != nil {
-			return err
 		}
 
 		go s.serveTLS()


### PR DESCRIPTION
Reverts river-build/river#630