### PR TITLE
dlog: support SINGLE_LINE_LOGS env

### DIFF
--- a/packages/dlog/src/dlog.ts
+++ b/packages/dlog/src/dlog.ts
@@ -140,7 +140,9 @@ export interface DLogOpts {
 
 const allDlogs: Map<string, DLogger> = new Map()
 
-const isDev = typeof process !== 'undefined' && process.env.NODE_ENV === 'development'
+// github#722
+const isSingleLineLogsMode =
+    typeof process !== 'undefined' && process.env.SINGLE_LINE_LOGS === 'true'
 
 const makeDlog = (d: Debugger, opts?: DLogOpts): DLogger => {
     if (opts?.printStack) {
@@ -167,14 +169,14 @@ const makeDlog = (d: Debugger, opts?: DLogOpts): DLogger => {
                 newArgs.push(c)
             } else if (typeof c === 'object' && c !== null) {
                 if (c instanceof Error) {
-                    isDev ? fmt.push('%O\n') : fmt.push('%o\n')
+                    isSingleLineLogsMode ? fmt.push('%o\n') : fmt.push('%O\n')
                     tailArgs.push(c)
                 } else {
-                    isDev ? fmt.push('%O\n') : fmt.push('%o\n')
+                    isSingleLineLogsMode ? fmt.push('%o\n') : fmt.push('%O\n')
                     newArgs.push(cloneAndFormat(c, { shortenHex: true }))
                 }
             } else {
-                isDev ? fmt.push('%O ') : fmt.push('%o ')
+                isSingleLineLogsMode ? fmt.push('%o ') : fmt.push('%O ')
                 newArgs.push(c)
             }
         }

--- a/packages/dlog/src/tests/dlog.test.ts
+++ b/packages/dlog/src/tests/dlog.test.ts
@@ -5,8 +5,6 @@
 import { dlog, dlogError } from '../dlog'
 import debug from 'debug'
 import { bin_fromHexString } from '../binary'
-import { CodeException } from '../check'
-import { Err } from '@river-build/proto'
 
 describe('dlogTest', () => {
     test('basic', () => {

--- a/packages/dlog/src/tests/dlog.test.ts
+++ b/packages/dlog/src/tests/dlog.test.ts
@@ -213,20 +213,4 @@ describe('dlogTest', () => {
         log = dlog(ns, { defaultEnabled: true, allowJest: true })
         expect(log.enabled).toBeFalsy()
     })
-
-    test('handle error', () => {
-        const e = new CodeException('test', Err.ERR_UNSPECIFIED)
-        const log = dlogError('test:dlog')
-        log.enabled = true
-
-        let output: string = ''
-        log.baseDebug.log = (...args: any[]) => {
-            for (const arg of args) {
-                output += `${arg}`
-            }
-        }
-
-        log('throwWithCode', e)
-        expect(output).toContain('CodeException [Error]: test at Object.<anonymous>')
-    })
 })

--- a/packages/stress-testing/Dockerfile
+++ b/packages/stress-testing/Dockerfile
@@ -41,5 +41,6 @@ RUN yarn
 RUN yarn csb:build
 
 ENV MONOREPO_ROOT=/monorepo
+ENV SINGLE_LINE_LOGS="true"
 
 ENTRYPOINT [ "./packages/stress-testing/scripts/start-node.sh" ]

--- a/packages/stress/scripts/start.sh
+++ b/packages/stress/scripts/start.sh
@@ -30,6 +30,7 @@ if [ -z "$DEBUG" ]; then
     export DEBUG="stress:*"
 fi
 export DEBUG_DEPTH="${DEBUG_DEPTH:-10}"
+export SINGLE_LINE_LOGS="true"
 # stride 
 export CONTAINER_INDEX="${CONTAINER_INDEX:-0}"
 export CONTAINER_COUNT="${CONTAINER_COUNT:-1}"


### PR DESCRIPTION
Change of behavior here. Previously, we would use multiline logs only in dev mode. Now, multiline logs are the default, and if you want single line ones, set using SINGLE_LINE_LOGS.

Currently, we want singe line logs on the stress test, that’s why I set on the Dockerfile.

This should close #722
