### PR TITLE
Fix callstack on syncAgent observable timeout error

### DIFF
--- a/packages/sdk/src/observable/observable.ts
+++ b/packages/sdk/src/observable/observable.ts
@@ -44,15 +44,11 @@ export class Observable<T> {
         condition: (value: T) => boolean,
         opts: { timeoutMs: number; description?: string } = { timeoutMs: 5000 },
     ): Promise<T> {
+        const logId = opts.description ? ` ${opts.description}` : ''
+        const timeoutError = new Error(`Timeout waiting for condition${logId}`)
         return new Promise((resolve, reject) => {
             const timeoutHandle = setTimeout(() => {
-                reject(
-                    new Error(
-                        `Timeout waiting for condition${
-                            opts.description ? ': ' + opts.description : ''
-                        } `,
-                    ),
-                )
+                reject(timeoutError)
             }, opts.timeoutMs)
             this.subscribe(
                 (value) => {


### PR DESCRIPTION
before:
stress:run:0:error unhandled error: Error: Timeout waiting for condition at Timeout._onTimeout (/Users/austinellis/hnt/river/packages/sdk/src/observable/observable.ts:50:21)     at listOnTimeout (node:internal/timers:573:17)     at process.processTimers (node:internal/timers:514:7)

after:
stress:run:0:error unhandled error: Error: Timeout waiting for condition at Observable.when (/Users/austinellis/hnt/river/packages/sdk/src/observable/observable.ts:47:30) at Channel2.sendMessage (/Users/austinellis/hnt/river/packages/sdk/src/sync-agent/spaces/models/channel.ts:84:37) at StressClient.sendMessage (/Users/austinellis/hnt/river/packages/stress/src/utils/stressClient.ts:143:24) at kickoffChat (/Users/austinellis/hnt/river/packages/stress/src/mode/chat/kickoffChat.ts:35:65)     at process.processTicksAndRejections (node:internal/process/task_queues:95:5) at startStressChat (/Users/austinellis/hnt/river/packages/stress/src/mode/chat/root_chat.ts:139:9)