### PR TITLE
Add timeout to PromoteBlock

### DIFF
--- a/core/node/storage/pg_storage.go
+++ b/core/node/storage/pg_storage.go
@@ -833,6 +833,8 @@ func (s *PostgresEventStore) PromoteBlock(
 	snapshotMiniblock bool,
 	envelopes [][]byte,
 ) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
 	return s.txRunner(
 		ctx,
 		"PromoteBlock",


### PR DESCRIPTION
PromoteBlock is not called as part of RPC, and as such doesn't timeout set.