### PR TITLE
use cross-chain entitlements for reactions

### DIFF
--- a/core/node/auth/auth_impl.go
+++ b/core/node/auth/auth_impl.go
@@ -412,8 +412,9 @@ func (ca *chainAuth) isEntitledToChannelUncached(
 	log := dlog.FromCtx(ctx)
 	log.Debug("isEntitledToChannelUncached", "args", args)
 
-	// For read and write permissions, fetch the entitlements and evaluate them locally.
-	if (args.permission == PermissionRead) || (args.permission == PermissionWrite) {
+	// For read, write and react permissions, fetch the entitlements and evaluate them locally.
+	if (args.permission == PermissionRead) || (args.permission == PermissionWrite) ||
+		(args.permission == PermissionReact) {
 		result, cacheHit, err := ca.entitlementManagerCache.executeUsingCache(
 			ctx,
 			cfg,


### PR DESCRIPTION
this PR makes sure that we also check across chains for rule entitlements involving reactions, not just read/write.

see related code in `SpaceDapp.ts`:
https://github.com/river-build/river/blob/eae805df5e45d9a8cac21e5a1475ab9ea306aaca/packages/web3/src/v3/SpaceDapp.ts#L732-L736