### PR TITLE
Rename lingering device key functions to user metadata

### DIFF
--- a/core/node/rules/can_create_stream.go
+++ b/core/node/rules/can_create_stream.go
@@ -64,7 +64,7 @@ type csUserRules struct {
 	inception *UserPayload_Inception
 }
 
-type csUserDeviceKeyRules struct {
+type csUserMetadataRules struct {
 	params    *csParams
 	inception *UserMetadataPayload_Inception
 }
@@ -292,7 +292,7 @@ func (ru *csParams) canCreateStream() ruleBuilderCS {
 			requireChainAuth(ru.params.getNewUserStreamChainAuth)
 
 	case *UserMetadataPayload_Inception:
-		ru := &csUserDeviceKeyRules{
+		ru := &csUserMetadataRules{
 			params:    ru,
 			inception: inception,
 		}


### PR DESCRIPTION
I missed this in the initial rename