### PR TITLE
[stream-metadata] remove literal string values in log message

### DIFF
--- a/packages/stream-metadata/src/riverStreamRpcClient.ts
+++ b/packages/stream-metadata/src/riverStreamRpcClient.ts
@@ -45,11 +45,12 @@ async function getStreamClient(log: FastifyBaseLogger, streamId: `0x${string}`) 
 		clients.set(client.url!, client)
 		url = client.url!
 	}
-	logger.info({ url }, `client connected to node ${url}`)
+	logger.info({ url }, 'client connected to node')
 
 	const client = clients.get(url)
 	if (!client) {
-		throw new Error(`Failed to get client for url ${url}`)
+		logger.error({ url }, 'Failed to get client for url')
+		throw new Error('Failed to get client for url')
 	}
 
 	return { client, lastMiniblockNum: node.lastMiniblockNum }
@@ -98,7 +99,7 @@ async function mediaContentFromStreamView(
 			spaceId: mediaInfo.spaceId,
 			mediaStreamId: streamView.mediaContent.streamId,
 		},
-		`decrypting media content in stream ${streamView.mediaContent.streamId}`,
+		'decrypting media content in stream',
 	)
 
 	// Aggregate data chunks into a single Uint8Array
@@ -134,7 +135,7 @@ async function mediaContentFromStreamView(
 			mediaStreamId: streamView.mediaContent.streamId,
 			mimeType,
 		},
-		`decrypted media content in stream ${streamView.mediaContent.streamId}`,
+		'decrypted media content in stream',
 	)
 
 	// Return decrypted data and MIME type
@@ -171,7 +172,7 @@ export async function getStream(
 			streamId,
 			lastMiniblockNum: lastMiniblockNum.toString(),
 		},
-		`getStream ${streamId}`,
+		'getStream',
 	)
 
 	const start = Date.now()
@@ -185,7 +186,7 @@ export async function getStream(
 		{
 			duration_ms,
 		},
-		`getStream finished in ${duration_ms}ms`,
+		'getStream finished',
 	)
 
 	const unpackedResponse = await unpackStream(response.stream)

--- a/packages/stream-metadata/src/streamRegistry.ts
+++ b/packages/stream-metadata/src/streamRegistry.ts
@@ -19,7 +19,7 @@ export async function getNodeForStream(
 	streamId: StreamIdHex,
 ): Promise<{ url: string; lastMiniblockNum: BigNumber }> {
 	const logger = getFunctionLogger(log, 'getNodeForStream')
-	logger.info({ streamId }, `find node for stream ${streamId}`)
+	logger.info({ streamId }, 'find node for stream')
 
 	const now = Date.now()
 	const cachedData = cache[streamId]


### PR DESCRIPTION
@mechanical-turk and I went through a DataDog Log viewer exercise and created a debug view for stream-metadata that keeps the log messages simple without requiring template strings. Relevant values are shown as column data.

https://app.datadoghq.com/logs?query=service%3Astream-metadata%20env%3Aomega&cols=%40url%2C%40streamId%2C%40req.url%2C%40spaceAddress&fromUser=true&index=%2A&messageDisplay=expanded-md&refresh_mode=sliding&saved-view-id=2897198&storage=hot&stream_sort=desc&viz=stream&from_ts=1724264295799&to_ts=1724267895799&live=true