### PR TITLE
Add /debug/stacks2 which supports stack labels from pprof

### DIFF
--- a/core/node/rpc/debug.go
+++ b/core/node/rpc/debug.go
@@ -144,7 +144,7 @@ func stacks2Handler(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "Unknown profile")
 		return
 	}
-	p.WriteTo(w, 1)
+	_ = p.WriteTo(w, 1)
 }
 
 type onChainConfigHandler struct {

--- a/core/node/rpc/debug.go
+++ b/core/node/rpc/debug.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"runtime"
+	runtimePProf "runtime/pprof"
 	"slices"
 	"strings"
 	"time"
@@ -84,6 +85,7 @@ func (s *Service) registerDebugHandlers(enableDebugEndpoints bool, cfg config.De
 
 	if cfg.Stacks || enableDebugEndpoints {
 		handler.Handle(mux, "/debug/stacks", &stacksHandler{maxSizeKb: cfg.StacksMaxSizeKb})
+		handler.HandleFunc(mux, "/debug/stacks2", stacks2Handler)
 	}
 
 	if cfg.TxPool || enableDebugEndpoints {
@@ -131,6 +133,18 @@ func (h *stacksHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(output.Bytes())
+}
+
+func stacks2Handler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	p := runtimePProf.Lookup("goroutine")
+	if p == nil {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintln(w, "Unknown profile")
+		return
+	}
+	p.WriteTo(w, 1)
 }
 
 type onChainConfigHandler struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new endpoint `/debug/stacks2` that provides profiling information about goroutines, enhancing debugging capabilities for developers.
  
- **Improvements**
	- Updated existing debug handler registration to include the new endpoint based on configuration settings for debug endpoints and stack traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->