### PR TITLE
generated: fix preinstall script

### DIFF
--- a/packages/generated/package.json
+++ b/packages/generated/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.32",
     "packageManager": "yarn@3.8.0",
     "scripts": {
-        "preinstall": "yarn make-config",
+        "preinstall": "node ./scripts/make-config.js",
         "make-config": "node ./scripts/make-config.js"
     }
 }


### PR DESCRIPTION
When adding `@river-build/sdk` with other packages managers such as `pnpm`, I was getting an error since the preinstall command uses `yarn`.

This commit inlines the preinstallation command to avoid the usage of a package manager script indirection call.

Previously:
```
node_modules/.pnpm/@river-build+generated@0.0.32/node_modules/@river-build/generated: Running preinstall script, failed in 289ms
.../node_modules/@river-build/generated preinstall$ yarn make-config
│ Usage Error: The nearest package directory (/Users/miguel/dev/hnt/www/node_modules/.pnpm/@river-build+generated@0.0.32/node_modules/@river-build/generated) doesn't seem to be…
│ - If /Users/miguel/dev/hnt/www isn't intended to be a project, remove any yarn.lock and/or package.json file there.
│ - If /Users/miguel/dev/hnt/www is intended to be a project, it might be that you forgot to list node_modules/.pnpm/@river-build+generated@0.0.32/node_modules/@river-build/gen…
│ - Finally, if /Users/miguel/dev/hnt/www is fine and you intend node_modules/.pnpm/@river-build+generated@0.0.32/node_modules/@river-build/generated to be treated as a complet…
│ $ yarn run [--inspect] [--inspect-brk] [-T,--top-level] [-B,--binaries-only] [--require #0] <scriptName> ...
└─ Failed in 289ms at /Users/miguel/dev/hnt/www/node_modules/.pnpm/@river-build+generated@0.0.32/node_modules/@river-build/generated
```

With this PR changes:
```
Progress: resolved 2182, reused 2111, downloaded 0, added 0, done
node_modules/.pnpm/@river-build+generated@0.0.32/node_modules/@river-build/generated: Running preinstall script, done in 77ms
node_modules/.pnpm/sharp@0.29.3/node_modules/sharp: Running install script, done in 2.1s
node_modules/.pnpm/@swc+core@1.5.24/node_modules/@swc/core: Running postinstall script, done in 460ms
node_modules/.pnpm/esbuild@0.18.20/node_modules/esbuild: Running postinstall script, done in 316ms
node_modules/.pnpm/sharp@0.32.6/node_modules/sharp: Running install script, done in 1.6s
```