### PR TITLE
core: don't lock tx pool on estimate gas

### DIFF
--- a/core/node/crypto/chain_txpool.go
+++ b/core/node/crypto/chain_txpool.go
@@ -279,9 +279,6 @@ func (r *transactionPool) LastReplacementTransactionUnix() int64 {
 }
 
 func (r *transactionPool) EstimateGas(ctx context.Context, createTx CreateTransaction) (uint64, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	opts := &bind.TransactOpts{
 		From:    r.wallet.Address,
 		Nonce:   new(big.Int).SetUint64(0),


### PR DESCRIPTION
There is no need to claim the tx pool lock when estimating gas.