### PR TITLE
Add helper functions to generate and parse “auth token”

### DIFF
--- a/packages/sdk/src/signerContext.ts
+++ b/packages/sdk/src/signerContext.ts
@@ -124,7 +124,7 @@ export async function makeAuthToken(
 ): Promise<string> {
     const delegate = await makeSignerDelegate(signer, expiry)
     const authToken = new AuthToken({
-        privateKey: delegate.delegateWallet.privateKey,
+        delegatePrivateKey: delegate.delegateWallet.privateKey,
         delegateSig: delegate.signerContext.delegateSig,
         expiryEpochMs: delegate.signerContext.delegateExpiryEpochMs,
     })
@@ -133,14 +133,14 @@ export async function makeAuthToken(
 
 export async function makeSignerContextFromAuthToken(authTokenStr: string): Promise<SignerContext> {
     const authToken = AuthToken.fromBinary(hexToBytes(authTokenStr))
-    const wallet = new ethers.Wallet(authToken.privateKey)
+    const delegateWallet = new ethers.Wallet(authToken.delegatePrivateKey)
     const creatorAddress = recoverPublicKeyFromDelegateSig({
-        delegatePubKey: wallet.publicKey,
+        delegatePubKey: delegateWallet.publicKey,
         delegateSig: authToken.delegateSig,
         expiryEpochMs: authToken.expiryEpochMs,
     })
     return {
-        signerPrivateKey: () => authToken.privateKey.slice(2), // remove the 0x prefix,
+        signerPrivateKey: () => authToken.delegatePrivateKey.slice(2), // remove the 0x prefix,
         creatorAddress,
         delegateSig: authToken.delegateSig,
         delegateExpiryEpochMs: authToken.expiryEpochMs,

--- a/packages/sdk/src/signerContext.ts
+++ b/packages/sdk/src/signerContext.ts
@@ -2,7 +2,8 @@ import { ecrecover, fromRpcSig, hashPersonalMessage } from '@ethereumjs/util'
 import { ethers } from 'ethers'
 import { bin_equal, bin_fromHexString, bin_toHexString, check } from '@river-build/dlog'
 import { publicKeyToAddress, publicKeyToUint8Array, riverDelegateHashSrc } from './sign'
-import { Err } from '@river-build/proto'
+import { AuthToken, Err } from '@river-build/proto'
+import { bytesToHex, hexToBytes } from 'ethereum-cryptography/utils'
 
 /**
  * SignerContext is a context used for signing events.
@@ -109,14 +110,53 @@ export async function makeSignerContext(
     }
 }
 
+// make auth token
+export async function makeAuthToken(
+    signer: ethers.Signer,
+    expiry:
+        | bigint
+        | {
+              days?: number
+              hours?: number
+              minutes?: number
+              seconds?: number
+          },
+): Promise<string> {
+    const delegate = await makeSignerDelegate(signer, expiry)
+    const authToken = new AuthToken({
+        privateKey: delegate.delegateWallet.privateKey,
+        delegateSig: delegate.signerContext.delegateSig,
+        expiryEpochMs: delegate.signerContext.delegateExpiryEpochMs,
+    })
+    return bytesToHex(authToken.toBinary())
+}
+
+export async function makeSignerContextFromAuthToken(authTokenStr: string): Promise<SignerContext> {
+    const authToken = AuthToken.fromBinary(hexToBytes(authTokenStr))
+    const wallet = new ethers.Wallet(authToken.privateKey)
+    const creatorAddress = recoverPublicKeyFromDelegateSig({
+        delegatePubKey: wallet.publicKey,
+        delegateSig: authToken.delegateSig,
+        expiryEpochMs: authToken.expiryEpochMs,
+    })
+    return {
+        signerPrivateKey: () => authToken.privateKey.slice(2), // remove the 0x prefix,
+        creatorAddress,
+        delegateSig: authToken.delegateSig,
+        delegateExpiryEpochMs: authToken.expiryEpochMs,
+    }
+}
+
 export async function makeSignerDelegate(
     signer: ethers.Signer,
-    expiry?: {
-        days?: number
-        hours?: number
-        minutes?: number
-        seconds?: number
-    },
+    expiry?:
+        | bigint
+        | {
+              days?: number
+              hours?: number
+              minutes?: number
+              seconds?: number
+          },
 ): Promise<{ delegateWallet: ethers.Wallet; signerContext: SignerContext }> {
     const delegateWallet = ethers.Wallet.createRandom()
     const signerContext = await makeSignerContext(signer, delegateWallet, expiry)

--- a/packages/sdk/src/sync-agent/syncAgent.test.ts
+++ b/packages/sdk/src/sync-agent/syncAgent.test.ts
@@ -6,11 +6,15 @@ import { waitFor } from '../util.test'
 import { MembershipOp } from '@river-build/proto'
 import { Bot } from './utils/bot'
 import { AuthStatus } from './river-connection/models/authStatus'
+import { makeAuthToken, makeSignerContextFromAuthToken } from '../signerContext'
+import { SyncAgent } from './syncAgent'
+import { makeRiverConfig } from '../riverConfig'
 
 const logger = dlogger('csb:test:syncAgent')
 
 describe('syncAgent.test.ts', () => {
-    const testUser = new Bot()
+    const riverConfig = makeRiverConfig()
+    const testUser = new Bot(undefined, riverConfig)
 
     beforeEach(async () => {
         await testUser.fundWallet()
@@ -26,6 +30,7 @@ describe('syncAgent.test.ts', () => {
             expect(syncAgent.riverConnection.authStatus.value).toBe(AuthStatus.Credentialed),
         )
         expect(Object.keys(syncAgent.user.memberships.data.memberships).length).toBe(0)
+        expect(syncAgent.spaces.data.spaceIds.length).toBe(0)
         syncAgent.store.newTransactionGroup('createSpace')
         const { spaceId, defaultChannelId } = await syncAgent.spaces.createSpace(
             { spaceName: 'BlastOff' },
@@ -42,6 +47,7 @@ describe('syncAgent.test.ts', () => {
         expect(syncAgent.user.value.status).toBe('loaded')
         await syncAgent.store.commitTransaction()
         expect(syncAgent.user.value.status).toBe('loaded')
+        expect(syncAgent.spaces.data.spaceIds.length).toBe(1)
         await syncAgent.stop()
     })
     test('syncAgent loads again', async () => {
@@ -52,6 +58,18 @@ describe('syncAgent.test.ts', () => {
         expect(syncAgent.user.value.status).toBe('loaded')
         expect(syncAgent.user.memberships.value.status).toBe('loaded')
         expect(syncAgent.user.memberships.data.initialized).toBe(true)
+        await waitFor(() => expect(syncAgent.spaces.data.spaceIds.length).toBe(1))
+        await syncAgent.stop()
+    })
+    test('logIn with delegate', async () => {
+        const authToken = await makeAuthToken(testUser.signer, { days: 1 })
+        logger.log('authTokenStr', authToken)
+        const signerContext = await makeSignerContextFromAuthToken(authToken)
+        const syncAgent = new SyncAgent({ riverConfig: makeRiverConfig(), context: signerContext })
+        await syncAgent.start()
+        expect(syncAgent.riverConnection.authStatus.value).toBe(AuthStatus.ConnectedToRiver)
+        expect(syncAgent.user.value.status).toBe('loaded')
+        await waitFor(() => expect(syncAgent.spaces.data.spaceIds.length).toBe(1))
         await syncAgent.stop()
     })
 })

--- a/protocol/payloads.proto
+++ b/protocol/payloads.proto
@@ -189,3 +189,10 @@ message ChunkedMedia {
 message UserBio {
     string bio = 1;
 }
+
+// a client created with an auth token cannot make blockchain transactions, but can add events to the river nodes
+message AuthToken {
+    string private_key = 1;
+    bytes delegate_sig = 2;
+    int64 expiry_epoch_ms = 3;
+}

--- a/protocol/payloads.proto
+++ b/protocol/payloads.proto
@@ -192,7 +192,7 @@ message UserBio {
 
 // a client created with an auth token cannot make blockchain transactions, but can add events to the river nodes
 message AuthToken {
-    string private_key = 1;
+    string delegate_private_key = 1;
     bytes delegate_sig = 2;
     int64 expiry_epoch_ms = 3;
 }


### PR DESCRIPTION
If you control the signer for a private key that owns a river user you can
- pick an expiration date
- create a new delegate wallet
- sign the new delegate wallets public key and expiration date with your signer
- export the private key, signature, and expiry as a hexified binary representaion of an AuthToken protobuf

Now you can create a signer context anywhere.

This auth token can be used to sign events and add them to river streams, but it can’t be used to make blockchain transactions.

it prints out a string like this:
```
0a4230786637666335656233636636633633376432326461393730363937316639326264313930336335663966643835306166373534353635626166623766366463663612414465bfdd7b9c56ebfcf93bf6e1767ac497d7fc0820589f2d3e3d61415d9e13060c7acd80b991281ce8fc31e0d2553298b20e2eb828abc31a93dcc64812a4f3561c18a6bb808e9a32
```