### PR TITLE
stress: follow filename convention for exported encryption device

### DIFF
--- a/packages/stress/src/utils/stressClient.ts
+++ b/packages/stress/src/utils/stressClient.ts
@@ -97,7 +97,10 @@ export class StressClient {
     }
 
     get deviceFilePath(): string {
-        return path.resolve(`/tmp/device_${this.clientIndex}.json`)
+        const envSuffix =
+            this.config.environmentId === 'gamma' ? '' : `-${this.config.environmentId}`
+        const filename = `stress-${this.userId}${envSuffix}`
+        return path.resolve(`/tmp/${filename}.json`)
     }
 
     async fundWallet() {


### PR DESCRIPTION
Example of filename: `stress-0x95D7701A0Faa5F514B4c5B49bf66580fCE9ffbf7-local_single.json`

Closes #658