### PR TITLE
POC of entitlement registry proxy manager

### DIFF
--- a/contracts/src/entitlements/EntitlementRegistry.sol
+++ b/contracts/src/entitlements/EntitlementRegistry.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// interfaces
+
+// libraries
+
+// contracts
+
+contract EntitlementRegistry {
+  error EntitlementRegistry__InvalidImplementation();
+  error EntitlementRegistry__ModuleAlreadyRegistered();
+  mapping(bytes4 => address) public entitlementModules;
+
+  function registerEntitlementModule(
+    bytes4 moduleId,
+    address implementation
+  ) external {
+    if (implementation == address(0))
+      revert EntitlementRegistry__InvalidImplementation();
+    if (entitlementModules[moduleId] != address(0))
+      revert EntitlementRegistry__ModuleAlreadyRegistered();
+
+    entitlementModules[moduleId] = implementation;
+  }
+
+  function getEntitlementModule(
+    bytes4 moduleId
+  ) external view virtual returns (address) {
+    return entitlementModules[moduleId];
+  }
+}

--- a/contracts/src/entitlements/modules/SimpleEntitlement.sol
+++ b/contracts/src/entitlements/modules/SimpleEntitlement.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// interfaces
+
+// libraries
+
+// contracts
+
+contract SimpleEntitlement {
+  function isEntitled(address[] memory users) external view returns (bool) {
+    SimpleEntitlementStorage.Layout storage l = SimpleEntitlementStorage
+      .layout();
+    for (uint256 i = 0; i < users.length; i++) {
+      if (!l.entitled[users[i]]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function setEntitled(address user, bool entitled) external {
+    SimpleEntitlementStorage.layout().entitled[user] = entitled;
+  }
+}
+
+library SimpleEntitlementStorage {
+  // keccak256(abi.encode(uint256(keccak256("entitlement.modules.SimpleEntitlement")) - 1)) & ~bytes32(uint256(0xff))
+  bytes32 internal constant STORAGE_SLOT =
+    0xf33e8ae617d5ced4a595c3b3d5ba50b9742af68f402a047fd18239071c310b00;
+
+  struct Layout {
+    mapping(address => bool) entitled;
+  }
+
+  function layout() internal pure returns (Layout storage l) {
+    assembly {
+      l.slot := STORAGE_SLOT
+    }
+  }
+}

--- a/contracts/src/entitlements/proxy/EntitlementProxy.sol
+++ b/contracts/src/entitlements/proxy/EntitlementProxy.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// interfaces
+
+// libraries
+
+// contracts
+
+import {EntitlementProxyBase} from "contracts/src/entitlements/proxy/EntitlementProxyBase.sol";
+
+contract EntitlementProxy is EntitlementProxyBase {
+  constructor(address manager, bytes4 managerSelector, bytes4 entitlementId) {
+    __EntitlementProxyBase_init(manager, managerSelector, entitlementId);
+  }
+}

--- a/contracts/src/entitlements/proxy/EntitlementProxyBase.sol
+++ b/contracts/src/entitlements/proxy/EntitlementProxyBase.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// interfaces
+import {IEntitlementProxyBase} from "contracts/src/entitlements/proxy/IEntitlementProxyBase.sol";
+
+// libraries
+import {EntitlementProxyStorage} from "contracts/src/entitlements/proxy/EntitlementProxyStorage.sol";
+
+// contracts
+import {Proxy} from "contracts/src/diamond/proxy/Proxy.sol";
+
+/**
+ * @title Proxy with externally controlled implementation
+ * @dev implementation fetched using immutable function selector
+ */
+abstract contract EntitlementProxyBase is Proxy, IEntitlementProxyBase {
+  function __EntitlementProxyBase_init(
+    address manager,
+    bytes4 managerSelector,
+    bytes4 entitlementId
+  ) internal {
+    EntitlementProxyStorage.Layout storage ds = EntitlementProxyStorage
+      .layout();
+    ds.managerSelector = managerSelector;
+    ds.manager = manager;
+    ds.entitlementId = entitlementId;
+  }
+
+  /**
+   * @inheritdoc Proxy
+   */
+  function _getImplementation()
+    internal
+    view
+    virtual
+    override
+    returns (address)
+  {
+    EntitlementProxyStorage.Layout storage ds = EntitlementProxyStorage
+      .layout();
+
+    (bool success, bytes memory data) = _getManager().staticcall(
+      abi.encodeWithSelector(ds.managerSelector, ds.entitlementId)
+    );
+
+    if (!success) revert EntitlementProxy__FetchImplementationFailed();
+    return abi.decode(data, (address));
+  }
+
+  /**
+   * @notice get manager of proxy implementation
+   * @return manager address
+   */
+  function _getManager() internal view virtual returns (address) {
+    return EntitlementProxyStorage.layout().manager;
+  }
+
+  /**
+   * @notice set manager of proxy implementation
+   * @param manager address
+   */
+  function _setManager(address manager) internal virtual {
+    if (manager == address(0)) revert EntitlementProxy__InvalidManager();
+    EntitlementProxyStorage.layout().manager = manager;
+  }
+
+  /**
+   * @notice set manager selector of proxy implementation
+   * @param managerSelector function selector used to fetch implementation from manager
+   */
+  function _setManagerSelector(bytes4 managerSelector) internal virtual {
+    if (managerSelector == bytes4(0))
+      revert EntitlementProxy__InvalidManagerSelector();
+    EntitlementProxyStorage.layout().managerSelector = managerSelector;
+  }
+
+  /**
+   * @notice set entitlement id of proxy implementation
+   * @param entitlementId bytes4 identifier of entitlement
+   */
+  function _setEntitlementId(bytes4 entitlementId) internal virtual {
+    EntitlementProxyStorage.layout().entitlementId = entitlementId;
+  }
+}

--- a/contracts/src/entitlements/proxy/EntitlementProxyStorage.sol
+++ b/contracts/src/entitlements/proxy/EntitlementProxyStorage.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// interfaces
+
+// libraries
+
+// contracts
+
+library EntitlementProxyStorage {
+  // keccak256(abi.encode(uint256(keccak256("diamond.entitlement.proxy.storage")) - 1)) & ~bytes32(uint256(0xff))
+  bytes32 internal constant STORAGE_SLOT =
+    0x23e75ba980826f1692d90550974ebb6400efde4cd9a3213f3a0482f77a1f0e00;
+
+  struct Layout {
+    address manager;
+    bytes4 managerSelector;
+    bytes4 entitlementId;
+  }
+
+  function layout() internal pure returns (Layout storage ds) {
+    bytes32 slot = STORAGE_SLOT;
+    assembly {
+      ds.slot := slot
+    }
+  }
+}

--- a/contracts/src/entitlements/proxy/IEntitlementProxyBase.sol
+++ b/contracts/src/entitlements/proxy/IEntitlementProxyBase.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// interfaces
+
+// libraries
+
+// contracts
+
+interface IEntitlementProxyBase {
+  error EntitlementProxy__FetchImplementationFailed();
+  error EntitlementProxy__InvalidManager();
+  error EntitlementProxy__InvalidManagerSelector();
+}
+
+interface IEntitlementProxy is IEntitlementProxyBase {
+  function getManager() external view returns (address);
+  function setManager(address manager) external;
+}

--- a/contracts/test/entitlements/EntitlementRegistry.t.sol
+++ b/contracts/test/entitlements/EntitlementRegistry.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.19;
+
+// utils
+import {TestUtils} from "contracts/test/utils/TestUtils.sol";
+
+//interfaces
+
+//libraries
+
+//contracts
+import {EntitlementRegistry} from "contracts/src/entitlements/EntitlementRegistry.sol";
+import {EntitlementProxy} from "contracts/src/entitlements/proxy/EntitlementProxy.sol";
+import {SimpleEntitlement} from "contracts/src/entitlements/modules/SimpleEntitlement.sol";
+
+contract EntitlementRegistryTest is TestUtils {
+  EntitlementRegistry registry;
+  SimpleEntitlement simpleEntitlement;
+  EntitlementProxy entitlementProxy;
+
+  bytes4 constant SIMPLE_ENTITLEMENT_ID =
+    bytes4(keccak256("SimpleEntitlement"));
+
+  function setUp() external {
+    registry = new EntitlementRegistry();
+    simpleEntitlement = new SimpleEntitlement();
+  }
+
+  modifier givenEntitlementModuleIsRegistered() {
+    vm.prank(_randomAddress());
+    registry.registerEntitlementModule(
+      SIMPLE_ENTITLEMENT_ID,
+      address(simpleEntitlement)
+    );
+    _;
+  }
+
+  function test_registerEntitlementModule()
+    external
+    givenEntitlementModuleIsRegistered
+  {
+    assertEq(
+      registry.getEntitlementModule(SIMPLE_ENTITLEMENT_ID),
+      address(simpleEntitlement)
+    );
+  }
+
+  function test_deployEntitlementProxy()
+    external
+    givenEntitlementModuleIsRegistered
+  {
+    // Deploy a new EntitlementProxy, pointing to the registry and the SimpleEntitlement module
+    EntitlementProxy simpleEntitlementProxy = new EntitlementProxy(
+      address(registry),
+      EntitlementRegistry.getEntitlementModule.selector,
+      SIMPLE_ENTITLEMENT_ID
+    );
+
+    // Generate a random address to use for testing
+    address randomAddress = _randomAddress();
+
+    // Set the random address as entitled using the proxy
+    SimpleEntitlement(address(simpleEntitlementProxy)).setEntitled(
+      randomAddress,
+      true
+    );
+
+    // Create an array with the random address for the isEntitled check
+    address[] memory users = new address[](1);
+    users[0] = randomAddress;
+
+    // Verify that the address is entitled through the proxy
+    assertTrue(
+      SimpleEntitlement(address(simpleEntitlementProxy)).isEntitled(users)
+    );
+
+    // Verify that the address is NOT entitled in the original SimpleEntitlement contract
+    // This proves that the proxy is working independently
+    assertFalse(simpleEntitlement.isEntitled(users));
+  }
+}


### PR DESCRIPTION
This is a POC of how an entitlement manager registry would work.

We would deploy entitlement implementations and register them with a given module id, during space creation we deploy proxies and point to the given module id implementation.

we could  add new "draft" versions of entitlements to this registry and when we're ready to update all space using a given entitlement we would update the new implementation to be the module id everyone is using.

