### PR TITLE
Extract kill-watches from tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -465,7 +465,7 @@
     {
       "label": "Kill Watches",
       "type": "shell",
-      "command": "echo 'killing watches' && kill $(ps -ax | grep 'yarn watch' | awk '{print $1}') && return 0",
+      "command": "./scripts/kill-watches.sh",
       "isBackground": false,
       "problemMatcher": [],
       "presentation": {

--- a/scripts/kill-watches.sh
+++ b/scripts/kill-watches.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -uo pipefail
+
+echo 'scripts/kill-watches.sh'
+watch_processes=$(ps -ax | grep 'yarn watch' | grep -v 'grep yarn watch' | awk '{print $1}')
+
+if [ -n "$watch_processes" ]; then
+    echo "killing watches $watch_processes"
+    kill $watch_processes
+else
+    echo 'no watches to kill'
+fi

--- a/scripts/kill-watches.sh
+++ b/scripts/kill-watches.sh
@@ -6,7 +6,7 @@ watch_processes=$(ps -ax | grep 'yarn watch' | grep -v 'grep yarn watch' | awk '
 
 if [ -n "$watch_processes" ]; then
     echo "killing watches $watch_processes"
-    kill $watch_processes
+    kill -- $watch_processes
 else
     echo 'no watches to kill'
 fi


### PR DESCRIPTION
For some reason it wasn’t working with cursor for me, and it’s nice to have this all as a bash command