### PR TITLE
chore(contract): Add `InteractSetDefaultUri` script

### DIFF
--- a/contracts/scripts/interactions/InteractSetDefaultUri.s.sol
+++ b/contracts/scripts/interactions/InteractSetDefaultUri.s.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {LibString} from "solady/utils/LibString.sol";
+import {ISpaceOwner} from "contracts/src/spaces/facets/owner/ISpaceOwner.sol";
+import {Interaction} from "../common/Interaction.s.sol";
+
+contract InteractSetDefaultUri is Interaction {
+  string internal constant URI = "https://alpha.river.delivery/";
+
+  function __interact(address deployer) internal override {
+    // vm.setEnv("DEPLOYMENT_CONTEXT", "alpha");
+    address spaceOwner = getDeployment("spaceOwner");
+
+    vm.broadcast(deployer);
+    ISpaceOwner(spaceOwner).setDefaultUri(URI);
+
+    require(LibString.eq(ISpaceOwner(spaceOwner).getDefaultUri(), URI));
+  }
+}


### PR DESCRIPTION
Introduce `InteractSetDefaultUri` script to set the default URI for spaceFactory contracts. This script ensures the consistent URI configuration by using the `setDefaultUri` method from `ISpaceOwner` interface and validating it with a requirement check.