### PR TITLE
fix pino logger printing

### DIFF
--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -16,13 +16,16 @@ process.title = 'stream-metadata'
 
 const logger = getLogger('server')
 
-logger.info({
-	riverEnv: config.riverEnv,
-	chainId: config.web3Config.river.chainId,
-	port: config.port,
-	riverRegistry: config.web3Config.river.addresses.riverRegistry,
-	riverChainRpcUrl: config.riverChainRpcUrl,
-})
+logger.info(
+	{
+		riverEnv: config.riverEnv,
+		chainId: config.web3Config.river.chainId,
+		port: config.port,
+		riverRegistry: config.web3Config.river.addresses.riverRegistry,
+		riverChainRpcUrl: config.riverChainRpcUrl,
+	},
+	'config',
+)
 
 /*
  * Server setup
@@ -57,16 +60,15 @@ export function setupRoutes(srv: Server) {
 
 	srv.get('/space/:spaceAddress', async (request, reply) => {
 		const { spaceAddress } = request.params as { spaceAddress?: string }
-		logger.info(`GET /space`, { spaceAddress })
+		logger.info({ spaceAddress }, 'GET /space/../metadata')
+
 		const { protocol, serverAddress } = getServerInfo()
 		return fetchSpaceMetadata(request, reply, `${protocol}://${serverAddress}`)
 	})
 
 	srv.get('/space/:spaceAddress/image', async (request, reply) => {
 		const { spaceAddress } = request.params as { spaceAddress?: string }
-		logger.info(`GET /space/../image`, {
-			spaceAddress,
-		})
+		logger.info({ spaceAddress }, 'GET /space/../image')
 
 		return fetchSpaceImage(request, reply)
 	})
@@ -95,8 +97,8 @@ process.on('SIGTERM', async () => {
 		await server.close()
 		logger.info('Server closed gracefully')
 		process.exit(0)
-	} catch (err) {
-		logger.error('Error during server shutdown', err)
+	} catch (error) {
+		logger.error(error, 'Error during server shutdown')
 		process.exit(1)
 	}
 })
@@ -107,8 +109,8 @@ async function main() {
 		setupRoutes(server)
 		await server.listen({ port: config.port })
 		logger.info('Server started')
-	} catch (err) {
-		logger.error('Error starting server', err)
+	} catch (error) {
+		logger.error(error, 'Error starting server')
 		process.exit(1)
 	}
 }

--- a/packages/stream-metadata/src/riverStreamRpcClient.ts
+++ b/packages/stream-metadata/src/riverStreamRpcClient.ts
@@ -25,9 +25,7 @@ const contentCache: Record<string, MediaContent | undefined> = {}
 export type StreamRpcClient = PromiseClient<typeof StreamService> & { url?: string }
 
 function makeStreamRpcClient(url: string): StreamRpcClient {
-	logger.info(`makeStreamRpcClient: Connecting`, {
-		url,
-	})
+	logger.info({ url }, 'makeStreamRpcClient: Connecting')
 
 	const options: ConnectTransportOptions = {
 		baseUrl: url,
@@ -47,7 +45,7 @@ async function getStreamClient(streamId: `0x${string}`) {
 		clients.set(client.url!, client)
 		url = client.url!
 	}
-	logger.info('getStreamClient: client url', url)
+	logger.info({ url }, 'getStreamClient: client url')
 
 	const client = clients.get(url)
 	if (!client) {
@@ -83,9 +81,12 @@ async function mediaContentFromStreamView(
 ): Promise<MediaContent> {
 	const mediaInfo = streamView.mediaContent.info
 	if (mediaInfo) {
-		logger.info(`mediaContentFromStreamView`, {
-			spaceId: mediaInfo.spaceId,
-		})
+		logger.info(
+			{
+				spaceId: mediaInfo.spaceId,
+			},
+			'mediaContentFromStreamView',
+		)
 
 		// Aggregate data chunks into a single Uint8Array
 		const data = new Uint8Array(
@@ -103,9 +104,7 @@ async function mediaContentFromStreamView(
 		// Determine the MIME type
 		const mimeType = filetypemime(decrypted)
 		if (mimeType?.length > 0) {
-			logger.info(`mediaContentFromStreamView`, {
-				mimeType,
-			})
+			logger.info({ mimeType }, 'mediaContentFromStreamView')
 
 			// Return decrypted data and MIME type
 			return {
@@ -133,24 +132,30 @@ export async function getStream(streamId: string): Promise<StreamStateView | und
 		const result = await getStreamClient(`0x${streamId}`)
 		client = result.client
 		lastMiniblockNum = result.lastMiniblockNum
-	} catch (e) {
-		logger.error('Failed to get client for stream', {
-			err: e,
-			streamId,
-		})
+	} catch (error) {
+		logger.error(
+			{
+				error,
+				streamId,
+			},
+			'Failed to get client for stream',
+		)
 		return undefined
 	}
 
 	if (!client) {
-		logger.error(`Failed to get client for stream`, { streamId })
+		logger.error({ streamId }, 'Failed to get client for stream')
 		return undefined
 	}
 
-	logger.info(`getStream`, {
-		clientUrl: client.url,
-		streamId,
-		lastMiniblockNum: lastMiniblockNum.toString(),
-	})
+	logger.info(
+		{
+			clientUrl: client.url,
+			streamId,
+			lastMiniblockNum: lastMiniblockNum.toString(),
+		},
+		'getStream',
+	)
 
 	const start = Date.now()
 
@@ -158,9 +163,12 @@ export async function getStream(streamId: string): Promise<StreamStateView | und
 		streamId: streamIdAsBytes(streamId),
 	})
 
-	logger.info(`getStream finished`, {
-		duration: Date.now() - start,
-	})
+	logger.info(
+		{
+			duration: Date.now() - start,
+		},
+		'getStream finished',
+	)
 
 	const unpackedResponse = await unpackStream(response.stream)
 	return streamViewFromUnpackedResponse(streamId, unpackedResponse)
@@ -194,11 +202,14 @@ export async function getMediaStreamContent(
 	let result: MediaContent | undefined
 	try {
 		result = await mediaContentFromStreamView(sv, secret, iv)
-	} catch (e) {
-		logger.error(`Failed to get media content for stream`, {
-			err: e,
-			streamId: fullStreamId,
-		})
+	} catch (error) {
+		logger.error(
+			{
+				error,
+				streamId: fullStreamId,
+			},
+			'Failed to get media content for stream',
+		)
 		return { data: null, mimeType: null }
 	}
 

--- a/packages/stream-metadata/src/routes/health.ts
+++ b/packages/stream-metadata/src/routes/health.ts
@@ -11,9 +11,9 @@ export async function checkHealth(request: FastifyRequest, reply: FastifyReply) 
 		await getRiverRegistry().getAllNodes()
 		// healthy
 		return reply.code(200).send({ status: 'ok' })
-	} catch (e) {
+	} catch (error) {
 		// unhealthy
-		logger.error('Failed to get river registry', { err: e })
+		logger.error(error, 'Failed to get river registry')
 		return reply.code(500).send({ status: 'error' })
 	}
 }

--- a/packages/stream-metadata/src/routes/spaceImage.ts
+++ b/packages/stream-metadata/src/routes/spaceImage.ts
@@ -28,11 +28,14 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 	try {
 		const streamId = makeStreamId(StreamPrefix.Space, spaceAddress)
 		stream = await getStream(streamId)
-	} catch (e) {
-		logger.error(`Failed to get stream`, {
-			error: e,
-			spaceAddress,
-		})
+	} catch (error) {
+		logger.error(
+			{
+				error,
+				spaceAddress,
+			},
+			'Failed to get stream',
+		)
 		return reply.code(404).send('Stream not found')
 	}
 
@@ -80,10 +83,13 @@ function getEncryption(chunkedMedia: ChunkedMedia): { key: Uint8Array; iv: Uint8
 			return { key, iv }
 		}
 		default:
-			logger.error('Unsupported encryption', {
-				case: chunkedMedia.encryption.case,
-				value: chunkedMedia.encryption.value,
-			})
+			logger.error(
+				{
+					case: chunkedMedia.encryption.case,
+					value: chunkedMedia.encryption.value,
+				},
+				'Unsupported encryption',
+			)
 			throw new Error('Unsupported encryption')
 	}
 }

--- a/packages/stream-metadata/src/streamRegistry.ts
+++ b/packages/stream-metadata/src/streamRegistry.ts
@@ -17,7 +17,7 @@ const logger = getLogger('streamRegistry')
 export async function getNodeForStream(
 	streamId: StreamIdHex,
 ): Promise<{ url: string; lastMiniblockNum: BigNumber }> {
-	logger.info('getNodeForStream', streamId)
+	logger.info({ streamId }, 'getNodeForStream')
 
 	const now = Date.now()
 	const cachedData = cache[streamId]
@@ -31,13 +31,16 @@ export async function getNodeForStream(
 	const streamData = await riverRegistry.streamRegistry.read.getStream(streamId)
 
 	if (streamData.nodes.length === 0) {
-		const err = new Error(`No nodes found for stream ${streamId}`)
-		logger.error(`No nodes found for stream`, {
-			streamId,
-			err,
-		})
+		const error = new Error(`No nodes found for stream ${streamId}`)
+		logger.error(
+			{
+				streamId,
+				err: error,
+			},
+			'No nodes found for stream',
+		)
 
-		throw err
+		throw error
 	}
 
 	const lastMiniblockNum = streamData.lastMiniblockNum
@@ -45,11 +48,14 @@ export async function getNodeForStream(
 	const randomIndex = Math.floor(Math.random() * streamData.nodes.length)
 	const node = await riverRegistry.nodeRegistry.read.getNode(streamData.nodes[randomIndex])
 
-	logger.info(`connected to node`, {
-		streamId,
-		nodeUrl: node.url,
-		lastMiniblockNum,
-	})
+	logger.info(
+		{
+			streamId,
+			nodeUrl: node.url,
+			lastMiniblockNum,
+		},
+		'connected to node',
+	)
 
 	// Cache the result with a 15-minute expiration
 	cache[streamId] = {


### PR DESCRIPTION
my logger statements only print the 1st argument strings, and ate up the subsequent arguments. Turns out that pino logger expects the arguments in the reverse order. First argument has to be the object; the 2nd argument is the message string.

**does not work (2nd arg eaten):**
```typescript
const obj = { fruit: 'apple' }
logger.info('print this', obj) // output: "print this"
logger.info(spaceContractAddress, 'the space contract address') // output: 0x12345
```

**this works:**
```typescript
const obj = { fruit: 'apple' }
logger.info(obj, 'print this')
// output: "print this"
//                    fruit: "apple"

logger.info({ spaceContractAddress }, 'the space contract address')
// output: "the space contract address"
                        spaceContractAddress: 0x12345
```

