### PR TITLE
removed parameter in setupRoutes

### DIFF
--- a/packages/stream-metadata/src/environment.ts
+++ b/packages/stream-metadata/src/environment.ts
@@ -7,14 +7,17 @@ dotenv.config({
 })
 
 const IntStringSchema = z.string().regex(/^[0-9]+$/)
+const BoolStringSchema = z.string().regex(/^(true|false)$/)
+
 const NumberFromIntStringSchema = IntStringSchema.transform((str) => parseInt(str, 10))
+const BoolFromStringSchema = BoolStringSchema.transform((str) => str === 'true')
 
 const envSchema = z.object({
 	RIVER_ENV: z.string(),
 	RIVER_CHAIN_RPC_URL: z.string().url(),
 	PORT: NumberFromIntStringSchema,
 	LOG_LEVEL: z.string().optional().default('info'),
-	LOG_PRETTY: z.boolean().optional().default(true),
+	LOG_PRETTY: BoolFromStringSchema.optional().default('true'),
 })
 
 function makeConfig() {

--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -49,16 +49,16 @@ async function registerPlugins() {
 	logger.info('CORS registered successfully')
 }
 
-export function setupRoutes(srv: Server) {
+function setupRoutes() {
 	/*
 	 * Routes
 	 */
-	srv.get('/health', async (request, reply) => {
+	server.get('/health', async (request, reply) => {
 		logger.info(`GET /health`)
 		return checkHealth(request, reply)
 	})
 
-	srv.get('/space/:spaceAddress', async (request, reply) => {
+	server.get('/space/:spaceAddress', async (request, reply) => {
 		const { spaceAddress } = request.params as { spaceAddress?: string }
 		logger.info({ spaceAddress }, 'GET /space/../metadata')
 
@@ -66,7 +66,7 @@ export function setupRoutes(srv: Server) {
 		return fetchSpaceMetadata(request, reply, `${protocol}://${serverAddress}`)
 	})
 
-	srv.get('/space/:spaceAddress/image', async (request, reply) => {
+	server.get('/space/:spaceAddress/image', async (request, reply) => {
 		const { spaceAddress } = request.params as { spaceAddress?: string }
 		logger.info({ spaceAddress }, 'GET /space/../image')
 
@@ -106,7 +106,7 @@ process.on('SIGTERM', async () => {
 async function main() {
 	try {
 		await registerPlugins()
-		setupRoutes(server)
+		setupRoutes()
 		await server.listen({ port: config.port })
 		logger.info('Server started')
 	} catch (error) {


### PR DESCRIPTION
line 77 had a reference to `server` directly whereas the other routes used the `srv` param. this pr attempts to simplify and standardize