### PR TITLE
stress: add `--enable-source-maps` in start/demo script

### DIFF
--- a/packages/stress/package.json
+++ b/packages/stress/package.json
@@ -9,8 +9,8 @@
         "build-esbuild": "node esbuild.config.mjs",
         "lint": "eslint . --ext .ts",
         "my-jest": "NODE_TLS_REJECT_UNAUTHORIZED=0 yarn node -r ../../scripts/node-no-warn.js --experimental-vm-modules $(yarn bin jest)",
-        "start": "node ./dist/start.cjs",
-        "demo": "node ./dist/demo.cjs",
+        "start": "node --enable-source-maps ./dist/start.cjs",
+        "demo": "node --enable-source-maps ./dist/demo.cjs",
         "test:ci:with-entitlements": "RIVER_ENV=local_multi DEBUG='stress:*,csb:enc*,csb:dec*' DEBUG_DEPTH='10' yarn my-jest"
     },
     "dependencies": {

--- a/packages/stress/scripts/localhost_chat_setup.sh
+++ b/packages/stress/scripts/localhost_chat_setup.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")"
 cd ..
 
-echo "stress/scripts/localhost_setup_chat.sh"
+echo "stress/scripts/localhost_chat_setup.sh"
 
 #
 # create space and channels for stress testing


### PR DESCRIPTION
Closes #746 

I added a random throw statement around the code to test. Results:

prev:
```
stress:run:0:error unhandled error: Error: not implemented at StressClient.sendMessage 
(/Users/miguel/dev/hnt/river/packages/stress/dist/start.cjs:174697:11)     at process.processTicksAndRejections 
(node:internal/process/task_queues:95:5) at async kickoffChat 
(/Users/miguel/dev/hnt/river/packages/stress/dist/start.cjs:174846:46) at async startStressChat 
(/Users/miguel/dev/hnt/river/packages/stress/dist/start.cjs:175460:5) at async run 
(/Users/miguel/dev/hnt/river/packages/stress/dist/start.cjs:175564:7)
```

with sourcemap
```
stress:run:0:error unhandled error: Error: not implemented at StressClient.sendMessage 
(/Users/miguel/dev/hnt/river/packages/stress/src/utils/stressClient.ts:252:15)     at process.processTicksAndRejections
 (node:internal/process/task_queues:95:5) at kickoffChat 
(/Users/miguel/dev/hnt/river/packages/stress/src/mode/chat/kickoffChat.ts:35:48) at startStressChat 
(/Users/miguel/dev/hnt/river/packages/stress/src/mode/chat/root_chat.ts:139:9) at run 
(/Users/miguel/dev/hnt/river/packages/stress/src/start.ts:41:13)
```

Now the stack trace error is pointing to the Typescript file, and not the bundled file.