### PR TITLE
sdk(sync-agent): flatten member onStreamInitialized 

### DIFF
--- a/packages/sdk/src/sync-agent/members/members.ts
+++ b/packages/sdk/src/sync-agent/members/members.ts
@@ -35,11 +35,21 @@ export class Members extends PersistedObservable<MembersModel> {
             client.on('streamNewUserJoined', this.onMemberJoin)
             client.on('streamNewUserInvited', this.onMemberInvite)
             client.on('streamUserLeft', this.onMemberLeave)
+            client.on('streamUsernameUpdated', this.onUsernameUpdated)
+            client.on('streamPendingUsernameUpdated', this.onUsernameUpdated)
+            client.on('streamNftUpdated', this.onNftUpdated)
+            client.on('streamEnsAddressUpdated', this.onEnsAddressUpdated)
+            client.on('streamDisplayNameUpdated', this.onDisplayNameUpdated)
             return () => {
                 client.off('streamInitialized', this.onStreamInitialized)
                 client.off('streamNewUserJoined', this.onMemberJoin)
                 client.off('streamNewUserInvited', this.onMemberInvite)
                 client.off('streamUserLeft', this.onMemberLeave)
+                client.off('streamUsernameUpdated', this.onUsernameUpdated)
+                client.off('streamPendingUsernameUpdated', this.onUsernameUpdated)
+                client.off('streamNftUpdated', this.onNftUpdated)
+                client.off('streamEnsAddressUpdated', this.onEnsAddressUpdated)
+                client.off('streamDisplayNameUpdated', this.onDisplayNameUpdated)
             }
         })
     }
@@ -167,5 +177,28 @@ export class Members extends PersistedObservable<MembersModel> {
                 )
             }
         }
+    }
+
+    private onUsernameUpdated = (streamId: string, userId: string): void => {
+        if (streamId !== this.data.id) return
+        const member = this.get(userId)
+        member.onUsernameUpdated(streamId, userId)
+    }
+
+    private onDisplayNameUpdated = (streamId: string, userId: string): void => {
+        if (streamId !== this.data.id) return
+        const member = this.get(userId)
+        member.onDisplayNameUpdated(streamId, userId)
+    }
+    private onNftUpdated = (streamId: string, userId: string): void => {
+        if (streamId !== this.data.id) return
+        const member = this.get(userId)
+        member.onNftUpdated(streamId, userId)
+    }
+
+    private onEnsAddressUpdated = (streamId: string, userId: string): void => {
+        if (streamId !== this.data.id) return
+        const member = this.get(userId)
+        member.onEnsAddressUpdated(streamId, userId)
     }
 }

--- a/packages/sdk/src/sync-agent/members/models/member.ts
+++ b/packages/sdk/src/sync-agent/members/models/member.ts
@@ -29,6 +29,12 @@ export class Member {
         }
     }
 
+    onStreamInitialized(streamId: string) {
+        for (const model of Object.values(this.observables)) {
+            model.onStreamInitialized(streamId)
+        }
+    }
+
     get username() {
         return this.observables.username.data.username
     }

--- a/packages/sdk/src/sync-agent/members/models/member.ts
+++ b/packages/sdk/src/sync-agent/members/models/member.ts
@@ -5,6 +5,7 @@ import { MemberDisplayName } from './metadata/displayName'
 import { MemberEnsAddress } from './metadata/ensAddress'
 import { MemberNft } from './metadata/nft'
 import { MemberUsername } from './metadata/username'
+import { MembershipOp } from '@river-build/proto'
 
 export class Member {
     observables: {
@@ -33,6 +34,26 @@ export class Member {
         for (const model of Object.values(this.observables)) {
             model.onStreamInitialized(streamId)
         }
+    }
+
+    onUsernameUpdated(streamId: string, userId: string) {
+        this.observables.username.onStreamUsernameUpdated(streamId, userId)
+    }
+
+    onDisplayNameUpdated(streamId: string, userId: string) {
+        this.observables.displayName.onStreamDisplayNameUpdated(streamId, userId)
+    }
+
+    onEnsAddressUpdated(streamId: string, userId: string) {
+        this.observables.ensAddress.onStreamEnsAddressUpdated(streamId, userId)
+    }
+
+    onNftUpdated(streamId: string, userId: string) {
+        this.observables.nft.onStreamNftUpdated(streamId, userId)
+    }
+
+    onMembershipUpdated(streamId: string, userId: string, op: MembershipOp) {
+        this.observables.membership.onStreamMembershipUpdated(streamId, userId, op)
     }
 
     get username() {

--- a/packages/sdk/src/sync-agent/members/models/membership.ts
+++ b/packages/sdk/src/sync-agent/members/models/membership.ts
@@ -13,8 +13,8 @@ export interface MemberMembershipModel extends Identifiable {
     op: MembershipOp
 }
 
-// The streamInitialized, streamNewUserInvited, streamNewUserJoined, streamUserLeft are not listened here.
-// They are listened in the members model, which propagates the updates to the membership model.
+// This model doenst listen to events here.
+// They are listened in the members model, which propagates the updates to this model.
 @persistedObservable({ tableName: 'member_membership' })
 export class MemberMembership extends PersistedObservable<MemberMembershipModel> {
     constructor(
@@ -44,11 +44,7 @@ export class MemberMembership extends PersistedObservable<MemberMembershipModel>
         }
     }
 
-    public onStreamMembershipUpdated = (
-        streamId: string,
-        userId: string,
-        op: MembershipOp.SO_JOIN | MembershipOp.SO_INVITE | MembershipOp.SO_LEAVE,
-    ) => {
+    public onStreamMembershipUpdated = (streamId: string, userId: string, op: MembershipOp) => {
         if (streamId === this.data.streamId && userId === this.data.id) {
             this.setData({ op })
         }

--- a/packages/sdk/src/sync-agent/members/models/metadata/displayName.ts
+++ b/packages/sdk/src/sync-agent/members/models/metadata/displayName.ts
@@ -15,6 +15,8 @@ export interface MemberDisplayNameModel extends Identifiable {
     isEncrypted?: boolean
 }
 
+// This model doenst listen to events here.
+// They are listened in the members model, which propagates the updates to this model.
 @persistedObservable({ tableName: 'member_displayName' })
 export class MemberDisplayName extends PersistedObservable<MemberDisplayNameModel> {
     constructor(
@@ -36,15 +38,6 @@ export class MemberDisplayName extends PersistedObservable<MemberDisplayNameMode
         )
     }
 
-    protected override async onLoaded() {
-        this.riverConnection.registerView((client) => {
-            client.on('streamDisplayNameUpdated', this.onStreamDisplayNameUpdated)
-            return () => {
-                client.off('streamDisplayNameUpdated', this.onStreamDisplayNameUpdated)
-            }
-        })
-    }
-
     public onStreamInitialized = (streamId: string) => {
         if (streamId === this.data.streamId) {
             const streamView = this.riverConnection.client?.stream(this.data.streamId)?.view
@@ -59,7 +52,7 @@ export class MemberDisplayName extends PersistedObservable<MemberDisplayNameMode
         }
     }
 
-    private onStreamDisplayNameUpdated = (streamId: string, userId: string) => {
+    public onStreamDisplayNameUpdated = (streamId: string, userId: string) => {
         if (streamId === this.data.streamId && userId === this.data.id) {
             const stream = this.riverConnection.client?.streams.get(streamId)
             const metadata = stream?.view.getMemberMetadata()

--- a/packages/sdk/src/sync-agent/members/models/metadata/displayName.ts
+++ b/packages/sdk/src/sync-agent/members/models/metadata/displayName.ts
@@ -38,22 +38,14 @@ export class MemberDisplayName extends PersistedObservable<MemberDisplayNameMode
 
     protected override async onLoaded() {
         this.riverConnection.registerView((client) => {
-            if (
-                client.streams.has(this.data.id) &&
-                client.streams.get(this.data.id)?.view.isInitialized
-            ) {
-                this.onStreamInitialized(this.data.id)
-            }
-            client.on('streamInitialized', this.onStreamInitialized)
             client.on('streamDisplayNameUpdated', this.onStreamDisplayNameUpdated)
             return () => {
-                client.off('streamInitialized', this.onStreamInitialized)
                 client.off('streamDisplayNameUpdated', this.onStreamDisplayNameUpdated)
             }
         })
     }
 
-    private onStreamInitialized = (streamId: string) => {
+    public onStreamInitialized = (streamId: string) => {
         if (streamId === this.data.streamId) {
             const streamView = this.riverConnection.client?.stream(this.data.streamId)?.view
             check(isDefined(streamView), 'streamView is not defined')

--- a/packages/sdk/src/sync-agent/members/models/metadata/ensAddress.ts
+++ b/packages/sdk/src/sync-agent/members/models/metadata/ensAddress.ts
@@ -32,22 +32,14 @@ export class MemberEnsAddress extends PersistedObservable<MemberEnsAddressModel>
 
     protected override async onLoaded() {
         this.riverConnection.registerView((client) => {
-            if (
-                client.streams.has(this.data.id) &&
-                client.streams.get(this.data.id)?.view.isInitialized
-            ) {
-                this.onStreamInitialized(this.data.id)
-            }
-            client.on('streamInitialized', this.onStreamInitialized)
             client.on('streamEnsAddressUpdated', this.onStreamEnsAddressUpdated)
             return () => {
-                client.off('streamInitialized', this.onStreamInitialized)
                 client.off('streamEnsAddressUpdated', this.onStreamEnsAddressUpdated)
             }
         })
     }
 
-    private onStreamInitialized = (streamId: string) => {
+    public onStreamInitialized = (streamId: string) => {
         if (streamId === this.data.streamId) {
             const streamView = this.riverConnection.client?.stream(this.data.streamId)?.view
             check(isDefined(streamView), 'streamView is not defined')

--- a/packages/sdk/src/sync-agent/members/models/metadata/ensAddress.ts
+++ b/packages/sdk/src/sync-agent/members/models/metadata/ensAddress.ts
@@ -15,6 +15,8 @@ export interface MemberEnsAddressModel extends Identifiable {
     ensAddress?: Address
 }
 
+// This model doenst listen to events here.
+// They are listened in the members model, which propagates the updates to this model.
 @persistedObservable({ tableName: 'member_ensAddress' })
 export class MemberEnsAddress extends PersistedObservable<MemberEnsAddressModel> {
     constructor(
@@ -30,15 +32,6 @@ export class MemberEnsAddress extends PersistedObservable<MemberEnsAddressModel>
         )
     }
 
-    protected override async onLoaded() {
-        this.riverConnection.registerView((client) => {
-            client.on('streamEnsAddressUpdated', this.onStreamEnsAddressUpdated)
-            return () => {
-                client.off('streamEnsAddressUpdated', this.onStreamEnsAddressUpdated)
-            }
-        })
-    }
-
     public onStreamInitialized = (streamId: string) => {
         if (streamId === this.data.streamId) {
             const streamView = this.riverConnection.client?.stream(this.data.streamId)?.view
@@ -49,7 +42,7 @@ export class MemberEnsAddress extends PersistedObservable<MemberEnsAddressModel>
         }
     }
 
-    private onStreamEnsAddressUpdated = (streamId: string, userId: string) => {
+    public onStreamEnsAddressUpdated = (streamId: string, userId: string) => {
         if (streamId === this.data.streamId && userId === this.data.id) {
             const stream = this.riverConnection.client?.streams.get(streamId)
             const metadata = stream?.view.getMemberMetadata()

--- a/packages/sdk/src/sync-agent/members/models/metadata/metadata.test.ts
+++ b/packages/sdk/src/sync-agent/members/models/metadata/metadata.test.ts
@@ -23,11 +23,12 @@ describe('metadata.test.ts', () => {
 
     test('update username', async () => {
         expect(bob).toBeDefined()
+        expect(bob.username).toBe('')
         await bob.setUsername('bob123')
         expect(bob.username).toBe('bob123')
     })
     test('update displayname', async () => {
-        expect(bob.displayName).toBe(undefined)
+        expect(bob.displayName).toBe('')
         await bob.setDisplayName('Bob')
         expect(bob.displayName).toBe('Bob')
     })

--- a/packages/sdk/src/sync-agent/members/models/metadata/nft.ts
+++ b/packages/sdk/src/sync-agent/members/models/metadata/nft.ts
@@ -36,23 +36,14 @@ export class MemberNft extends PersistedObservable<MemberNftModel> {
     }
     protected override async onLoaded() {
         this.riverConnection.registerView((client) => {
-            if (
-                client.streams.has(this.data.id) &&
-                client.streams.get(this.data.id)?.view.isInitialized
-            ) {
-                this.onStreamInitialized(this.data.id)
-            }
-            client.on('streamInitialized', this.onStreamInitialized)
-
             client.on('streamNftUpdated', this.onStreamNftUpdated)
             return () => {
-                client.off('streamInitialized', this.onStreamInitialized)
                 client.off('streamNftUpdated', this.onStreamNftUpdated)
             }
         })
     }
 
-    private onStreamInitialized = (streamId: string) => {
+    public onStreamInitialized = (streamId: string) => {
         if (streamId === this.data.streamId) {
             const streamView = this.riverConnection.client?.stream(this.data.streamId)?.view
             check(isDefined(streamView), 'streamView is not defined')

--- a/packages/sdk/src/sync-agent/members/models/metadata/nft.ts
+++ b/packages/sdk/src/sync-agent/members/models/metadata/nft.ts
@@ -20,6 +20,8 @@ export interface MemberNftModel extends Identifiable {
     nft?: NftModel
 }
 
+// This model doenst listen to events here.
+// They are listened in the members model, which propagates the updates to this model.
 @persistedObservable({ tableName: 'member_nft' })
 export class MemberNft extends PersistedObservable<MemberNftModel> {
     constructor(
@@ -33,14 +35,6 @@ export class MemberNft extends PersistedObservable<MemberNftModel> {
             store,
             LoadPriority.high,
         )
-    }
-    protected override async onLoaded() {
-        this.riverConnection.registerView((client) => {
-            client.on('streamNftUpdated', this.onStreamNftUpdated)
-            return () => {
-                client.off('streamNftUpdated', this.onStreamNftUpdated)
-            }
-        })
     }
 
     public onStreamInitialized = (streamId: string) => {
@@ -62,7 +56,7 @@ export class MemberNft extends PersistedObservable<MemberNftModel> {
         }
     }
 
-    private onStreamNftUpdated = (streamId: string, userId: string) => {
+    public onStreamNftUpdated = (streamId: string, userId: string) => {
         if (streamId === this.data.streamId && userId === this.data.id) {
             const streamView = this.riverConnection.client?.stream(streamId)?.view
             const metadata = streamView?.getMemberMetadata()

--- a/packages/sdk/src/sync-agent/members/models/metadata/username.ts
+++ b/packages/sdk/src/sync-agent/members/models/metadata/username.ts
@@ -16,6 +16,8 @@ export interface MemberUsernameModel extends Identifiable {
     isUsernameEncrypted: boolean
 }
 
+// This model doenst listen to events here.
+// They are listened in the members model, which propagates the updates to this model.
 @persistedObservable({ tableName: 'member_username' })
 export class MemberUsername extends PersistedObservable<MemberUsernameModel> {
     constructor(
@@ -38,17 +40,6 @@ export class MemberUsername extends PersistedObservable<MemberUsernameModel> {
         )
     }
 
-    protected override async onLoaded() {
-        this.riverConnection.registerView((client) => {
-            client.on('streamUsernameUpdated', this.onStreamUsernameUpdated)
-            client.on('streamPendingUsernameUpdated', this.onStreamUsernameUpdated)
-            return () => {
-                client.off('streamUsernameUpdated', this.onStreamUsernameUpdated)
-                client.off('streamPendingUsernameUpdated', this.onStreamUsernameUpdated)
-            }
-        })
-    }
-
     public onStreamInitialized = (streamId: string) => {
         if (streamId === this.data.streamId) {
             const streamView = this.riverConnection.client?.stream(this.data.streamId)?.view
@@ -64,7 +55,7 @@ export class MemberUsername extends PersistedObservable<MemberUsernameModel> {
         }
     }
 
-    private onStreamUsernameUpdated = (streamId: string, userId: string) => {
+    public onStreamUsernameUpdated = (streamId: string, userId: string) => {
         if (streamId === this.data.streamId && userId === this.data.id) {
             const stream = this.riverConnection.client?.streams.get(streamId)
             const metadata = stream?.view.getMemberMetadata()

--- a/packages/sdk/src/sync-agent/members/models/metadata/username.ts
+++ b/packages/sdk/src/sync-agent/members/models/metadata/username.ts
@@ -40,24 +40,16 @@ export class MemberUsername extends PersistedObservable<MemberUsernameModel> {
 
     protected override async onLoaded() {
         this.riverConnection.registerView((client) => {
-            if (
-                client.streams.has(this.data.id) &&
-                client.streams.get(this.data.id)?.view.isInitialized
-            ) {
-                this.onStreamInitialized(this.data.id)
-            }
-            client.on('streamInitialized', this.onStreamInitialized)
             client.on('streamUsernameUpdated', this.onStreamUsernameUpdated)
             client.on('streamPendingUsernameUpdated', this.onStreamUsernameUpdated)
             return () => {
-                client.off('streamInitialized', this.onStreamInitialized)
                 client.off('streamUsernameUpdated', this.onStreamUsernameUpdated)
                 client.off('streamPendingUsernameUpdated', this.onStreamUsernameUpdated)
             }
         })
     }
 
-    private onStreamInitialized = (streamId: string) => {
+    public onStreamInitialized = (streamId: string) => {
         if (streamId === this.data.streamId) {
             const streamView = this.riverConnection.client?.stream(this.data.streamId)?.view
             check(isDefined(streamView), 'streamView is not defined')

--- a/packages/sdk/src/sync-agent/river-connection/riverConnection.ts
+++ b/packages/sdk/src/sync-agent/river-connection/riverConnection.ts
@@ -161,7 +161,7 @@ export class RiverConnection extends PersistedObservable<RiverConnectionModel> {
             this.clientParams.logNamespaceFilter,
             this.clientParams.highPriorityStreamIds,
         )
-        client.setMaxListeners(5000)
+        client.setMaxListeners(100)
         this.client = client
         // initialize views
         this.store.withTransaction('RiverConnection::onNewClient', () => {


### PR DESCRIPTION
Previously, all member metadata models were listening to the stream initialized event, causing unneeded subscriptions.

`Membership` model was listening to `streamNewUserJoined`, which is an unneeded listening, since this model lives in the `Member` model, which lives in the `Members` model, which gets the `streamNewUserJoined` too to update the member state.