### PR TITLE
bugfix(sdk) Udpate client.waitForStream

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1035,7 +1035,7 @@ export class Client
         }
 
         await new Promise<void>((resolve, reject) => {
-            const timout = setTimeout(() => {
+            const timeout = setTimeout(() => {
                 this.off('streamInitialized', handler)
                 reject(new Error(`waitForStream: timeout waiting for ${streamId}`))
             }, timeoutMs)
@@ -1043,7 +1043,7 @@ export class Client
                 if (newStreamId === streamId) {
                     this.logCall('waitForStream: got streamInitialized', newStreamId)
                     this.off('streamInitialized', handler)
-                    clearTimeout(timout)
+                    clearTimeout(timeout)
                     resolve()
                 } else {
                     this.logCall(

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1021,19 +1021,29 @@ export class Client
         return stream.view.getUserMetadata().usernames.cleartextUsernameAvailable(username) ?? false
     }
 
-    async waitForStream(streamId: string | Uint8Array): Promise<Stream> {
-        this.logCall('waitForStream', streamId)
+    async waitForStream(
+        inStreamId: string | Uint8Array,
+        opts?: { timeoutMs?: number },
+    ): Promise<Stream> {
+        this.logCall('waitForStream', inStreamId)
+        const timeoutMs = opts?.timeoutMs ?? 15000
+        const streamId = streamIdAsString(inStreamId)
         let stream = this.stream(streamId)
         if (stream !== undefined && stream.view.isInitialized) {
             this.logCall('waitForStream: stream already initialized', streamId)
             return stream
         }
 
-        await new Promise<void>((resolve) => {
+        await new Promise<void>((resolve, reject) => {
+            const timout = setTimeout(() => {
+                this.off('streamInitialized', handler)
+                reject(new Error(`waitForStream: timeout waiting for ${streamId}`))
+            }, timeoutMs)
             const handler = (newStreamId: string) => {
                 if (newStreamId === streamId) {
                     this.logCall('waitForStream: got streamInitialized', newStreamId)
                     this.off('streamInitialized', handler)
+                    clearTimeout(timout)
                     resolve()
                 } else {
                     this.logCall(


### PR DESCRIPTION
waitForStream was accepting a string or uint8array and was then comparing to a string. It was never called with a uint8array, but that was a bug waiting to happen

it also didn’t timeout, so if the stream never initialized, initStream would hang forever.

add timeout so that the ui can continue and not hang on loading screens.