### PR TITLE
Change the miniblock_candidate primary key to be covering for the queries we run. Change one fetch to avoid a sort

### DIFF
--- a/core/node/storage/migrations/000004_alter_miniblock_candidates_pk.down.sql
+++ b/core/node/storage/migrations/000004_alter_miniblock_candidates_pk.down.sql
@@ -1,0 +1,7 @@
+-- Drop the existing primary key
+ALTER TABLE miniblock_candidates
+DROP CONSTRAINT miniblock_candidates_pkey;
+
+-- Add the new primary key with the desired order
+ALTER TABLE miniblock_candidates
+ADD PRIMARY KEY (stream_id, block_hash, seq_num);

--- a/core/node/storage/migrations/000004_alter_miniblock_candidates_pk.up.sql
+++ b/core/node/storage/migrations/000004_alter_miniblock_candidates_pk.up.sql
@@ -1,0 +1,7 @@
+-- Drop the existing primary key
+ALTER TABLE miniblock_candidates
+DROP CONSTRAINT miniblock_candidates_pkey;
+
+-- Add the new primary key with the desired order
+ALTER TABLE miniblock_candidates
+ADD PRIMARY KEY (stream_id, seq_num, block_hash);

--- a/core/node/storage/pg_storage.go
+++ b/core/node/storage/pg_storage.go
@@ -590,7 +590,8 @@ func (s *PostgresEventStore) writeEventTx(
 ) error {
 	envelopesRow, err := tx.Query(
 		ctx,
-		"SELECT generation, slot_num FROM minipools WHERE stream_id = $1 ORDER BY slot_num",
+		// Ordering by generation, slot_num allows this to be an index only query
+		"SELECT generation, slot_num FROM minipools WHERE stream_id = $1 ORDER BY generation, slot_num",
 		streamId,
 	)
 	if err != nil {

--- a/core/node/storage/pg_storage_test.go
+++ b/core/node/storage/pg_storage_test.go
@@ -383,10 +383,9 @@ func TestAddEventConsistencyChecksImproperGeneration(t *testing.T) {
 	err := pgEventStore.WriteEvent(ctx, streamId, 1, 3, []byte("event4"))
 
 	require.NotNil(err)
-	require.Contains(err.Error(), "Wrong event generation in minipool")
-	require.Equal(AsRiverError(err).GetTag("ActualGeneration"), int64(777))
-	require.Equal(AsRiverError(err).GetTag("ExpectedGeneration"), int64(1))
-	require.Equal(AsRiverError(err).GetTag("SlotNumber"), 1)
+	require.Contains(err.Error(), "Wrong slot number in minipool")
+	require.Equal(AsRiverError(err).GetTag("ActualSlotNumber"), 2)
+	require.Equal(AsRiverError(err).GetTag("ExpectedSlotNumber"), 1)
 }
 
 // Test that if there is a gap in minipool records, we will get error


### PR DESCRIPTION
I've reviewed all of the queries that were resulting in serialization errors and I'm unable to figure out why we would be having any errors in the first place. It's a red flag that our transaction order, which is quite small, is causing a serialization error.

Along the way I found two queries that we doing some table level access that should have been index only. This fixes those cases.