### PR TITLE
stress clients: Remove localhost hack for redis storage

### DIFF
--- a/packages/stress/scripts/localhost_chat.sh
+++ b/packages/stress/scripts/localhost_chat.sh
@@ -4,6 +4,7 @@ cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")"
 cd ..
 
 # run scripts/localhost_chat_setup.sh to set up the environment variables
+
 # List of environment files to source
 ENV_FILES=(
     "./scripts/.env.localhost_chat"

--- a/packages/stress/scripts/localhost_demo.sh
+++ b/packages/stress/scripts/localhost_demo.sh
@@ -9,9 +9,26 @@ echo "stress/scripts/localhost_demo.sh"
 # simple test that runs in ci to ensure that the stress test can run in node against local env
 #
 
+# List of environment files to source
+ENV_FILES=(
+    "./scripts/.env.storage"
+)
+
+# Loop through each file in the list
+for file in "${ENV_FILES[@]}"; do
+    if [ -f "$file" ]; then
+        source "$file"
+        echo "Sourced: $file"
+    else
+        echo "Skipped: $file file does not exist."
+    fi
+done
+
 export RIVER_ENV="${RIVER_ENV:-local_multi}"
 export STRESS_MODE="${STRESS_MODE:-test}"
 export SESSION_ID="${SESSION_ID:-$(uuidgen)}"
+
+export REDIS_HOST="${REDIS_HOST:-}"
 
 export MNEMONIC="toy alien remain valid print employ age multiply claim student story aware" 
 export WALLET_ADDRESS="0x95D7701A0Faa5F514B4c5B49bf66580fCE9ffbf7"

--- a/packages/stress/scripts/start_redis.sh
+++ b/packages/stress/scripts/start_redis.sh
@@ -18,8 +18,8 @@ else
 
   # write the environment variables to a file so the tests can load it
   FILE="./scripts/.env.storage"
-  ENV_VAR="REDIS_HOST=http://localhost:6379"
-  echo $ENV_VAR >> $FILE # hard coded port from the docker compose file 
+  ENV_VAR="REDIS_HOST=localhost"
+  echo $ENV_VAR > $FILE # overwrites the .env file
   
   docker-compose -p "stress" -f ./scripts/docker_compose_redis.yml up
 fi

--- a/packages/stress/src/demo.ts
+++ b/packages/stress/src/demo.ts
@@ -9,6 +9,7 @@ import { expect, isSet } from './utils/expect'
 import { printSystemInfo } from './utils/systemInfo'
 import { waitFor } from './utils/waitFor'
 import { Wallet } from 'ethers'
+import { RedisStorage } from './utils/storage'
 
 check(isSet(process.env.RIVER_ENV), 'process.env.RIVER_ENV')
 
@@ -116,9 +117,23 @@ async function encryptDecrypt() {
     bobAccount.free()
 }
 
+async function demoExternalStoreage() {
+    if (isSet(process.env.REDIS_HOST)) {
+        const storage = new RedisStorage(process.env.REDIS_HOST)
+        const value = await storage.get('demo_key')
+        logger.info('value', value)
+        const nextValue = value ? parseInt(value) + 1 : 1
+        await storage.set('demo_key', nextValue.toString())
+        const newValue = await storage.get('demo_key')
+        logger.info('value updated', { from: value, to: newValue })
+    }
+}
+
 printSystemInfo(logger)
 
 const run = async () => {
+    logger.log('========================storage========================')
+    await demoExternalStoreage()
     logger.log('==========================spamInfo==========================')
     await spamInfo(1)
     logger.log('=======================encryptDecrypt=======================')

--- a/packages/stress/src/mode/chat/sumarizeChat.ts
+++ b/packages/stress/src/mode/chat/sumarizeChat.ts
@@ -20,7 +20,19 @@ export async function sumarizeChat(
     const message = defaultChannel.view.timeline.find(
         channelMessagePostWhere((value) => value.body.includes(cfg.sessionId)),
     )
-    check(isDefined(message), 'message not found')
+
+    if (!message) {
+        logger.error('message not found', { defaultChannel })
+        return {
+            containerIndex: cfg.containerIndex,
+            processIndex: cfg.processIndex,
+            freeMemory: getSystemInfo().FreeMemory,
+            checkinCounts: {},
+            errors: [
+                `message not found in ${cfg.announceChannelId} that includes ${cfg.sessionId}`,
+            ],
+        }
+    }
 
     const checkinCounts: Record<string, Record<string, number>> = {}
 

--- a/packages/stress/src/utils/storage.ts
+++ b/packages/stress/src/utils/storage.ts
@@ -10,26 +10,11 @@ export interface IStorage {
     close(): Promise<void>
 }
 
-function parseRedisUrl(uri: string) {
-    const defaultRedisPort = 6379
-    try {
-        const url = new URL(uri)
-        const host = `${url.protocol}//${url.hostname}`
-        const port = url.port.length > 0 ? parseInt(url.port) : defaultRedisPort
-        const opts = host.includes('localhost') ? { port } : { host, port }
-        return opts
-    } catch (error) {
-        return { host: uri, port: defaultRedisPort }
-    }
-}
-
 export class RedisStorage implements IStorage {
     private client: Redis
 
-    constructor(uri: string) {
-        const opts = parseRedisUrl(uri)
-        logger.log('New Redis connection', opts)
-        this.client = new Redis(opts)
+    constructor(host: string, port?: number) {
+        this.client = new Redis({ host, port: port ?? 6379 })
     }
     async get(key: string): Promise<string | null> {
         try {


### PR DESCRIPTION
The param is REDIS_HOST because aws only provides a host, there is no protocol or port. Mimic the same thing for localhost and do the right thing.