### PR TITLE
perf(contract): Use `unchecked` where appropriate and cache storage pointer

### DIFF
--- a/contracts/src/spaces/facets/gated/EntitlementGatedBase.sol
+++ b/contracts/src/spaces/facets/gated/EntitlementGatedBase.sol
@@ -71,8 +71,9 @@ abstract contract EntitlementGatedBase is IEntitlementGatedBase {
     transaction.roleIds.push(roleId);
 
     uint256 length = selectedNodes.length;
+    NodeVote[] storage nodeVotes = transaction.nodeVotesArray[roleId];
     for (uint256 i; i < length; ++i) {
-      transaction.nodeVotesArray[roleId].push(
+      nodeVotes.push(
         NodeVote({node: selectedNodes[i], vote: NodeVoteStatus.NOT_VOTED})
       );
     }
@@ -111,10 +112,11 @@ abstract contract EntitlementGatedBase is IEntitlementGatedBase {
     uint256 passed = 0;
     uint256 failed = 0;
 
-    uint256 transactionNodesLength = transaction.nodeVotesArray[roleId].length;
+    NodeVote[] storage nodeVotes = transaction.nodeVotesArray[roleId];
+    uint256 transactionNodesLength = nodeVotes.length;
 
     for (uint256 i; i < transactionNodesLength; ++i) {
-      NodeVote storage tempVote = transaction.nodeVotesArray[roleId][i];
+      NodeVote storage tempVote = nodeVotes[i];
 
       // Update vote if not yet voted
       if (tempVote.node == msg.sender) {
@@ -175,7 +177,7 @@ abstract contract EntitlementGatedBase is IEntitlementGatedBase {
 
     Transaction storage transaction = ds.transactions[transactionId];
 
-    if (transaction.hasBenSet == false) {
+    if (!transaction.hasBenSet) {
       revert EntitlementGated_TransactionNotRegistered();
     }
 

--- a/contracts/test/spaces/entitlements/EntitlementDataQueryable.t.sol
+++ b/contracts/test/spaces/entitlements/EntitlementDataQueryable.t.sol
@@ -45,7 +45,7 @@ contract EntitlementDataQueryableTest is
     );
   }
 
-  function test_getEntitlementDataByRole() external view {
+  function test_getEntitlementDataByPermission() external view {
     EntitlementData[] memory entitlement = entitlements
       .getEntitlementDataByPermission(Permissions.JoinSpace);
 


### PR DESCRIPTION
Replaced pre-increment operators for better performance and utilized unchecked blocks to optimize arithmetic operations. Additionally, fixed a typo in a comment and updated a test function name for clarity.