### PR TITLE
Remove derived encryption as an option in the chunked media message

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -28,9 +28,7 @@ import {
     MemberPayload_Nft,
     CreateStreamRequest,
     AddEventResponse_Error,
-    MediaInfo,
     ChunkedMedia,
-    EmbeddedMedia,
 } from '@river-build/proto'
 import {
     bin_fromHexString,
@@ -901,33 +899,26 @@ export class Client
         return ChunkedMedia.fromBinary(plaintext)
     }
 
-    async setSpaceImage(
-        spaceStreamId: string,
-        mediaStreamId: string,
-        info: MediaInfo,
-        thumbnail?: EmbeddedMedia,
-    ) {
-        this.logCall('setSpaceImage', spaceStreamId, mediaStreamId, info)
+    async setSpaceImage(spaceStreamId: string, chunkedMediaInfo: PlainMessage<ChunkedMedia>) {
+        this.logCall(
+            'setSpaceImage',
+            spaceStreamId,
+            chunkedMediaInfo.streamId,
+            chunkedMediaInfo.info,
+        )
 
         // create the chunked media to be added
         const spaceAddress = contractAddressFromSpaceId(spaceStreamId)
         const context = spaceAddress.toLowerCase()
-        const chunkedMedia = new ChunkedMedia({
-            info,
-            streamId: mediaStreamId,
-            thumbnail,
-            encryption: {
-                case: 'derived',
-                value: {
-                    context,
-                },
-            },
-        })
 
         // encrypt the chunked media
         // use the lowercased spaceId as the key phrase
         const { key, iv } = await deriveKeyAndIV(context)
-        const { ciphertext } = await encryptAESGCM(chunkedMedia.toBinary(), key, iv)
+        const { ciphertext } = await encryptAESGCM(
+            new ChunkedMedia(chunkedMediaInfo).toBinary(),
+            key,
+            iv,
+        )
         const encryptedData = new EncryptedData({
             ciphertext: uint8ArrayToBase64(ciphertext),
             algorithm: AES_GCM_DERIVED_ALGORITHM,

--- a/protocol/payloads.proto
+++ b/protocol/payloads.proto
@@ -178,15 +178,10 @@ message ChunkedMedia {
         bytes secretKey = 2;
     }
 
-    message DerivedAESGCM {
-        string context = 1;
-    }
-
     MediaInfo info = 1;
     string streamId = 2;
     EmbeddedMedia thumbnail = 3;
     oneof encryption {
         AESGCM aesgcm = 101;
-        DerivedAESGCM derived = 102;
     }
 }

--- a/services/fetch-image/src/handleImageRequest.ts
+++ b/services/fetch-image/src/handleImageRequest.ts
@@ -1,4 +1,4 @@
-import { Address, StreamIdHex } from './types'
+import { StreamIdHex } from './types'
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { StreamPrefix, StreamStateView, makeStreamId } from '@river-build/sdk'
 import { getMediaStreamContent, getStream } from './riverStreamRpcClient'
@@ -56,9 +56,7 @@ export async function handleImageRequest(request: FastifyRequest, reply: Fastify
 	}
 }
 
-async function getSpaceImage(
-	streamView: StreamStateView,
-): Promise<ChunkedMedia | undefined> {
+async function getSpaceImage(streamView: StreamStateView): Promise<ChunkedMedia | undefined> {
 	if (streamView.contentKind !== 'spaceContent') {
 		return undefined
 	}

--- a/services/fetch-image/src/handleImageRequest.ts
+++ b/services/fetch-image/src/handleImageRequest.ts
@@ -3,8 +3,7 @@ import { FastifyReply, FastifyRequest } from 'fastify'
 import { StreamPrefix, StreamStateView, makeStreamId } from '@river-build/sdk'
 import { getMediaStreamContent, getStream } from './riverStreamRpcClient'
 import { isBytes32String, isValidEthereumAddress } from './validators'
-
-import { deriveKeyAndIV } from '@river-build/sdk'
+import { ChunkedMedia } from '@river-build/proto'
 
 export async function handleImageRequest(request: FastifyRequest, reply: FastifyReply) {
 	const { spaceAddress } = request.params as { spaceAddress?: string }
@@ -35,21 +34,18 @@ export async function handleImageRequest(request: FastifyRequest, reply: Fastify
 	}
 
 	// get the image metatdata from the stream
-	const mediaStreamId = await getSpaceImageStreamId(stream)
+	const mediaStreamInfo = await getSpaceImage(stream)
 
-	if (!mediaStreamId) {
+	if (!mediaStreamInfo) {
 		return reply.code(404).send('Image not found')
 	}
 
-	const fullStreamId: StreamIdHex = `0x${mediaStreamId}`
+	const fullStreamId: StreamIdHex = `0x${mediaStreamInfo.streamId}`
 	if (!isBytes32String(fullStreamId)) {
 		return reply.code(400).send('Invalid stream ID')
 	}
 
-	// derive the key and IV from the space address to decrypt the image
-	// the spaceAddress must be all lowercase
-	const context = spaceAddress.toLowerCase()
-	const { key, iv } = await deriveKeyAndIV(context)
+	const { key, iv } = getEncryption(mediaStreamInfo)
 
 	const { data, mimeType } = await getMediaStreamContent(fullStreamId, key, iv)
 
@@ -60,12 +56,24 @@ export async function handleImageRequest(request: FastifyRequest, reply: Fastify
 	}
 }
 
-async function getSpaceImageStreamId(streamView: StreamStateView) {
+async function getSpaceImage(
+	streamView: StreamStateView,
+): Promise<ChunkedMedia | undefined> {
 	if (streamView.contentKind !== 'spaceContent') {
 		return undefined
 	}
 
 	const spaceImage = await streamView.spaceContent.getSpaceImage()
-	const streamId = spaceImage?.streamId
-	return streamId
+	return spaceImage
+}
+
+function getEncryption(chunkedMedia: ChunkedMedia): { key: Uint8Array; iv: Uint8Array } {
+	switch (chunkedMedia.encryption.case) {
+		case 'aesgcm':
+			const key = new Uint8Array(chunkedMedia.encryption.value.secretKey)
+			const iv = new Uint8Array(chunkedMedia.encryption.value.iv)
+			return { key, iv }
+		default:
+			throw new Error(`Unsupported encryption: ${chunkedMedia.encryption}`)
+	}
 }


### PR DESCRIPTION
We don’t need this value to be derived. The chunked media payload itself is encrypted with a derived key, we don’t need to make any changes around uploading media in our client.
(Event if it is derived, we derive secret and iv so we should just use those values in this payload)