### PR TITLE
Improve waitForStream error message and cleanup streams after failed createStreamAndSync

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -520,6 +520,8 @@ export class Client
                 await this.streams.addStreamToSync(stream.view.syncCookie)
             }
         } catch (err) {
+            this.logError('Failed to initialize stream', streamId)
+            this.streams.delete(streamId)
             this.creatingStreamIds.delete(streamId)
             throw err
         }
@@ -1076,7 +1078,11 @@ export class Client
             return stream
         }
         const logId = opts?.logId ? opts.logId + ' ' : ''
-        const timeoutError = new Error(`waitForStream: timeout waiting for ${logId}${streamId}`)
+        const timeoutError = new Error(
+            `waitForStream: timeout waiting for ${logId}${streamId} creating streams: ${Array.from(
+                this.creatingStreamIds,
+            ).join(',')}`,
+        )
         await new Promise<void>((resolve, reject) => {
             const timeout = setTimeout(() => {
                 this.off('streamInitialized', handler)


### PR DESCRIPTION
I’m seeing this in the stress test logs

```
2024-08-28T20:07:41.449Z stress:run:2:error client22:0xFCc3..887d error calling joinChat Error: waitForStream: timeout waiting for 10a38bcf15ab6b94d404c201dee9f67c6428c0ecb10000000000000000000000 at TransactionalClient.waitForStream (/monorepo/packages/sdk/src/client.ts:1075:30) at TransactionalClient.initStream (/monorepo/packages/sdk/src/client.ts:1221:33) at TransactionalClient.joinStream (/monorepo/packages/sdk/src/client.ts:1681:35) at <anonymous> (/monorepo/packages/sdk/src/sync-agent/spaces/models/space.ts:88:26) at RiverConnection2.call (/monorepo/packages/sdk/src/sync-agent/river-connection/riverConnection.ts:108:20) at Space3.join (/monorepo/packages/sdk/src/sync-agent/spaces/models/space.ts:87:36) at process.processTicksAndRejections (node:internal/process/task_queues:95:5) at async startFollowerClient (/monorepo/packages/stress/src/mode/chat/joinChat.ts:113:13) at async joinChat (/monorepo/packages/stress/src/mode/chat/joinChat.ts:30:5) at async Promise.allSettled (index 2)
```

Hopefully after this change 40/40 bots will start joining the stress channel again.