### PR TITLE
Improve stress client log when selecting node url

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1077,7 +1077,7 @@ export class Client
         const timeoutError = new Error(
             `waitForStream: timeout waiting for ${logId}${streamId} creating streams: ${Array.from(
                 this.creatingStreamIds,
-            ).join(',')}`,
+            ).join(',')} rpcUrl: ${this.rpcClient.url}`,
         )
         await new Promise<void>((resolve, reject) => {
             const timeout = setTimeout(() => {

--- a/packages/stress/src/utils/rpc-http2.ts
+++ b/packages/stress/src/utils/rpc-http2.ts
@@ -8,9 +8,6 @@ import {
     retryInterceptor,
     type RetryParams,
 } from '@river-build/sdk'
-import { dlogger } from '@river-build/dlog'
-
-const logger = dlogger('csb:rpc:rpc-http2')
 
 export type StreamRpcClient = PromiseClient<typeof StreamService> & { url?: string }
 
@@ -23,7 +20,6 @@ export function makeHttp2StreamRpcClient(
 ): StreamRpcClient {
     const transportId = nextRpcClientNum++
     const url = randomUrlSelector(urls)
-    logger.info(`makeHttp2StreamRpcClient: Connecting to url=${url}`)
     const options: ConnectTransportOptions = {
         httpVersion: '2',
         baseUrl: url,

--- a/packages/stress/src/utils/stressClient.ts
+++ b/packages/stress/src/utils/stressClient.ts
@@ -80,7 +80,12 @@ export class StressClient {
         public globalPersistedStore: IStorage | undefined,
         public storageKey: string,
     ) {
-        logger.log('StressClient', { clientIndex, userId, logId: this.logId })
+        logger.log('StressClient', {
+            clientIndex,
+            userId,
+            logId: this.logId,
+            rpcUrl: this.streamsClient.rpcClient.url,
+        })
     }
 
     get logId(): string {


### PR DESCRIPTION
We're seeing nodes fail to fetch spaces. Maybe it's always the same node.