### PR TITLE
sdk(sync-agent): don't treat Myself model as special

### DIFF
--- a/packages/react-sdk/src/useDisplayName.ts
+++ b/packages/react-sdk/src/useDisplayName.ts
@@ -3,7 +3,7 @@ import { ObservableConfig, useObservable } from './useObservable'
 import { type ActionConfig, useAction } from './internals/useAction'
 
 export const useDisplayName = (
-    member: Member,
+    member: Member | Myself,
     config?: ObservableConfig.FromObservable<MemberDisplayName>,
 ) => {
     const { data, ...rest } = useObservable(member?.observables.displayName, config)

--- a/packages/react-sdk/src/useEnsAddress.ts
+++ b/packages/react-sdk/src/useEnsAddress.ts
@@ -3,7 +3,7 @@ import { ObservableConfig, useObservable } from './useObservable'
 import { type ActionConfig, useAction } from './internals/useAction'
 
 export const useEnsAddress = (
-    member: Member,
+    member: Member | Myself,
     config?: ObservableConfig.FromObservable<MemberEnsAddress>,
 ) => {
     const { data, ...rest } = useObservable(member?.observables.ensAddress, config)

--- a/packages/react-sdk/src/useNft.ts
+++ b/packages/react-sdk/src/useNft.ts
@@ -2,7 +2,10 @@ import type { Member, MemberNft, Myself } from '@river-build/sdk'
 import { ObservableConfig, useObservable } from './useObservable'
 import { type ActionConfig, useAction } from './internals/useAction'
 
-export const useNft = (member: Member, config?: ObservableConfig.FromObservable<MemberNft>) => {
+export const useNft = (
+    member: Member | Myself,
+    config?: ObservableConfig.FromObservable<MemberNft>,
+) => {
     const { data, ...rest } = useObservable(member?.observables.nft, config)
     return {
         ...data,

--- a/packages/react-sdk/src/useUsername.ts
+++ b/packages/react-sdk/src/useUsername.ts
@@ -3,7 +3,7 @@ import { ObservableConfig, useObservable } from './useObservable'
 import { type ActionConfig, useAction } from './internals/useAction'
 
 export const useUsername = (
-    member: Member,
+    member: Member | Myself,
     config?: ObservableConfig.FromObservable<MemberUsername>,
 ) => {
     const { data, ...rest } = useObservable(member?.observables.username, config)

--- a/packages/sdk/src/sync-agent/members/models/myself.ts
+++ b/packages/sdk/src/sync-agent/members/models/myself.ts
@@ -1,17 +1,37 @@
 import type { Address } from '@river-build/web3'
-import type { Store } from '../../../store/store'
 import type { RiverConnection } from '../../river-connection/riverConnection'
 import { type NftModel } from './metadata/nft'
 import { addressFromUserId } from '../../../id'
 import { Member } from './member'
 
-export class Myself extends Member {
+export class Myself {
+    observables: Member['observables']
     constructor(
-        private streamId: string,
+        public member: Member,
+        protected streamId: string,
         protected riverConnection: RiverConnection,
-        store: Store,
     ) {
-        super(riverConnection.userId, streamId, riverConnection, store)
+        this.observables = member.observables
+    }
+
+    get username() {
+        return this.member.username
+    }
+
+    get displayName() {
+        return this.member.displayName
+    }
+
+    get ensAddress() {
+        return this.member.ensAddress
+    }
+
+    get nft() {
+        return this.member.nft
+    }
+
+    get membership() {
+        return this.member.membership
     }
 
     async setUsername(username: string) {


### PR DESCRIPTION
Previously, the Myself model was extending a Member model, which required some special treatment to avoid creating it twice.

Now, the `Myself` model is wrapping a Member with some set actions, removing the cognitive overhead when changing the `Members` model, since we dont need to keep the special myself case in mind when doing changes.