### PR TITLE
Log sync start/exit, add syncId to callstacks

### DIFF
--- a/core/node/rpc/service_sync_streams.go
+++ b/core/node/rpc/service_sync_streams.go
@@ -2,6 +2,9 @@ package rpc
 
 import (
 	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"time"
 
 	"connectrpc.com/connect"
 
@@ -10,15 +13,37 @@ import (
 	"github.com/river-build/river/core/node/utils"
 )
 
+func magicFromString(s string) (uint64, string) {
+	bb := []byte(s)
+	if len(bb) < 8 {
+		padded := make([]byte, 8)
+		copy(padded, bb)
+		bb = padded
+	}
+	return binary.BigEndian.Uint64(bb), hex.EncodeToString(bb)
+}
+
 func (s *Service) SyncStreams(
 	ctx context.Context,
 	req *connect.Request[SyncStreamsRequest],
 	res *connect.ServerStream[SyncStreamsResponse],
 ) error {
 	ctx, log := utils.CtxAndLogForRequest(ctx, req)
-	syncId, err := s.syncHandler.SyncStreams(ctx, req, res)
+	startTime := time.Now()
+	syncId := GenNanoid()
+	magic, hex := magicFromString(syncId)
+	log.Info("SyncStreams START", "syncId", syncId, "magic", hex)
+
+	err := s.syncHandler.SyncStreams(magic, ctx, syncId, req, res)
 	if err != nil {
-		err = AsRiverError(err).Func("SyncStreams").Tag("syncId", syncId).LogWarn(log).AsConnectError()
+		err = AsRiverError(
+			err,
+		).Func("SyncStreams").
+			Tags("syncId", syncId, "duration", time.Since(startTime), "magic", hex).
+			LogWarn(log).
+			AsConnectError()
+	} else {
+		log.Info("SyncStreams DONE", "syncId", syncId, "duration", time.Since(startTime), "magic", hex)
 	}
 	return err
 }
@@ -28,12 +53,13 @@ func (s *Service) AddStreamToSync(
 	req *connect.Request[AddStreamToSyncRequest],
 ) (*connect.Response[AddStreamToSyncResponse], error) {
 	ctx, log := utils.CtxAndLogForRequest(ctx, req)
-	res, err := s.syncHandler.AddStreamToSync(ctx, req)
+	magic, hex := magicFromString(req.Msg.GetSyncId())
+	res, err := s.syncHandler.AddStreamToSync(magic, ctx, req)
 	if err != nil {
 		err = AsRiverError(
 			err,
 		).Func("AddStreamToSync").
-			Tags("syncId", req.Msg.GetSyncId(), "streamId", req.Msg.GetSyncPos().GetStreamId()).
+			Tags("syncId", req.Msg.GetSyncId(), "streamId", req.Msg.GetSyncPos().GetStreamId(), "magic", hex).
 			LogWarn(log).
 			AsConnectError()
 	}
@@ -45,12 +71,13 @@ func (s *Service) RemoveStreamFromSync(
 	req *connect.Request[RemoveStreamFromSyncRequest],
 ) (*connect.Response[RemoveStreamFromSyncResponse], error) {
 	ctx, log := utils.CtxAndLogForRequest(ctx, req)
-	res, err := s.syncHandler.RemoveStreamFromSync(ctx, req)
+	magic, hex := magicFromString(req.Msg.GetSyncId())
+	res, err := s.syncHandler.RemoveStreamFromSync(magic, ctx, req)
 	if err != nil {
 		err = AsRiverError(
 			err,
 		).Func("RemoveStreamFromSync").
-			Tags("syncId", req.Msg.GetSyncId(), "streamId", req.Msg.GetStreamId()).
+			Tags("syncId", req.Msg.GetSyncId(), "streamId", req.Msg.GetStreamId(), "magic", hex).
 			LogWarn(log).
 			AsConnectError()
 	}
@@ -62,12 +89,13 @@ func (s *Service) CancelSync(
 	req *connect.Request[CancelSyncRequest],
 ) (*connect.Response[CancelSyncResponse], error) {
 	ctx, log := utils.CtxAndLogForRequest(ctx, req)
-	res, err := s.syncHandler.CancelSync(ctx, req)
+	magic, hex := magicFromString(req.Msg.GetSyncId())
+	res, err := s.syncHandler.CancelSync(magic, ctx, req)
 	if err != nil {
 		err = AsRiverError(
 			err,
 		).Func("CancelSync").
-			Tag("syncId", req.Msg.GetSyncId()).
+			Tags("syncId", req.Msg.GetSyncId(), "magic", hex).
 			LogWarn(log).
 			AsConnectError()
 	}
@@ -79,12 +107,13 @@ func (s *Service) PingSync(
 	req *connect.Request[PingSyncRequest],
 ) (*connect.Response[PingSyncResponse], error) {
 	ctx, log := utils.CtxAndLogForRequest(ctx, req)
-	res, err := s.syncHandler.PingSync(ctx, req)
+	magic, hex := magicFromString(req.Msg.GetSyncId())
+	res, err := s.syncHandler.PingSync(magic, ctx, req)
 	if err != nil {
 		err = AsRiverError(
 			err,
 		).Func("PingSync").
-			Tag("syncId", req.Msg.GetSyncId()).
+			Tags("syncId", req.Msg.GetSyncId(), "magic", hex).
 			LogWarn(log).
 			AsConnectError()
 	}

--- a/core/node/rpc/sync/handler.go
+++ b/core/node/rpc/sync/handler.go
@@ -20,27 +20,33 @@ type (
 		// SyncStreams runs a stream sync operation that subscribes to streams on the local node and remote nodes.
 		// It returns syncId, if any and an error.
 		SyncStreams(
+			_ uint64,
 			ctx context.Context,
+			syncId string,
 			req *connect.Request[SyncStreamsRequest],
 			res *connect.ServerStream[SyncStreamsResponse],
-		) (string, error)
+		) error
 
 		AddStreamToSync(
+			_ uint64,
 			ctx context.Context,
 			req *connect.Request[AddStreamToSyncRequest],
 		) (*connect.Response[AddStreamToSyncResponse], error)
 
 		RemoveStreamFromSync(
+			_ uint64,
 			ctx context.Context,
 			req *connect.Request[RemoveStreamFromSyncRequest],
 		) (*connect.Response[RemoveStreamFromSyncResponse], error)
 
 		CancelSync(
+			_ uint64,
 			ctx context.Context,
 			req *connect.Request[CancelSyncRequest],
 		) (*connect.Response[CancelSyncResponse], error)
 
 		PingSync(
+			_ uint64,
 			ctx context.Context,
 			req *connect.Request[PingSyncRequest],
 		) (*connect.Response[PingSyncResponse], error)
@@ -89,13 +95,15 @@ func NewHandler(
 }
 
 func (h *handlerImpl) SyncStreams(
+	_ uint64,
 	ctx context.Context,
+	syncId string,
 	req *connect.Request[SyncStreamsRequest],
 	res *connect.ServerStream[SyncStreamsResponse],
-) (string, error) {
-	op, err := NewStreamsSyncOperation(ctx, h.nodeAddr, h.streamCache, h.nodeRegistry)
+) error {
+	op, err := NewStreamsSyncOperation(ctx, syncId, h.nodeAddr, h.streamCache, h.nodeRegistry)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	h.activeSyncOperations.Store(op.SyncID, op)
@@ -103,8 +111,7 @@ func (h *handlerImpl) SyncStreams(
 
 	doneChan := make(chan error, 1)
 	go h.runSyncStreams(req, res, op, doneChan)
-	err = <-doneChan
-	return op.SyncID, err
+	return <-doneChan
 }
 
 func (h *handlerImpl) runSyncStreams(
@@ -127,6 +134,7 @@ func (h *handlerImpl) runSyncStreams(
 }
 
 func (h *handlerImpl) AddStreamToSync(
+	_ uint64,
 	ctx context.Context,
 	req *connect.Request[AddStreamToSyncRequest],
 ) (*connect.Response[AddStreamToSyncResponse], error) {
@@ -137,6 +145,7 @@ func (h *handlerImpl) AddStreamToSync(
 }
 
 func (h *handlerImpl) RemoveStreamFromSync(
+	_ uint64,
 	ctx context.Context,
 	req *connect.Request[RemoveStreamFromSyncRequest],
 ) (*connect.Response[RemoveStreamFromSyncResponse], error) {
@@ -147,6 +156,7 @@ func (h *handlerImpl) RemoveStreamFromSync(
 }
 
 func (h *handlerImpl) CancelSync(
+	_ uint64,
 	ctx context.Context,
 	req *connect.Request[CancelSyncRequest],
 ) (*connect.Response[CancelSyncResponse], error) {
@@ -158,6 +168,7 @@ func (h *handlerImpl) CancelSync(
 }
 
 func (h *handlerImpl) PingSync(
+	_ uint64,
 	ctx context.Context,
 	req *connect.Request[PingSyncRequest],
 ) (*connect.Response[PingSyncResponse], error) {

--- a/core/node/rpc/sync/operation.go
+++ b/core/node/rpc/sync/operation.go
@@ -2,11 +2,13 @@ package sync
 
 import (
 	"context"
-	"github.com/river-build/river/core/node/dlog"
 	"time"
+
+	"github.com/river-build/river/core/node/dlog"
 
 	"connectrpc.com/connect"
 	"github.com/ethereum/go-ethereum/common"
+
 	. "github.com/river-build/river/core/node/base"
 	"github.com/river-build/river/core/node/events"
 	"github.com/river-build/river/core/node/nodes"
@@ -60,6 +62,7 @@ func (cmd *subCommand) Reply(err error) {
 // Use the Run method to start syncing.
 func NewStreamsSyncOperation(
 	ctx context.Context,
+	syncId string,
 	node common.Address,
 	streamCache events.StreamCache,
 	nodeRegistry nodes.NodeRegistry,
@@ -70,7 +73,7 @@ func NewStreamsSyncOperation(
 	return &StreamSyncOperation{
 		ctx:             ctx,
 		cancel:          cancel,
-		SyncID:          GenNanoid(),
+		SyncID:          syncId,
 		thisNodeAddress: node,
 		commands:        make(chan *subCommand, 64),
 		streamCache:     streamCache,
@@ -95,7 +98,6 @@ func (syncOp *StreamSyncOperation) Run(
 	syncers, messages, err := client.NewSyncers(
 		syncOp.ctx, syncOp.cancel, syncOp.SyncID, syncOp.streamCache,
 		syncOp.nodeRegistry, syncOp.thisNodeAddress, cookies)
-
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
While service doesn't lock up anymore (#640), notification service still fails to receive all expected data.