### PR TITLE
fix inconsistent permission enum

### DIFF
--- a/core/node/auth/permissions.go
+++ b/core/node/auth/permissions.go
@@ -10,7 +10,7 @@ const (
 	PermissionJoin
 	PermissionRedact
 	PermissionBan
-	PermissionPinMessages
+	PermissionPinMessage
 	PermissionAddRemoveChannels
 	PermissionModifySpaceSettings
 	PermissionReact
@@ -32,8 +32,8 @@ func (p Permission) String() string {
 		return "Redact"
 	case PermissionBan:
 		return "Ban"
-	case PermissionPinMessages:
-		return "PinMessages"
+	case PermissionPinMessage:
+		return "PinMessage"
 	case PermissionAddRemoveChannels:
 		return "AddRemoveChannels"
 	case PermissionModifySpaceSettings:


### PR DESCRIPTION
we don't check these before allowing a Pin payload atm, but once we do, this constant will cause issues:
see https://github.com/river-build/river/blob/53acc46aee8a71af34ec059be7820aff10e785bd/packages/web3/src/ContractTypes.ts#L25