### PR TITLE
sdk: remove `decryptSpaceImage` from client

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -136,13 +136,7 @@ import { SyncState } from './syncedStreamsLoop'
 import { SyncedStream } from './syncedStream'
 import { SyncedStreamsExtension } from './syncedStreamsExtension'
 import { SignerContext } from './signerContext'
-import {
-    decryptAESGCM,
-    decryptDerivedAESGCM,
-    deriveKeyAndIV,
-    encryptAESGCM,
-    uint8ArrayToBase64,
-} from './crypto_utils'
+import { decryptAESGCM, deriveKeyAndIV, encryptAESGCM, uint8ArrayToBase64 } from './crypto_utils'
 
 export type ClientEvents = StreamEvents & DecryptionEvents
 
@@ -875,14 +869,6 @@ export class Client
             }),
             { method: 'updateUserBlock' },
         )
-    }
-
-    async decryptSpaceImage(spaceId: string, encryptedData: EncryptedData): Promise<ChunkedMedia> {
-        this.logCall('getDecryptedSpaceImage', spaceId)
-
-        const keyPhrase = contractAddressFromSpaceId(spaceId)
-        const plaintext = await decryptDerivedAESGCM(keyPhrase, encryptedData)
-        return ChunkedMedia.fromBinary(plaintext)
     }
 
     async setSpaceImage(spaceStreamId: string, chunkedMediaInfo: PlainMessage<ChunkedMedia>) {

--- a/packages/sdk/src/space.test.ts
+++ b/packages/sdk/src/space.test.ts
@@ -183,9 +183,7 @@ describe('spaceTests', () => {
                 isEncryptedData(encryptedData) &&
                 encryptedData.algorithm === AES_GCM_DERIVED_ALGORITHM,
         ).toBe(true)
-        const decrypted = encryptedData
-            ? await bobsClient.decryptSpaceImage(spaceId, encryptedData)
-            : undefined
+        const decrypted = await spaceStream.view.spaceContent.getSpaceImage()
         expect(
             decrypted !== undefined &&
                 decrypted.info?.mimetype === image.mimetype &&


### PR DESCRIPTION
This function is only used in `space.test.ts`, in order to check if the decryted image == original image. However, the stream view already does this, and we can call the `getSpaceImage()` from it, which will return the decrypted image.