### PR TITLE
Kerem/stream metadata dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
-node_modules
 .env
 .envrc
+.dockerignore
+packages/stream-metadata/Dockerfile
+packages/metrics-discovery/Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,6 @@
 .envrc
 .dockerignore
 packages/stream-metadata/Dockerfile
+packages/stream-metadata/docker-compose.yml
 packages/metrics-discovery/Dockerfile
+packages/metrics-discovery/docker-compose.yml

--- a/.github/workflows/Stream_metadata_docker.yml
+++ b/.github/workflows/Stream_metadata_docker.yml
@@ -1,0 +1,64 @@
+name: 'Build Stream Metadata Docker Image'
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - 'packages/**'
+    workflow_dispatch:
+
+env:
+    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CD_WORKFLOW_WEBHOOK_URL }}
+
+jobs:
+    build:
+        name: Build docker image
+
+        runs-on: ubuntu-latest
+
+        permissions:
+            contents: write
+            packages: write
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: us-east-1
+
+            - name: Login to Amazon ECR
+              id: login-aws-ecr
+              uses: aws-actions/amazon-ecr-login@v2
+              with:
+                  registry-type: 'public'
+
+            - name: Build and push docker image to Amazon ECR
+              env:
+                  ECR_REGISTRY: ${{ steps.login-aws-ecr.outputs.registry }}
+                  #This can be custom alias once requested to aws and approved for public repo
+                  REGISTRY_ALIAS: h5v6m2x1
+                  ECR_REPOSITORY: river-stream-metadata
+              run: |
+                  docker build -t $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:latest . -f ./packages/stream-metadata/Dockerfile
+                  docker push $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+
+            # If action failed, we send a slack notification
+            - name: Slack notification
+              if: failure()
+              uses: slackapi/slack-github-action@v1.24.0
+              with:
+                  payload: |
+                      {
+                          "step": "Build Stream Metadata Docker Image",
+                          "environment": "N/",
+                          "branch": "${{ github.ref }}",
+                          "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                          "commit": "${{ github.sha }}",
+                          "actor": "${{ github.actor }}"
+                      }

--- a/packages/stream-metadata/.env.local.sample
+++ b/packages/stream-metadata/.env.local.sample
@@ -1,9 +1,5 @@
 # Required.
-RIVER_ENV=alpha
-RIVER_CHAIN_RPC_URL=https://mainnet.rpc.river.build/http
+RIVER_ENV=local_multi
+RIVER_CHAIN_RPC_URL=http://localhost:8546
 # port that the server listens at. e.g. http://localhost:3002
 PORT=3002
-
-# IMPORTANT: disable tls cert validation in localhost env ONLY
-# in all other environments, comment out this line.
-NODE_TLS_REJECT_UNAUTHORIZED=0

--- a/packages/stream-metadata/.env.local.sample
+++ b/packages/stream-metadata/.env.local.sample
@@ -3,3 +3,7 @@ RIVER_ENV=local_multi
 RIVER_CHAIN_RPC_URL=http://localhost:8546
 # port that the server listens at. e.g. http://localhost:3002
 PORT=3002
+
+# IMPORTANT: disable tls cert validation in localhost env ONLY
+# in all other environments, comment out this line.
+NODE_TLS_REJECT_UNAUTHORIZED=0

--- a/packages/stream-metadata/.env.local.sample
+++ b/packages/stream-metadata/.env.local.sample
@@ -1,6 +1,6 @@
 # Required.
-RIVER_ENV=local_multi
-RIVER_CHAIN_RPC_URL=http://localhost:8546
+RIVER_ENV=alpha
+RIVER_CHAIN_RPC_URL=https://mainnet.rpc.river.build/http
 # port that the server listens at. e.g. http://localhost:3002
 PORT=3002
 

--- a/packages/stream-metadata/Dockerfile
+++ b/packages/stream-metadata/Dockerfile
@@ -1,0 +1,48 @@
+FROM node:lts-alpine3.20 as builder
+
+WORKDIR /river
+
+# monorepo root config
+COPY ./package.json ./package.json
+COPY ./.yarn/plugins ./.yarn/plugins
+COPY ./.yarn/releases ./.yarn/releases
+COPY ./remappings.txt ./remappings.txt
+COPY ./.yarnrc.yml ./.yarnrc.yml
+COPY ./buf.yaml ./buf.yaml
+COPY ./lerna.json ./lerna.json
+COPY ./yarn.lock ./yarn.lock
+COPY ./turbo.json ./turbo.json
+COPY ./packages/tsconfig.base.json ./packages/tsconfig.base.json
+
+# monorepo core dependencies
+COPY ./protocol ./protocol
+
+# monorepo scripts
+COPY ./scripts ./scripts
+
+# monorepo packages
+COPY ./packages/eslint-config /river/packages/eslint-config
+COPY ./packages/prettier-config /river/packages/prettier-config
+COPY ./packages/generated /river/packages/generated
+COPY ./packages/web3 /river/packages/web3
+COPY ./packages/dlog /river/packages/dlog
+COPY ./packages/proto /river/packages/proto
+COPY ./packages/sdk /river/packages/sdk
+COPY ./packages/encryption /river/packages/encryption
+COPY ./packages/stream-metadata /river/packages/stream-metadata
+
+# install dependencies and build
+RUN apk add --no-cache git curl
+RUN corepack enable
+RUN yarn install
+
+RUN yarn run turbo build --filter @river-build/stream-metadata
+
+FROM node:lts-alpine3.20 as runner
+
+COPY --from=builder /river/packages/stream-metadata/dist /river/packages/stream-metadata/dist
+
+ENV NODE_ENV=production 
+WORKDIR /river/packages/stream-metadata
+
+CMD ["node", "./dist/node_esbuild.cjs"]

--- a/packages/stream-metadata/Dockerfile
+++ b/packages/stream-metadata/Dockerfile
@@ -35,14 +35,13 @@ COPY ./packages/stream-metadata /river/packages/stream-metadata
 RUN apk add --no-cache git curl
 RUN corepack enable
 RUN yarn install
-
 RUN yarn run turbo build --filter @river-build/stream-metadata
 
+# create runner image with only the necessary files
 FROM node:lts-alpine3.20 as runner
-
 COPY --from=builder /river/packages/stream-metadata/dist /river/packages/stream-metadata/dist
 
-ENV NODE_ENV=production 
+# run the service
 WORKDIR /river/packages/stream-metadata
-
+ENV NODE_ENV=production 
 CMD ["node", "./dist/node_esbuild.cjs"]

--- a/packages/stream-metadata/Dockerfile
+++ b/packages/stream-metadata/Dockerfile
@@ -44,4 +44,4 @@ COPY --from=builder /river/packages/stream-metadata/dist /river/packages/stream-
 # run the service
 WORKDIR /river/packages/stream-metadata
 ENV NODE_ENV=production 
-CMD ["node", "./dist/node_esbuild.cjs"]
+CMD ["node", "--enable-source-maps", "./dist/node_esbuild.cjs"]

--- a/packages/stream-metadata/Dockerfile
+++ b/packages/stream-metadata/Dockerfile
@@ -34,7 +34,7 @@ COPY ./packages/stream-metadata /river/packages/stream-metadata
 # install dependencies and build
 RUN apk add --no-cache git curl
 RUN corepack enable
-RUN yarn install --frozen-lockfile
+RUN yarn install
 RUN yarn run turbo build --filter @river-build/stream-metadata
 
 # create runner image with only the necessary files

--- a/packages/stream-metadata/Dockerfile
+++ b/packages/stream-metadata/Dockerfile
@@ -34,7 +34,7 @@ COPY ./packages/stream-metadata /river/packages/stream-metadata
 # install dependencies and build
 RUN apk add --no-cache git curl
 RUN corepack enable
-RUN yarn install
+RUN yarn install --frozen-lockfile
 RUN yarn run turbo build --filter @river-build/stream-metadata
 
 # create runner image with only the necessary files

--- a/packages/stream-metadata/docker-compose.yml
+++ b/packages/stream-metadata/docker-compose.yml
@@ -5,7 +5,7 @@ services:
             dockerfile: ./packages/stream-metadata/Dockerfile
         environment:
             RIVER_ENV: alpha
-            RIVER_CHAIN_RPC_URL: https://mainnet.rpc.river.build/http
+            RIVER_CHAIN_RPC_URL: https://testnet.rpc.river.build/http
             PORT: 80
         ports:
             - 80:80

--- a/packages/stream-metadata/docker-compose.yml
+++ b/packages/stream-metadata/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+    river-metrics-discovery:
+        container_name: river-metrics-discovery
+        build:
+            context: ../../
+            dockerfile: ./packages/stream-metadata/Dockerfile
+        environment:
+            RIVER_ENV: alpha
+            RIVER_CHAIN_RPC_URL: https://mainnet.rpc.river.build/http
+            PORT: 80
+        ports:
+            - 80:80

--- a/packages/stream-metadata/docker-compose.yml
+++ b/packages/stream-metadata/docker-compose.yml
@@ -1,6 +1,5 @@
 services:
-    river-metrics-discovery:
-        container_name: river-metrics-discovery
+    stream-metadata:
         build:
             context: ../../
             dockerfile: ./packages/stream-metadata/Dockerfile

--- a/packages/stream-metadata/package.json
+++ b/packages/stream-metadata/package.json
@@ -7,6 +7,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "node ./esbuild.config.mjs",
+		"build:turbo": "turbo build",
 		"lint": "eslint . --ext .ts",
 		"lint:fix": "eslint . --ext .ts --fix",
 		"dev": "yarn build && node ./dist/node_esbuild.cjs",

--- a/packages/stream-metadata/package.json
+++ b/packages/stream-metadata/package.json
@@ -7,7 +7,6 @@
 	"type": "module",
 	"scripts": {
 		"build": "node ./esbuild.config.mjs",
-		"build:turbo": "turbo build",
 		"lint": "eslint . --ext .ts",
 		"lint:fix": "eslint . --ext .ts --fix",
 		"dev": "yarn build && node ./dist/node_esbuild.cjs",

--- a/packages/stream-metadata/package.json
+++ b/packages/stream-metadata/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "stream-metadata",
+	"name": "@river-build/stream-metadata",
 	"version": "0.0.0",
 	"packageManager": "yarn@3.8.0",
 	"private": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3829,6 +3829,40 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@river-build/stream-metadata@workspace:packages/stream-metadata":
+  version: 0.0.0-use.local
+  resolution: "@river-build/stream-metadata@workspace:packages/stream-metadata"
+  dependencies:
+    "@bufbuild/buf": ^1.32.0
+    "@bufbuild/protobuf": ^1.9.0
+    "@connectrpc/connect": ^1.4.0
+    "@connectrpc/connect-web": ^1.4.0
+    "@fastify/cors": ^9.0.1
+    "@river-build/eslint-config": "workspace:^"
+    "@river-build/generated": "workspace:^"
+    "@river-build/prettier-config": "workspace:^"
+    "@river-build/proto": "workspace:^"
+    "@river-build/sdk": "workspace:^"
+    "@river-build/web3": "workspace:^"
+    "@types/node": ^20.5.0
+    "@typescript-eslint/parser": ^7.14.1
+    dotenv: ^16.4.5
+    esbuild: ^0.21.5
+    esbuild-plugin-pino: ^2.2.0
+    eslint: ^8.53.0
+    ethers: ^5.7.2
+    fastify: ^4.28.1
+    magic-bytes.js: ^1.10.0
+    pino: ^8.17.1
+    pino-pretty: ^10.2.3
+    prettier: ^2.8.8
+    rollup: ^4.18.1
+    ts-node: ^10.9.1
+    typescript: ^5.1.6
+    zod: ^3.21.4
+  languageName: unknown
+  linkType: soft
+
 "@river-build/stress@workspace:packages/stress":
   version: 0.0.0-use.local
   resolution: "@river-build/stress@workspace:packages/stress"
@@ -18382,40 +18416,6 @@ __metadata:
   checksum: c9b78453aeb0c84fcc59555518ac62bacab9fa98e323e7b7666e5f9f58af8f3155e34481078509b02929bd1268427f664d186604cdccee95abc446099b339f83
   languageName: node
   linkType: hard
-
-"stream-metadata@workspace:packages/stream-metadata":
-  version: 0.0.0-use.local
-  resolution: "stream-metadata@workspace:packages/stream-metadata"
-  dependencies:
-    "@bufbuild/buf": ^1.32.0
-    "@bufbuild/protobuf": ^1.9.0
-    "@connectrpc/connect": ^1.4.0
-    "@connectrpc/connect-web": ^1.4.0
-    "@fastify/cors": ^9.0.1
-    "@river-build/eslint-config": "workspace:^"
-    "@river-build/generated": "workspace:^"
-    "@river-build/prettier-config": "workspace:^"
-    "@river-build/proto": "workspace:^"
-    "@river-build/sdk": "workspace:^"
-    "@river-build/web3": "workspace:^"
-    "@types/node": ^20.5.0
-    "@typescript-eslint/parser": ^7.14.1
-    dotenv: ^16.4.5
-    esbuild: ^0.21.5
-    esbuild-plugin-pino: ^2.2.0
-    eslint: ^8.53.0
-    ethers: ^5.7.2
-    fastify: ^4.28.1
-    magic-bytes.js: ^1.10.0
-    pino: ^8.17.1
-    pino-pretty: ^10.2.3
-    prettier: ^2.8.8
-    rollup: ^4.18.1
-    ts-node: ^10.9.1
-    typescript: ^5.1.6
-    zod: ^3.21.4
-  languageName: unknown
-  linkType: soft
 
 "stream-shift@npm:^1.0.0":
   version: 1.0.3


### PR DESCRIPTION
This PR introduces a Dockerfile for the stream-metadata service, as well as a github action that builds and publishes the image. The total image size comes down to `153 mb`, about 20mb above the base nodejs alpine image.

<img width="1201" alt="image" src="https://github.com/user-attachments/assets/b052f6db-1d4f-427a-a6b9-32e5c80bb7c8">