### PR TITLE
react-sdk: support config in all hooks

### DIFF
--- a/packages/react-sdk/src/internals/useAction.ts
+++ b/packages/react-sdk/src/internals/useAction.ts
@@ -17,7 +17,7 @@ type ReturnOf<T> = Awaited<ReturnType<ActionFn<T>>>
 export const useAction = <Namespace, Key extends keyof Namespace, Fn extends Namespace[Key]>(
     namespace: Namespace,
     fnName: Key & string,
-    config: ActionConfig<Fn> = {},
+    config?: ActionConfig<Fn>,
 ) => {
     const [status, setStatus] = useState<'loading' | 'error' | 'success' | 'idle'>('idle')
     const [error, setError] = useState<Error | undefined>()
@@ -31,15 +31,16 @@ export const useAction = <Namespace, Key extends keyof Namespace, Fn extends Nam
             }
             setStatus('loading')
             try {
-                const data = await fn.apply(namespace, args)
-                setData(data as ReturnOf<Fn>)
+                const data = (await fn.apply(namespace, args)) as ReturnOf<Fn>
+                setData(data)
                 setStatus('success')
+                config?.onSuccess?.(data)
                 return data as ReturnOf<Fn>
             } catch (error: unknown) {
                 setStatus('error')
                 if (error instanceof Error) {
                     setError(error)
-                    config.onError?.(error)
+                    config?.onError?.(error)
                 }
                 // Let the caller handle the error
                 throw error

--- a/packages/react-sdk/src/useChannel.ts
+++ b/packages/react-sdk/src/useChannel.ts
@@ -1,17 +1,22 @@
 'use client'
 
 import { useMemo } from 'react'
+import type { Channel } from '@river-build/sdk'
 import { useSyncAgent } from './useSyncAgent'
-import { useObservable } from './useObservable'
+import { type ObservableConfig, useObservable } from './useObservable'
 
 /**
  *  Views a channel by its channelId and spaceId.
  */
-export const useChannel = (spaceId: string, channelId: string) => {
+export const useChannel = (
+    spaceId: string,
+    channelId: string,
+    config?: ObservableConfig.FromObservable<Channel>,
+) => {
     const sync = useSyncAgent()
     const channel = useMemo(
         () => sync.spaces.getSpace(spaceId).getChannel(channelId),
         [sync.spaces, spaceId, channelId],
     )
-    return useObservable(channel)
+    return useObservable(channel, config)
 }

--- a/packages/react-sdk/src/useCreateChannel.ts
+++ b/packages/react-sdk/src/useCreateChannel.ts
@@ -7,7 +7,7 @@ import { useSyncAgent } from './useSyncAgent'
 
 export const useCreateChannel = (
     spaceId: string,
-    config: ActionConfig<Space['createChannel']> = {},
+    config?: ActionConfig<Space['createChannel']>,
 ) => {
     const sync = useSyncAgent()
     const space = useMemo(() => sync.spaces.getSpace(spaceId), [spaceId, sync.spaces])

--- a/packages/react-sdk/src/useJoinSpace.ts
+++ b/packages/react-sdk/src/useJoinSpace.ts
@@ -4,7 +4,7 @@ import type { Spaces } from '@river-build/sdk'
 import { type ActionConfig, useAction } from './internals/useAction'
 import { useSyncAgent } from './useSyncAgent'
 
-export const useJoinSpace = (config: ActionConfig<Spaces['joinSpace']> = {}) => {
+export const useJoinSpace = (config?: ActionConfig<Spaces['joinSpace']>) => {
     const sync = useSyncAgent()
     const { action: joinSpace, ...rest } = useAction(sync.spaces, 'joinSpace', config)
 

--- a/packages/react-sdk/src/useObservable.ts
+++ b/packages/react-sdk/src/useObservable.ts
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useMemo, useSyncExternalStore } from 'react'
 import { type Observable, type PersistedModel } from '@river-build/sdk'
+import { isPersistedModel } from './utils'
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export declare namespace ObservableConfig {
@@ -44,16 +45,6 @@ type ObservableValue<Data> = Data extends PersistedModel<infer UnwrappedData>
           isLoaded: true
       }
 
-const isPersisted = <T>(value: T | PersistedModel<T>): value is PersistedModel<T> => {
-    if (typeof value !== 'object') {
-        return false
-    }
-    if (value === null) {
-        return false
-    }
-    return 'status' in value && 'data' in value
-}
-
 export function useObservable<T>(
     observable: Observable<T>,
     config?: ObservableConfig.FromData<T>,
@@ -69,7 +60,7 @@ export function useObservable<T>(
     )
 
     useEffect(() => {
-        if (isPersisted(value)) {
+        if (isPersistedModel(value)) {
             if (value.status === 'loaded') {
                 opts.onUpdate?.(value.data)
             }
@@ -82,7 +73,7 @@ export function useObservable<T>(
     }, [opts, value])
 
     const data = useMemo(() => {
-        if (isPersisted(value)) {
+        if (isPersistedModel(value)) {
             const { data, status } = value
             return {
                 data: data,

--- a/packages/react-sdk/src/useObservable.ts
+++ b/packages/react-sdk/src/useObservable.ts
@@ -2,20 +2,27 @@
 import { useEffect, useMemo, useSyncExternalStore } from 'react'
 import { type Observable, type PersistedModel } from '@river-build/sdk'
 
-// TODO: Some util props:
-// - select: select a subset of the data, or transform it
-// - remove onError is is not a persisted model data
-export type ObservableConfig<Data> = Data extends PersistedModel<infer UnwrappedData>
-    ? {
-          fireImmediately?: boolean
-          onUpdate?: (data: UnwrappedData) => void
-          onError?: (error: Error) => void
-      }
-    : {
-          fireImmediately?: boolean
-          onUpdate?: (data: Data) => void
-          onError?: (error: Error) => void
-      }
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export declare namespace ObservableConfig {
+    export type FromObservable<Observable_> = Observable_ extends Observable<infer Data>
+        ? FromData<Data>
+        : never
+
+    // TODO: Some util props:
+    // - select: select a subset of the data, or transform it
+    // - remove onError is is not a persisted model data
+    export type FromData<Data> = Data extends PersistedModel<infer UnwrappedData>
+        ? {
+              fireImmediately?: boolean
+              onUpdate?: (data: UnwrappedData) => void
+              onError?: (error: Error) => void
+          }
+        : {
+              fireImmediately?: boolean
+              onUpdate?: (data: Data) => void
+              onError?: (error: Error) => void
+          }
+}
 
 type ObservableValue<Data> = Data extends PersistedModel<infer UnwrappedData>
     ? {
@@ -49,12 +56,12 @@ const isPersisted = <T>(value: T | PersistedModel<T>): value is PersistedModel<T
 
 export function useObservable<T>(
     observable: Observable<T>,
-    config?: ObservableConfig<T>,
+    config?: ObservableConfig.FromData<T>,
 ): ObservableValue<T> {
     const opts = useMemo(
         () => ({ fireImmediately: true, ...config }),
         [config],
-    ) as ObservableConfig<T>
+    ) as ObservableConfig.FromData<T>
 
     const value = useSyncExternalStore(
         (subscriber) => observable.subscribe(subscriber, { fireImediately: opts?.fireImmediately }),

--- a/packages/react-sdk/src/useReaction.ts
+++ b/packages/react-sdk/src/useReaction.ts
@@ -8,7 +8,7 @@ import { useSyncAgent } from './useSyncAgent'
 export const useReaction = (
     spaceId: string,
     channelId: string,
-    config: ActionConfig<Channel['sendReaction']> = {},
+    config?: ActionConfig<Channel['sendReaction']>,
 ) => {
     const sync = useSyncAgent()
     const channel = useMemo(

--- a/packages/react-sdk/src/useRiver.ts
+++ b/packages/react-sdk/src/useRiver.ts
@@ -7,7 +7,7 @@ type SyncSelector = SyncAgent['observables']
 
 export function useRiver<T>(
     selector: (sync: SyncSelector) => Observable<T>,
-    config?: ObservableConfig<T>,
+    config?: ObservableConfig.FromData<T>,
 ) {
     const syncAgent = useSyncAgent()
     return useObservable(selector(syncAgent.observables), config)

--- a/packages/react-sdk/src/useRiverAuthStatus.ts
+++ b/packages/react-sdk/src/useRiverAuthStatus.ts
@@ -2,9 +2,10 @@
 
 import { AuthStatus } from '@river-build/sdk'
 import { useRiver } from './useRiver'
+import type { ObservableConfig } from './useObservable'
 
-export const useRiverAuthStatus = () => {
-    const { data: status } = useRiver((s) => s.riverAuthStatus)
+export const useRiverAuthStatus = (config?: ObservableConfig.FromObservable<AuthStatus>) => {
+    const { data: status } = useRiver((s) => s.riverAuthStatus, config)
     return {
         status,
         isInitializing: status === AuthStatus.Initializing,

--- a/packages/react-sdk/src/useSendMessage.ts
+++ b/packages/react-sdk/src/useSendMessage.ts
@@ -8,7 +8,7 @@ import { useSyncAgent } from './useSyncAgent'
 export const useSendMessage = (
     spaceId: string,
     channelId: string,
-    config: ActionConfig<Channel['sendMessage']> = {},
+    config?: ActionConfig<Channel['sendMessage']>,
 ) => {
     const sync = useSyncAgent()
     const channel = useMemo(

--- a/packages/react-sdk/src/useSpace.ts
+++ b/packages/react-sdk/src/useSpace.ts
@@ -1,11 +1,12 @@
 'use client'
 
 import { useMemo } from 'react'
+import type { Space } from '@river-build/sdk'
 import { useSyncAgent } from './useSyncAgent'
-import { useObservable } from './useObservable'
+import { type ObservableConfig, useObservable } from './useObservable'
 
-export const useSpace = (spaceId: string) => {
+export const useSpace = (spaceId: string, config?: ObservableConfig.FromObservable<Space>) => {
     const sync = useSyncAgent()
     const observable = useMemo(() => sync.spaces.getSpace(spaceId), [sync, spaceId])
-    return useObservable(observable)
+    return useObservable(observable, config)
 }

--- a/packages/react-sdk/src/useTimeline.tsx
+++ b/packages/react-sdk/src/useTimeline.tsx
@@ -1,12 +1,17 @@
 import { useMemo } from 'react'
+import type { TimelineEvents } from '@river-build/sdk'
 import { useSyncAgent } from './useSyncAgent'
-import { useObservable } from './useObservable'
+import { type ObservableConfig, useObservable } from './useObservable'
 
-export const useTimeline = (spaceId: string, channelId: string) => {
+export const useTimeline = (
+    spaceId: string,
+    channelId: string,
+    config?: ObservableConfig.FromObservable<TimelineEvents>,
+) => {
     const sync = useSyncAgent()
     const channel = useMemo(
         () => sync.spaces.getSpace(spaceId).getChannel(channelId),
         [sync.spaces, spaceId, channelId],
     )
-    return useObservable(channel.timeline.events)
+    return useObservable(channel.timeline.events, config)
 }

--- a/packages/react-sdk/src/useUserSpaces.ts
+++ b/packages/react-sdk/src/useUserSpaces.ts
@@ -1,6 +1,8 @@
+import type { Spaces } from '@river-build/sdk'
+import type { ObservableConfig } from './useObservable'
 import { useRiver } from './useRiver'
 
-export const useUserSpaces = () => {
-    const { data, ...rest } = useRiver((s) => s.spaces)
+export const useUserSpaces = (config?: ObservableConfig.FromObservable<Spaces>) => {
+    const { data, ...rest } = useRiver((s) => s.spaces, config)
     return { spaceIds: data.spaceIds, ...rest }
 }

--- a/packages/react-sdk/src/utils.ts
+++ b/packages/react-sdk/src/utils.ts
@@ -1,8 +1,11 @@
 import type { PersistedModel } from '@river-build/sdk'
 
-export const isPersistedModel = <T>(data: T | PersistedModel<T>): data is PersistedModel<T> => {
-    if (typeof data === 'object' && data !== null) {
-        return 'status' in data
+export const isPersistedModel = <T>(value: T | PersistedModel<T>): value is PersistedModel<T> => {
+    if (typeof value !== 'object') {
+        return false
     }
-    return false
+    if (value === null) {
+        return false
+    }
+    return 'status' in value && 'data' in value
 }


### PR DESCRIPTION
This PR adds support for config parameters in all observable hooks. The implementation is based in two utils:

```ts
export declare namespace ObservableConfig {
    export type FromObservable<Observable> = ...
    export type FromData<Data> = ...
}
```
Making it easy to create those `ObservableConfig` objects.
