### PR TITLE
test(contract): enhance `RuleEntitlement` tests 

### DIFF
--- a/contracts/test/crosschain/RuleEntitlement.t.sol
+++ b/contracts/test/crosschain/RuleEntitlement.t.sol
@@ -142,7 +142,8 @@ contract RuleEntitlementTest is
   // =============================================================
   //                  Request Entitlement Check
   // =============================================================
-  function test_revertOnDirectionFailureEntitlementRule() external {
+
+  function test_revertOnDirectionFailureEntitlementRule() external virtual {
     Operation[] memory operations = new Operation[](4);
     CheckOperation[] memory checkOperations = new CheckOperation[](2);
     LogicalOperation[] memory logicalOperations = new LogicalOperation[](2);
@@ -182,7 +183,7 @@ contract RuleEntitlementTest is
     ruleEntitlement.setEntitlement(0, encodedData);
 
     Operation[] memory ruleOperations = ruleEntitlement
-      .getRuleData(uint256(0))
+      .getRuleData(0)
       .operations;
     assertEq(ruleOperations.length, 0);
   }

--- a/contracts/test/crosschain/RuleEntitlement.t.sol
+++ b/contracts/test/crosschain/RuleEntitlement.t.sol
@@ -37,7 +37,7 @@ contract RuleEntitlementTest is
     ruleEntitlement = RuleEntitlement(entitlement);
   }
 
-  modifier givenRuleEntitlementIsSet() {
+  function setRuleEntitlement() internal returns (bytes memory encodedData) {
     uint256 chainId = block.chainid;
     address erc20Contract = _randomAddress();
     address erc721Contract = _randomAddress();
@@ -87,25 +87,20 @@ contract RuleEntitlementTest is
       logicalOperations
     );
 
-    bytes memory encodedData = abi.encode(ruleData);
+    encodedData = abi.encode(ruleData);
 
     vm.prank(space);
     ruleEntitlement.setEntitlement(roleId, encodedData);
-    _;
   }
 
-  function test_setRuleEntitlement() public virtual givenRuleEntitlementIsSet {
-    Operation[] memory ruleOperations = ruleEntitlement
-      .getRuleData(roleId)
-      .operations;
-    assertEq(ruleOperations.length, 3);
+  function test_setRuleEntitlement() public virtual {
+    bytes memory encodedData = setRuleEntitlement();
+    assertEq(ruleEntitlement.getEntitlementDataByRoleId(roleId), encodedData);
   }
 
-  function test_removeRuleEntitlement()
-    external
-    virtual
-    givenRuleEntitlementIsSet
-  {
+  function test_removeRuleEntitlement() external virtual {
+    setRuleEntitlement();
+
     vm.prank(space);
     ruleEntitlement.removeEntitlement(roleId);
 

--- a/contracts/test/crosschain/RuleEntitlement.t.sol
+++ b/contracts/test/crosschain/RuleEntitlement.t.sol
@@ -14,20 +14,16 @@ contract RuleEntitlementTest is
   IEntitlementBase,
   IRuleEntitlementBase
 {
-  RuleEntitlement internal implementation;
   RuleEntitlement internal ruleEntitlement;
 
   address internal entitlement;
-  address internal deployer;
-  address internal space;
+  address internal deployer = makeAddr("deployer");
+  address internal space = makeAddr("space");
   uint256 internal roleId = 0;
 
-  function setUp() public {
-    deployer = _randomAddress();
-    space = _randomAddress();
-
+  function setUp() public virtual {
     vm.startPrank(deployer);
-    implementation = new RuleEntitlement();
+    RuleEntitlement implementation = new RuleEntitlement();
     entitlement = address(
       new ERC1967Proxy(
         address(implementation),

--- a/contracts/test/crosschain/RuleEntitlementV2.t.sol
+++ b/contracts/test/crosschain/RuleEntitlementV2.t.sol
@@ -18,7 +18,9 @@ contract RuleEntitlementV2Test is RuleEntitlementTest {
     ruleEntitlementV2 = RuleEntitlementV2(entitlement);
   }
 
-  function test_upgradeToRuleV2() public givenRuleEntitlementIsSet {
+  function test_upgradeToRuleV2() public {
+    setRuleEntitlement();
+
     // Validate Rule V1 exists
     RuleData memory ruleData = ruleEntitlement.getRuleData(roleId);
     assertTrue(ruleData.operations.length > 0);
@@ -55,12 +57,12 @@ contract RuleEntitlementV2Test is RuleEntitlementTest {
     assertTrue(ruleDataV2.operations.length == 0);
 
     // Set Rule V2
+    bytes memory encodedData = _createRuleDataV2();
     vm.prank(space);
-    ruleEntitlementV2.setEntitlement(roleId, abi.encode(_createRuleDataV2()));
+    ruleEntitlementV2.setEntitlement(roleId, encodedData);
 
     // Validate Rule V2 exists and Rule V1 does not
-    ruleDataV2 = ruleEntitlementV2.getRuleDataV2(roleId);
-    assertTrue(ruleDataV2.operations.length > 0);
+    assertEq(ruleEntitlementV2.getEntitlementDataByRoleId(roleId), encodedData);
 
     RuleData memory ruleData = ruleEntitlementV2.getRuleData(roleId);
     assertTrue(ruleData.operations.length == 0);
@@ -161,7 +163,7 @@ contract RuleEntitlementV2Test is RuleEntitlementTest {
   function _createRuleDataV2()
     internal
     view
-    returns (RuleDataV2 memory ruleData)
+    returns (bytes memory encodedData)
   {
     uint256 chainId = block.chainid;
     address erc20Contract = _randomAddress();
@@ -206,6 +208,12 @@ contract RuleEntitlementV2Test is RuleEntitlementTest {
     operations[2] = Operation(CombinedOperationType.LOGICAL, 0);
 
     // we are combining all the operations into a rule data struct
-    ruleData = RuleDataV2(operations, checkOperations, logicalOperations);
+    RuleDataV2 memory ruleData = RuleDataV2(
+      operations,
+      checkOperations,
+      logicalOperations
+    );
+
+    encodedData = abi.encode(ruleData);
   }
 }

--- a/contracts/test/crosschain/RuleEntitlementV2.t.sol
+++ b/contracts/test/crosschain/RuleEntitlementV2.t.sol
@@ -1,105 +1,23 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-// utils
-import {TestUtils} from "contracts/test/utils/TestUtils.sol";
-
-import {RuleEntitlement} from "contracts/src/spaces/entitlements/rule/RuleEntitlement.sol";
 import {RuleEntitlementV2} from "contracts/src/spaces/entitlements/rule/RuleEntitlementV2.sol";
 
-import {IEntitlementBase} from "contracts/src/spaces/entitlements/IEntitlement.sol";
-import {IRuleEntitlement, IRuleEntitlementV2, IRuleEntitlementBase} from "contracts/src/spaces/entitlements/rule/IRuleEntitlement.sol";
+import {IRuleEntitlement, IRuleEntitlementV2} from "contracts/src/spaces/entitlements/rule/IRuleEntitlement.sol";
 
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {RuleEntitlementTest} from "./RuleEntitlement.t.sol";
 
 // TODO: add tests for RuleEntitlementV2
-contract RuleEntitlementV2Test is
-  TestUtils,
-  IEntitlementBase,
-  IRuleEntitlementBase
-{
-  RuleEntitlement internal ruleEntitlement;
+contract RuleEntitlementV2Test is RuleEntitlementTest {
   RuleEntitlementV2 internal ruleEntitlementV2;
 
-  address internal entitlement;
-  address internal deployer = makeAddr("deployer");
-  address internal space = makeAddr("space");
-  uint256 internal roleId = 0;
-
-  function setUp() public {
-    vm.startPrank(deployer);
-    RuleEntitlement implementation = new RuleEntitlement();
-    entitlement = address(
-      new ERC1967Proxy(
-        address(implementation),
-        abi.encodeCall(RuleEntitlement.initialize, (space))
-      )
-    );
-    vm.stopPrank();
-
-    ruleEntitlement = RuleEntitlement(entitlement);
+  function setUp() public override {
+    super.setUp();
     ruleEntitlementV2 = RuleEntitlementV2(entitlement);
   }
 
-  modifier givenRuleV1EntitlementIsSet() {
-    uint256 chainId = block.chainid;
-    address erc20Contract = _randomAddress();
-    address erc721Contract = _randomAddress();
-    uint256 threshold = 100;
-
-    // we have 3 operations total
-    Operation[] memory operations = new Operation[](3);
-
-    // we have 2 check operations
-    CheckOperation[] memory checkOperations = new CheckOperation[](2);
-
-    // and 1 logical operation
-    LogicalOperation[] memory logicalOperations = new LogicalOperation[](1);
-
-    // for the first check operation, we are checking ERC20 balance of 100 on chain 31337
-    checkOperations[0] = CheckOperation(
-      CheckOperationType.ERC20,
-      chainId,
-      erc20Contract,
-      threshold
-    );
-
-    // for the second check operation, we are checking ERC721 balance of 100 on chain 31337
-    checkOperations[1] = CheckOperation(
-      CheckOperationType.ERC721,
-      chainId,
-      erc721Contract,
-      threshold
-    );
-
-    // we are combining the two check operations with an AND operation so both must pass
-    logicalOperations[0] = LogicalOperation(LogicalOperationType.AND, 0, 1);
-
-    // the first operation is a check operation
-    operations[0] = Operation(CombinedOperationType.CHECK, 0);
-
-    // the second operation is a check operation
-    operations[1] = Operation(CombinedOperationType.CHECK, 1);
-
-    // the third operation is a logical operation
-    operations[2] = Operation(CombinedOperationType.LOGICAL, 0);
-
-    // we are combining all the operations into a rule data struct
-    RuleData memory ruleData = RuleData(
-      operations,
-      checkOperations,
-      logicalOperations
-    );
-
-    bytes memory encodedData = abi.encode(ruleData);
-
-    vm.prank(space);
-    ruleEntitlement.setEntitlement(roleId, encodedData);
-    _;
-  }
-
-  function test_upgradeToRuleV2() external givenRuleV1EntitlementIsSet {
+  function test_upgradeToRuleV2() external givenRuleEntitlementIsSet {
     // Validate Rule V1 exists
     RuleData memory ruleData = ruleEntitlement.getRuleData(roleId);
     assertTrue(ruleData.operations.length > 0);

--- a/contracts/test/crosschain/RuleEntitlementV2.t.sol
+++ b/contracts/test/crosschain/RuleEntitlementV2.t.sol
@@ -64,6 +64,13 @@ contract RuleEntitlementV2Test is RuleEntitlementTest {
 
     RuleData memory ruleData = ruleEntitlementV2.getRuleData(roleId);
     assertTrue(ruleData.operations.length == 0);
+
+    bytes32 slot = getMappingValueSlot(roleId, ENTITLEMENTS_SLOT);
+    bytes32 grantedBy = vm.load(entitlement, slot);
+    assertEq(grantedBy, bytes32(0));
+    bytes32 grantedTime = vm.load(entitlement, bytes32(uint256(slot) + 1));
+    assertEq(grantedTime, bytes32(0));
+    assertEq(vm.getMappingLength(entitlement, bytes32(ENTITLEMENTS_SLOT)), 0);
   }
 
   function test_removeRuleEntitlement() external override {

--- a/contracts/test/utils/TestUtils.sol
+++ b/contracts/test/utils/TestUtils.sol
@@ -48,6 +48,13 @@ contract TestUtils is Test {
     // solhint-enable
   }
 
+  function getMappingValueSlot(
+    uint256 mappingSlot,
+    uint256 key
+  ) internal pure returns (bytes32) {
+    return keccak256(abi.encode(key, mappingSlot));
+  }
+
   function _bytes32ToString(bytes32 str) internal pure returns (string memory) {
     return string(abi.encodePacked(str));
   }


### PR DESCRIPTION
Refactor entitlement deployment and upgrade tests.

Refactor `RuleEntitlement` tests for efficiency and clarity.

Enhance `removeEntitlement` tests.

Remove unused import and add entitlement rule test.

Add assertions for removal of V1 rule data.

Refactor rule entitlement setup and validation.