### PR TITLE
Short-circuit ruleData evaluation when first good result is found

### DIFF
--- a/packages/web3/src/Utils.ts
+++ b/packages/web3/src/Utils.ts
@@ -29,7 +29,7 @@ export class NoEntitledWalletError extends Error {
      * @returns undefined
      * @throws AggregateError
      */
-    static throwIfRuntimeErrors(error: AggregateError) {
+    static throwIfRuntimeErrors = (error: AggregateError) => {
         const runtimeErrors = error.errors.filter(
             (e) => !(e instanceof NoEntitledWalletError),
         ) as Error[]

--- a/packages/web3/src/Utils.ts
+++ b/packages/web3/src/Utils.ts
@@ -9,6 +9,37 @@ export const MOCK_ADDRESS = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
 export const MOCK_ADDRESS_2 = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbee2'
 export const MOCK_ADDRESS_3 = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbee3'
 
+export class NoEntitledWalletError extends Error {
+    constructor() {
+        super('No entitled wallet found')
+        this.name = 'NoEntitledWalletError'
+
+        // Setting the prototype is necessary for instanceof to work correctly
+        // It ensures that instanceof NoEntitledWalletError returns true
+        // This is because TypeScript's class syntax doesn't set up the prototype chain correctly for custom errors
+        Object.setPrototypeOf(this, NoEntitledWalletError.prototype)
+    }
+
+    /**
+     * throwIfRuntimeErrors is a helper function to process AggregateErrors emitted from Promise.any that may
+     * contain promises rejected with NoEntitledWalletErrors, which represent an entitlement check that evaluates
+     * to false, and not a true error condition. This method will filter out NoEntitledWalletErrors and throw an
+     * AggregateError with the remaining errors, if any exist. Otherwise, it will simply return undefined.
+     * @param error AggregateError
+     * @returns undefined
+     * @throws AggregateError
+     */
+    static throwIfRuntimeErrors(error: AggregateError) {
+        const runtimeErrors = error.errors.filter(
+            (e) => !(e instanceof NoEntitledWalletError),
+        ) as Error[]
+        if (runtimeErrors.length > 0) {
+            throw new AggregateError(runtimeErrors)
+        }
+        return undefined
+    }
+}
+
 export function isEthersProvider(
     provider: ethers.providers.Provider | PublicClient,
 ): provider is ethers.providers.Provider {

--- a/packages/web3/src/v3/SpaceDapp.ts
+++ b/packages/web3/src/v3/SpaceDapp.ts
@@ -35,7 +35,7 @@ import {
 } from './index'
 import { PricingModules } from './PricingModules'
 import { dlogger, isJest } from '@river-build/dlog'
-import { EVERYONE_ADDRESS, stringifyChannelMetadataJSON } from '../Utils'
+import { EVERYONE_ADDRESS, stringifyChannelMetadataJSON, NoEntitledWalletError } from '../Utils'
 import { evaluateOperationsForEntitledWallet, ruleDataToOperations } from '../entitlement'
 import { RuleEntitlementShim } from './RuleEntitlementShim'
 import { PlatformRequirements } from './PlatformRequirements'
@@ -707,9 +707,11 @@ export class SpaceDapp implements ISpaceDapp {
                 if (result !== ethers.constants.AddressZero) {
                     return result
                 }
-                throw new Error('No entitled wallet found for this rule')
+                // This is not a true error, but is used here so that the Promise.any will not
+                // resolve with an unentitled wallet.
+                throw new NoEntitledWalletError()
             }),
-        ).catch(() => undefined)
+        ).catch(NoEntitledWalletError.throwIfRuntimeErrors)
     }
 
     /**

--- a/packages/web3/tsconfig.json
+++ b/packages/web3/tsconfig.json
@@ -4,5 +4,5 @@
         "baseUrl": "./src" /* Specify the root folder within your source files. */,
         "outDir": "./dist" /* Specify an output folder for all emitted files. */
     },
-    "include": ["src/**/*"]
+    "include": ["src/**/*", "tests/**/*"]
 }

--- a/packages/web3/tsconfig.json
+++ b/packages/web3/tsconfig.json
@@ -4,5 +4,5 @@
         "baseUrl": "./src" /* Specify the root folder within your source files. */,
         "outDir": "./dist" /* Specify an output folder for all emitted files. */
     },
-    "include": ["src/**/*", "tests/**/*"]
+    "include": ["src/**/*"]
 }


### PR DESCRIPTION
This underlying call now uses a promise.any and throws an error for a non-entitled result to ensure the promise will terminate as soon as an entitled wallet is found.