### PR TITLE
chore: Add path_filters to .coderabbit.yaml

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,6 +11,7 @@ reviews:
     poem: false
     collapse_walkthrough: false
     sequence_diagrams: false
+    path_filters: ['!packages/generated/**']
     auto_review:
         enabled: true
         drafts: false


### PR DESCRIPTION
Included path_filters to exclude 'packages/generated/**' paths. This update ensures auto_review ignores generated files, keeping the review process focused on relevant code changes.