### PR TITLE
Add sync stats to bad_prev_miniblock_hash message

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -2000,14 +2000,12 @@ export class Client
             retryCount = retryCount ?? 0
             if (errorContains(err, Err.BAD_PREV_MINIBLOCK_HASH) && retryCount < 3) {
                 const expectedHash = getRpcErrorProperty(err, 'expected')
-                this.logInfo(
-                    'RETRYING event after BAD_PREV_MINIBLOCK_HASH response',
+                this.logInfo('RETRYING event after BAD_PREV_MINIBLOCK_HASH response', {
+                    syncStats: this.streams.stats(),
                     retryCount,
-                    'prevHash:',
                     prevMiniblockHash,
-                    'expectedHash:',
                     expectedHash,
-                )
+                })
                 check(isDefined(expectedHash), 'expected hash not found in error')
                 return await this.makeEventWithHashAndAddToStream(
                     streamId,

--- a/packages/sdk/src/syncedStreams.ts
+++ b/packages/sdk/src/syncedStreams.ts
@@ -46,6 +46,10 @@ export class SyncedStreams {
         return this.syncedStreamsLoop?.pingInfo
     }
 
+    public stats() {
+        return this.syncedStreamsLoop?.stats()
+    }
+
     public has(streamId: string | Uint8Array): boolean {
         return this.streams.get(streamIdAsString(streamId)) !== undefined
     }

--- a/packages/sdk/src/syncedStreamsLoop.ts
+++ b/packages/sdk/src/syncedStreamsLoop.ts
@@ -140,6 +140,15 @@ export class SyncedStreamsLoop {
         return this._syncState
     }
 
+    public stats() {
+        return {
+            syncState: this.syncState,
+            streams: this.streams.size,
+            syncId: this.syncId,
+            queuedResponses: this.responsesQueue.length,
+        }
+    }
+
     public getSyncId(): string | undefined {
         return this.syncId
     }


### PR DESCRIPTION
Add sync stats to bad_prev_miniblock_hash message

I ran the stress tests locally and confirmed that when I get a "RETRYING event after BAD_PREV_MINIBLOCK_HASH response" message
I DO NOT have any stream responses queued, which implies that the streams are getting backed up in the node.