### PR TITLE
DApp: Add create channel with permission overrides

### DIFF
--- a/packages/web3/src/ISpaceDapp.ts
+++ b/packages/web3/src/ISpaceDapp.ts
@@ -144,6 +144,15 @@ export interface ISpaceDapp {
         signer: SignerType,
         txnOpts?: TransactionOpts,
     ) => Promise<TransactionType>
+    createChannelWithPermissionOverrides: (
+        spaceId: string,
+        channelName: string,
+        channelDescription: string,
+        channelNetworkId: string,
+        roles: { roleId: number; permissions: Permission[] }[],
+        signer: SignerType,
+        txnOpts?: TransactionOpts,
+    ) => Promise<TransactionType>
     legacyCreateRole(
         spaceId: string,
         roleName: string,

--- a/packages/web3/src/v3/SpaceDapp.ts
+++ b/packages/web3/src/v3/SpaceDapp.ts
@@ -341,6 +341,35 @@ export class SpaceDapp implements ISpaceDapp {
         )
     }
 
+    public async createChannelWithPermissionOverrides(
+        spaceId: string,
+        channelName: string,
+        channelDescription: string,
+        channelNetworkId: string,
+        roles: { roleId: number; permissions: Permission[] }[],
+        signer: ethers.Signer,
+        txnOpts?: TransactionOpts,
+    ): Promise<ContractTransaction> {
+        const space = this.getSpace(spaceId)
+        if (!space) {
+            throw new Error(`Space with spaceId "${spaceId}" is not found.`)
+        }
+        const channelId = ensureHexPrefix(channelNetworkId)
+
+        return wrapTransaction(
+            () =>
+                space.Channels.write(signer).createChannelWithOverridePermissions(
+                    channelId,
+                    stringifyChannelMetadataJSON({
+                        name: channelName,
+                        description: channelDescription,
+                    }),
+                    roles,
+                ),
+            txnOpts,
+        )
+    }
+
     public async legacyCreateRole(
         spaceId: string,
         roleName: string,


### PR DESCRIPTION
This could replace the default `createChannel` eventually, but this would be a breaking change