### PR TITLE
Fix for flaky DMMessagesAreBlockedDuringBlockedPeriod test

### DIFF
--- a/packages/sdk/src/userSettings.test.ts
+++ b/packages/sdk/src/userSettings.test.ts
@@ -136,7 +136,6 @@ describe('userSettingsTests', () => {
             ).toBe(false)
         })
 
-
         // bob blocks alice again
         await bobsClient.updateUserBlock(alicesClient.userId, true)
         // alice sends two messages after being blocked again, total blocked message should be 5

--- a/packages/sdk/src/userSettings.test.ts
+++ b/packages/sdk/src/userSettings.test.ts
@@ -106,19 +106,6 @@ describe('userSettingsTests', () => {
         await expect(alicesClient.sendMessage(streamId, 'hello 2nd')).toResolve()
         await expect(alicesClient.sendMessage(streamId, 'hello 3rd')).toResolve()
 
-        // bob unblocks alice, there will be two blocks
-        await bobsClient.updateUserBlock(alicesClient.userId, false)
-        // alice sends one more message after being unblocked, total blocked message should still be 3
-        await expect(alicesClient.sendMessage(streamId, 'hello 4th')).toResolve()
-
-        await waitFor(() => {
-            expect(
-                bobsClient
-                    .stream(bobsClient.userSettingsStreamId!)
-                    ?.view?.userSettingsContent?.isUserBlocked(alicesClient.userId),
-            ).toBe(false)
-        })
-
         // verify in bob's client, there are 3 blocked messages from alice
         await waitFor(() => {
             expect(
@@ -135,6 +122,20 @@ describe('userSettingsTests', () => {
                 }).length,
             ).toBe(3)
         })
+
+        // bob unblocks alice
+        await bobsClient.updateUserBlock(alicesClient.userId, false)
+        // alice sends one more message after being unblocked, total blocked message should still be 3
+        await expect(alicesClient.sendMessage(streamId, 'hello 4th')).toResolve()
+
+        await waitFor(() => {
+            expect(
+                bobsClient
+                    .stream(bobsClient.userSettingsStreamId!)
+                    ?.view?.userSettingsContent?.isUserBlocked(alicesClient.userId),
+            ).toBe(false)
+        })
+
 
         // bob blocks alice again
         await bobsClient.updateUserBlock(alicesClient.userId, true)


### PR DESCRIPTION
seeing this fail a lot lately

https://github.com/river-build/river/actions/runs/10363799599/job/28688037477

we’re having issuses with the stream subscription backing up, i think the message wasn’t getting there in time.

fix: explicitly wait for all three messages before unblocking alice