### PR TITLE
Increase stress test timeout waiting for initial stream

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1009,7 +1009,7 @@ export class Client
 
     async waitForStream(
         inStreamId: string | Uint8Array,
-        opts?: { timeoutMs?: number },
+        opts?: { timeoutMs?: number; logId?: string },
     ): Promise<Stream> {
         this.logCall('waitForStream', inStreamId)
         const timeoutMs = opts?.timeoutMs ?? 15000
@@ -1023,7 +1023,13 @@ export class Client
         await new Promise<void>((resolve, reject) => {
             const timeout = setTimeout(() => {
                 this.off('streamInitialized', handler)
-                reject(new Error(`waitForStream: timeout waiting for ${streamId}`))
+                reject(
+                    new Error(
+                        `waitForStream: timeout waiting for ${
+                            opts?.logId ? opts.logId + ' ' : ''
+                        }${streamId}`,
+                    ),
+                )
             }, timeoutMs)
             const handler = (newStreamId: string) => {
                 if (newStreamId === streamId) {

--- a/packages/stress/src/mode/chat/joinChat.ts
+++ b/packages/stress/src/mode/chat/joinChat.ts
@@ -29,7 +29,10 @@ export async function joinChat(client: StressClient, cfg: ChatConfig) {
     // start up the client
     await startFollowerClient(client, cfg.spaceId, announceChannelId)
 
-    const announceChannel = await client.streamsClient.waitForStream(announceChannelId)
+    const announceChannel = await client.streamsClient.waitForStream(announceChannelId, {
+        timeoutMs: 1000 * 60,
+        logId: 'joinChatWaitForAnnounceChannel',
+    })
     let count = 0
     const message = await client.waitFor(
         () => {


### PR DESCRIPTION
We recently started seeing a few clients get dropped from the stress tests. 
Also I recently added a timeout in waitForStream. I guess 15 seconds wasn't enough, this is where the clients are dying.

Up the timeout for the join chat section where we wait for the announcement channel