### PR TITLE
enable caching on the stream-metadata service

### DIFF
--- a/packages/stream-metadata/src/environment.ts
+++ b/packages/stream-metadata/src/environment.ts
@@ -18,6 +18,7 @@ const envSchema = z.object({
 	BASE_CHAIN_RPC_URL: z.string().url(),
 	PORT: NumberFromIntStringSchema,
 	HOST: z.string().optional().default('127.0.0.1'),
+	ENABLE_CACHE: BoolFromStringSchema.optional().default('true'),
 	LOG_LEVEL: z.string().optional().default('info'),
 	LOG_PRETTY: BoolFromStringSchema.optional().default('true'),
 })
@@ -34,6 +35,7 @@ function makeConfig() {
 		riverChainRpcUrl: env.RIVER_CHAIN_RPC_URL,
 		host: env.HOST,
 		port: env.PORT,
+		enableCache: env.ENABLE_CACHE,
 		log: {
 			level: env.LOG_LEVEL,
 			pretty: env.LOG_PRETTY,

--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -26,6 +26,7 @@ logger.info(
 		riverRegistry: config.web3Config.river.addresses.riverRegistry,
 		riverChainRpcUrl: config.riverChainRpcUrl,
 		baseChainRpcUrl: config.baseChainRpcUrl,
+		enableCache: config.enableCache,
 	},
 	'config',
 )

--- a/packages/stream-metadata/src/riverStreamRpcClient.ts
+++ b/packages/stream-metadata/src/riverStreamRpcClient.ts
@@ -207,11 +207,11 @@ export async function getMediaStreamContent(
 
 	const secretHex = toHexString(secret)
 	const ivHex = toHexString(iv)
+	const cacheKey = `${fullStreamId}${secretHex}${ivHex}`
 
 	if (config.enableCache) {
-		const concatenatedString = `${fullStreamId}${secretHex}${ivHex}`
-	if (contentCache[concatenatedString]) {
-		return contentCache[concatenatedString]
+		if (contentCache[cacheKey]) {
+		return contentCache[cacheKey]
 		}
 	}
 
@@ -226,8 +226,7 @@ export async function getMediaStreamContent(
 	const result = await mediaContentFromStreamView(logger, sv, secret, iv)
 
 	// Cache the result
-	const concatenatedString = `${fullStreamId}${secretHex}${ivHex}`
-	contentCache[concatenatedString] = result
+	contentCache[cacheKey] = result
 
 	return result
 }

--- a/packages/stream-metadata/src/riverStreamRpcClient.ts
+++ b/packages/stream-metadata/src/riverStreamRpcClient.ts
@@ -15,6 +15,7 @@ import { FastifyBaseLogger } from 'fastify'
 import { MediaContent, StreamIdHex } from './types'
 import { getNodeForStream } from './streamRegistry'
 import { getFunctionLogger } from './logger'
+import { config } from './environment'
 
 const clients = new Map<string, StreamRpcClient>()
 
@@ -207,11 +208,12 @@ export async function getMediaStreamContent(
 	const secretHex = toHexString(secret)
 	const ivHex = toHexString(iv)
 
-	/*
+	if (config.enableCache) {
+		const concatenatedString = `${fullStreamId}${secretHex}${ivHex}`
 	if (contentCache[concatenatedString]) {
-		return contentCache[concatenatedString];
+		return contentCache[concatenatedString]
+		}
 	}
-	*/
 
 	const streamId = stripHexPrefix(fullStreamId)
 	const sv = await getStream(logger, streamId)

--- a/packages/stream-metadata/tests/testUtils.ts
+++ b/packages/stream-metadata/tests/testUtils.ts
@@ -20,6 +20,8 @@ import { config } from '../src/environment'
 import { getRiverRegistry } from '../src/evmRpcClient'
 import { StreamRpcClient } from '../src/riverStreamRpcClient'
 
+export type ImageMimeType = 'image/jpeg' | 'image/png' // for testing purposes
+
 export function isTest(): boolean {
 	return (
 		process.env.NODE_ENV === 'test' ||
@@ -102,13 +104,21 @@ export async function makeUserContext(wallet: ethers.Wallet): Promise<SignerCont
 	return makeSignerContext(userPrimaryWallet, delegateWallet, { days: 1 })
 }
 
-export function makeJpegBlob(fillSize: number): {
+export function makeImageBlob(mimeType: ImageMimeType, fillSize: number): {
 	magicBytes: number[]
 	data: Uint8Array
 	info: MediaInfo
 } {
-	// Example of JPEG magic bytes (0xFF 0xD8 0xFF)
-	const magicBytes = [0xff, 0xd8, 0xff]
+	let magicBytes: number[]
+	
+	// Determine magic bytes based on the MIME type
+	if (mimeType === 'image/jpeg') {
+		magicBytes = [0xff, 0xd8, 0xff]
+	} else if (mimeType === 'image/png') {
+		magicBytes = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+	} else {
+		throw new Error(`Unsupported image mime type: ${mimeType}`)
+	}
 
 	// Create a Uint8Array with the size including magic bytes
 	const data = new Uint8Array(fillSize + magicBytes.length)
@@ -125,7 +135,7 @@ export function makeJpegBlob(fillSize: number): {
 		magicBytes,
 		data,
 		info: new MediaInfo({
-			mimetype: 'image/jpeg', // Set the expected MIME type
+			mimetype: mimeType, // Set the expected MIME type
 			sizeBytes: BigInt(data.length),
 		}),
 	}


### PR DESCRIPTION
Branch off from [PR 860](https://github.com/river-build/river/pull/860).

- enable image caching using the streamId+secret+iv as the cache key
- add test to verify that the updated space image is returned correctly with caching enabled
- add an optional env config to enable / disable cache. Enabled by default.