### PR TITLE
Add streamExists function on the RiverRegistryDapp

### DIFF
--- a/packages/sdk/src/sync-agent/streams/streams.test.ts
+++ b/packages/sdk/src/sync-agent/streams/streams.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @group with-entitilements
+ */
+import { dlogger } from '@river-build/dlog'
+import { Bot } from '../utils/bot'
+import { makeUniqueMediaStreamId, streamIdAsBytes } from '../../id'
+
+const logger = dlogger('csb:test:streams')
+
+describe('streams.test.ts', () => {
+    logger.log('start')
+    const testUser = new Bot()
+
+    beforeAll(async () => {
+        await testUser.fundWallet()
+    })
+
+    test('stream exists', async () => {
+        const syncAgent = await testUser.makeSyncAgent()
+        await syncAgent.start()
+        const { spaceId, defaultChannelId } = await syncAgent.spaces.createSpace(
+            { spaceName: 'BlastOff' },
+            testUser.signer,
+        )
+        const spaceExists = await syncAgent.riverConnection.riverRegistryDapp.streamExists(
+            streamIdAsBytes(spaceId),
+        )
+        expect(spaceExists).toBe(true)
+
+        const channelExists = await syncAgent.riverConnection.riverRegistryDapp.streamExists(
+            streamIdAsBytes(defaultChannelId),
+        )
+        expect(channelExists).toBe(true)
+
+        const notAStream = makeUniqueMediaStreamId()
+        const notAStreamExists = await syncAgent.riverConnection.riverRegistryDapp.streamExists(
+            streamIdAsBytes(notAStream),
+        )
+        expect(notAStreamExists).toBe(false)
+    })
+})

--- a/packages/web3/src/v3/RiverRegistry.ts
+++ b/packages/web3/src/v3/RiverRegistry.ts
@@ -4,6 +4,7 @@ import { INodeRegistryShim } from './INodeRegistryShim'
 import { ethers } from 'ethers'
 import { IStreamRegistryShim } from './IStreamRegistryShim'
 import { IOperatorRegistryShim } from './IOperatorRegistryShim'
+import { StreamStructOutput } from '@river-build/generated/dev/typings/IStreamRegistry'
 
 interface RiverNodesMap {
     [nodeAddress: string]: NodeStructOutput
@@ -87,6 +88,23 @@ export class RiverRegistry {
 
     async getStreamCount(): Promise<ethers.BigNumber> {
         return this.streamRegistry.read.getStreamCount()
+    }
+
+    async getStream(streamAddress: Uint8Array): Promise<StreamStructOutput> {
+        return this.streamRegistry.read.getStream(streamAddress)
+    }
+
+    async streamExists(streamAddress: Uint8Array): Promise<boolean> {
+        try {
+            await this.getStream(streamAddress)
+            return true
+        } catch (error) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            if ((error as any).reason === 'NOT_FOUND') {
+                return false
+            }
+            throw error
+        }
     }
 
     private async getStreamCountOnNode(nodeAddress: string): Promise<ethers.BigNumber> {


### PR DESCRIPTION
Really useful to just go to the stream registry to see if a stream exists instead of an “optional” get stream request.