### PR TITLE
Add PingSync tests

### DIFF
--- a/packages/sdk/src/syncedStreams.ts
+++ b/packages/sdk/src/syncedStreams.ts
@@ -105,7 +105,7 @@ export class SyncedStreams {
     // and are cleared when sync stops
     private responsesQueue: SyncStreamsResponse[] = []
     private inProgressTick?: Promise<void>
-    private pingInfo: PingInfo = {
+    public pingInfo: PingInfo = {
         currentSequence: 0,
         nonces: {},
     }


### PR DESCRIPTION
Try to flush out any race in sending and receiving pings. Could be useful to run while also running a stress test.