### PR TITLE
Remove datadogRum from the sdk

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -26,7 +26,6 @@
         "@bufbuild/protobuf": "^1.9.0",
         "@connectrpc/connect": "^1.4.0",
         "@connectrpc/connect-web": "^1.4.0",
-        "@datadog/browser-rum": "^5.8.0",
         "@ethereumjs/util": "^8.0.1",
         "@river-build/dlog": "workspace:^",
         "@river-build/encryption": "workspace:^",

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-redundant-type-constituents */
 import { Message, PlainMessage } from '@bufbuild/protobuf'
-import { datadogRum } from '@datadog/browser-rum'
 import { Permission } from '@river-build/web3'
 import {
     MembershipOp,
@@ -348,10 +347,7 @@ export class Client
         this.syncedStreamsExtensions.start()
         const initializeUserEndTime = performance.now()
         const executionTime = initializeUserEndTime - initializeUserStartTime
-
-        datadogRum.addAction('userInitializationDuration', {
-            userInitializationDuration: executionTime,
-        })
+        this.logCall('initializeUser::executionTime', executionTime)
     }
 
     private async initUserStream(metadata: { spaceId: Uint8Array } | undefined) {

--- a/packages/sdk/src/syncedStreamsExtension.ts
+++ b/packages/sdk/src/syncedStreamsExtension.ts
@@ -10,7 +10,6 @@ import { check, dlog, dlogError } from '@river-build/dlog'
 import { Stream } from './stream'
 import { ClientInitStatus } from './types'
 import pLimit from 'p-limit'
-import { datadogRum } from '@datadog/browser-rum'
 
 interface StreamSyncItem {
     streamId: string
@@ -105,7 +104,7 @@ export class SyncedStreamsExtension {
             const initStreamsEndTime = performance.now()
             const executionTime = initStreamsEndTime - this.initStreamsStartTime
 
-            datadogRum.addAction('streamInitializationDuration', {
+            this.log('streamInitializationDuration', {
                 streamInitializationDuration: executionTime,
                 streamsInitializedFromCache: this.numStreamsLoadedFromCache,
                 streamsInitializedFromNetwork: this.numStreamsLoadedFromNetwork,

--- a/yarn.lock
+++ b/yarn.lock
@@ -743,37 +743,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/browser-core@npm:5.8.0":
-  version: 5.8.0
-  resolution: "@datadog/browser-core@npm:5.8.0"
-  checksum: 3282c104976b7e151a3db5d67100b2b98714d092f3c8395cf8dbafd6db470a83ef54a61ffb1e2a171e147145a95a0a0af50918baa5a14251996b8c68788a5c0b
-  languageName: node
-  linkType: hard
-
-"@datadog/browser-rum-core@npm:5.8.0":
-  version: 5.8.0
-  resolution: "@datadog/browser-rum-core@npm:5.8.0"
-  dependencies:
-    "@datadog/browser-core": 5.8.0
-  checksum: b99d5dbe5dc2b9976362a5028cf97cd8f274b65729e92f3d8086e24c540ad987ae558e8f246a6b10ff41bf27c3679b8d43736b462411a3ad06cd9b9d9d72de80
-  languageName: node
-  linkType: hard
-
-"@datadog/browser-rum@npm:^5.8.0":
-  version: 5.8.0
-  resolution: "@datadog/browser-rum@npm:5.8.0"
-  dependencies:
-    "@datadog/browser-core": 5.8.0
-    "@datadog/browser-rum-core": 5.8.0
-  peerDependencies:
-    "@datadog/browser-logs": 5.8.0
-  peerDependenciesMeta:
-    "@datadog/browser-logs":
-      optional: true
-  checksum: ca564c4a23c3b2d2343c048c74ca03774a90c32bac8aea29050ed286a3698d4a071fa00ea7a629543df6bcbc88595f9b78dd8fa032be623819100110dfbd996b
-  languageName: node
-  linkType: hard
-
 "@effect/data@npm:0.12.9":
   version: 0.12.9
   resolution: "@effect/data@npm:0.12.9"
@@ -3784,7 +3753,6 @@ __metadata:
     "@bufbuild/protobuf": ^1.9.0
     "@connectrpc/connect": ^1.4.0
     "@connectrpc/connect-web": ^1.4.0
-    "@datadog/browser-rum": ^5.8.0
     "@ethereumjs/util": ^8.0.1
     "@jest/globals": ^29.6.2
     "@river-build/dlog": "workspace:^"


### PR DESCRIPTION
we don’t use it any more and all telemetry is captured in app