### PR TITLE
Change name of new AuthToken to BearerToken to emphasis significance

### DIFF
--- a/packages/sdk/src/sync-agent/syncAgent.test.ts
+++ b/packages/sdk/src/sync-agent/syncAgent.test.ts
@@ -6,7 +6,7 @@ import { waitFor } from '../util.test'
 import { MembershipOp } from '@river-build/proto'
 import { Bot } from './utils/bot'
 import { AuthStatus } from './river-connection/models/authStatus'
-import { makeAuthToken, makeSignerContextFromAuthToken } from '../signerContext'
+import { makeBearerToken, makeSignerContextFromBearerToken } from '../signerContext'
 import { SyncAgent } from './syncAgent'
 import { makeRiverConfig } from '../riverConfig'
 
@@ -62,9 +62,9 @@ describe('syncAgent.test.ts', () => {
         await syncAgent.stop()
     })
     test('logIn with delegate', async () => {
-        const authToken = await makeAuthToken(testUser.signer, { days: 1 })
-        logger.log('authTokenStr', authToken)
-        const signerContext = await makeSignerContextFromAuthToken(authToken)
+        const bearerToken = await makeBearerToken(testUser.signer, { days: 1 })
+        logger.log('bearerTokenStr', bearerToken)
+        const signerContext = await makeSignerContextFromBearerToken(bearerToken)
         const syncAgent = new SyncAgent({ riverConfig: makeRiverConfig(), context: signerContext })
         await syncAgent.start()
         expect(syncAgent.riverConnection.authStatus.value).toBe(AuthStatus.ConnectedToRiver)

--- a/protocol/payloads.proto
+++ b/protocol/payloads.proto
@@ -190,8 +190,8 @@ message UserBio {
     string bio = 1;
 }
 
-// a client created with an auth token cannot make blockchain transactions, but can add events to the river nodes
-message AuthToken {
+// a client created with an bearer token cannot make blockchain transactions, but can add events to the river nodes
+message BearerToken {
     string delegate_private_key = 1;
     bytes delegate_sig = 2;
     int64 expiry_epoch_ms = 3;


### PR DESCRIPTION
According to google an authToken is a type of bearerToken, I don’t want anyone to assume the wrong thing so we’re going with the more formal sounding name.