### PR TITLE
chore(sdk) remove unused transport type on makeStreamRpcClient

### DIFF
--- a/packages/sdk/src/makeStreamRpcClient.ts
+++ b/packages/sdk/src/makeStreamRpcClient.ts
@@ -9,41 +9,35 @@ const logInfo = dlog('csb:rpc:info')
 let nextRpcClientNum = 0
 
 export type StreamRpcClient = PromiseClient<typeof StreamService> & { url?: string }
+export type MakeRpcClientType = typeof makeStreamRpcClient
 
 export function makeStreamRpcClient(
-    dest: Transport | string,
+    dest: string,
     retryParams: RetryParams = { maxAttempts: 3, initialRetryDelay: 2000, maxRetryDelay: 6000 },
     refreshNodeUrl?: () => Promise<string>,
 ): StreamRpcClient {
     const transportId = nextRpcClientNum++
     logInfo('makeStreamRpcClient, transportId =', transportId)
-    let transport: Transport
-    let url: string | undefined
-    if (typeof dest === 'string') {
-        url = randomUrlSelector(dest)
-        logInfo('makeStreamRpcClient: Connecting to url=', url, ' allUrls=', dest)
-        const options: ConnectTransportOptions = {
-            baseUrl: url,
-            interceptors: [
-                retryInterceptor({ ...retryParams, refreshNodeUrl }),
-                loggingInterceptor(transportId),
-            ],
-        }
-        if (getEnvVar('RIVER_DEBUG_TRANSPORT') !== 'true') {
-            options.useBinaryFormat = true
-        } else {
-            logInfo('makeStreamRpcClient: running in debug mode, using JSON format')
-            options.useBinaryFormat = false
-            options.jsonOptions = {
-                emitDefaultValues: true,
-                useProtoFieldName: true,
-            }
-        }
-        transport = createConnectTransport(options)
-    } else {
-        logInfo('makeStreamRpcClient: Connecting to provided transport')
-        transport = dest
+    const url = randomUrlSelector(dest)
+    logInfo('makeStreamRpcClient: Connecting to url=', url, ' allUrls=', dest)
+    const options: ConnectTransportOptions = {
+        baseUrl: url,
+        interceptors: [
+            retryInterceptor({ ...retryParams, refreshNodeUrl }),
+            loggingInterceptor(transportId),
+        ],
     }
+    if (getEnvVar('RIVER_DEBUG_TRANSPORT') !== 'true') {
+        options.useBinaryFormat = true
+    } else {
+        logInfo('makeStreamRpcClient: running in debug mode, using JSON format')
+        options.useBinaryFormat = false
+        options.jsonOptions = {
+            emitDefaultValues: true,
+            useProtoFieldName: true,
+        }
+    }
+    const transport = createConnectTransport(options)
 
     const client: StreamRpcClient = createPromiseClient(StreamService, transport) as StreamRpcClient
     client.url = url

--- a/packages/sdk/src/makeStreamRpcClient.ts
+++ b/packages/sdk/src/makeStreamRpcClient.ts
@@ -1,4 +1,4 @@
-import { PromiseClient, Transport, createPromiseClient } from '@connectrpc/connect'
+import { PromiseClient, createPromiseClient } from '@connectrpc/connect'
 import { ConnectTransportOptions, createConnectTransport } from '@connectrpc/connect-web'
 import { StreamService } from '@river-build/proto'
 import { dlog } from '@river-build/dlog'


### PR DESCRIPTION
this was lingering from the very first implementation, it gets in the way when we want to override it with an http2 client in node.