### PR TITLE
add non-random aes-gcm encryption test

### DIFF
--- a/packages/sdk/src/crypto_utils.test.ts
+++ b/packages/sdk/src/crypto_utils.test.ts
@@ -3,7 +3,7 @@
  */
 
 import crypto from 'crypto'
-import { deriveKeyAndIV } from './crypto_utils'
+import { deriveKeyAndIV, encryptAESGCM } from './crypto_utils'
 
 describe('crypto_utils', () => {
     test('derivedKeyAndIV', async () => {


### PR DESCRIPTION
this PR adds a non-random AES-GCM encryption test. the purpose is to simplify the implementation of an identical encryption algorithm on other platforms.