### PR TITLE
core/node: reconcile streams with peers on node start

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/kr/text v0.2.0
 	github.com/matoous/go-nanoid v1.5.0
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/panjf2000/ants/v2 v2.10.0
 	github.com/prometheus/client_golang v1.19.1
 	github.com/rogpeppe/go-internal v1.12.0
 	github.com/rs/cors v1.9.0

--- a/core/go.sum
+++ b/core/go.sum
@@ -275,6 +275,8 @@ github.com/openzipkin/zipkin-go v0.4.3 h1:9EGwpqkgnwdEIJ+Od7QVSEIH+ocmm5nPat0G7s
 github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LDHcMZmk3RmK7c=
 github.com/outcaste-io/ristretto v0.2.3 h1:AK4zt/fJ76kjlYObOeNwh4T3asEuaCmp26pOvUOL9w0=
 github.com/outcaste-io/ristretto v0.2.3/go.mod h1:W8HywhmtlopSB1jeMg3JtdIhf+DYkLAr0VN/s4+MHac=
+github.com/panjf2000/ants/v2 v2.10.0 h1:zhRg1pQUtkyRiOFo2Sbqwjp0GfBNo9cUY2/Grpx1p+8=
+github.com/panjf2000/ants/v2 v2.10.0/go.mod h1:7ZxyxsqE4vvW0M7LSD8aI3cKwgFhBHbxnlN8mDqHa1I=
 github.com/pelletier/go-toml/v2 v2.1.1 h1:LWAJwfNvjQZCFIDKWYQaM62NcYeYViCmWIwmOStowAI=
 github.com/pelletier/go-toml/v2 v2.1.1/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/philhofer/fwd v1.1.2 h1:bnDivRJ1EWPjUIRXV5KfORO897HTbpFAQddBdE8t7Gw=
@@ -345,6 +347,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
@@ -434,6 +437,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/core/node/events/miniblock_producer.go
+++ b/core/node/events/miniblock_producer.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/river-build/river/core/contracts/river"
 	. "github.com/river-build/river/core/node/base"
 	"github.com/river-build/river/core/node/crypto"
@@ -23,7 +22,7 @@ const (
 	MiniblockCandidateBatchSize = 50
 )
 
-// RemoteMiniblockProvider abstracts comminications required for coordinated miniblock production.
+// RemoteMiniblockProvider abstracts communications required for coordinated miniblock production.
 type RemoteMiniblockProvider interface {
 	GetMbProposal(
 		ctx context.Context,
@@ -31,12 +30,28 @@ type RemoteMiniblockProvider interface {
 		streamId StreamId,
 		forceSnapshot bool,
 	) (*MiniblockProposal, error)
+
 	SaveMbCandidate(
 		ctx context.Context,
 		node common.Address,
 		streamId StreamId,
 		mb *Miniblock,
 	) error
+
+	// GetMiniBlocksStreamed returns a stream of mini-blocks or an error for the given stream in the range
+	// [fromMiniBlockNum..toMiniBlockNum).
+	GetMbsStreamed(
+		ctx context.Context,
+		node common.Address,
+		stream StreamId,
+		fromMiniBlockNum int64, // inclusive
+		toMiniBlockNum int64, // exclusive
+	) <-chan *MbOrError
+}
+
+type MbOrError struct {
+	Miniblock *Miniblock
+	Err       error
 }
 
 type MiniblockProducer interface {
@@ -329,7 +344,6 @@ func gatherRemoteProposals(
 		go func(i int, node common.Address) {
 			defer wg.Done()
 			proposal, err := params.RemoteMiniblockProvider.GetMbProposal(ctx, node, streamId, forceSnapshot)
-
 			mu.Lock()
 			defer mu.Unlock()
 			if err != nil {

--- a/core/node/events/stream.go
+++ b/core/node/events/stream.go
@@ -7,14 +7,12 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-
-	"github.com/river-build/river/core/node/dlog"
-	"github.com/river-build/river/core/node/storage"
-
 	. "github.com/river-build/river/core/node/base"
+	"github.com/river-build/river/core/node/dlog"
 	. "github.com/river-build/river/core/node/nodes"
 	. "github.com/river-build/river/core/node/protocol"
 	. "github.com/river-build/river/core/node/shared"
+	"github.com/river-build/river/core/node/storage"
 
 	mapset "github.com/deckarep/golang-set/v2"
 )
@@ -134,6 +132,79 @@ func (s *streamImpl) ApplyMiniblock(ctx context.Context, miniblock *MiniblockInf
 	return s.applyMiniblockImplNoLock(ctx, miniblock)
 }
 
+// importMiniblock imports the given miniblocks.
+func (s *streamImpl) importMiniblocks(
+	ctx context.Context,
+	miniblocks []*MiniblockInfo,
+) error {
+	if len(miniblocks) == 0 {
+		return nil
+	}
+
+	blocksToWriteToStorage := make([]*storage.LatestMiniBlock, len(miniblocks))
+	for i, miniblock := range miniblocks {
+		bytes, err := miniblock.ToBytes()
+		if err != nil {
+			return err
+		}
+
+		blocksToWriteToStorage[i] = &storage.LatestMiniBlock{
+			StreamID:      s.streamId,
+			Number:        miniblock.Num,
+			MiniBlockInfo: bytes,
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.view == nil {
+		importFromGenesis := miniblocks[0].header().MiniblockNum == 0
+		if importFromGenesis {
+			if err := s.initFromGenesis(ctx, miniblocks[0], blocksToWriteToStorage[0]); err != nil {
+				return err
+			}
+			miniblocks = miniblocks[1:]
+			blocksToWriteToStorage = blocksToWriteToStorage[1:]
+		}
+
+		if err := s.loadInternal(ctx); err != nil {
+			return err
+		}
+	}
+
+	// apply mini-blocks one by one on view, backup existing view in case
+	// applying/writing miniblocks fails rollback view.
+	var (
+		err              error
+		viewBeforeImport = s.view
+	)
+	for _, miniblock := range miniblocks {
+		if miniblock.Num <= s.view.LastBlock().Num {
+			blocksToWriteToStorage = blocksToWriteToStorage[1:]
+			continue
+		}
+
+		view, err := s.view.copyAndApplyBlock(miniblock, s.params.ChainConfig, true)
+		if err != nil {
+			s.view = viewBeforeImport
+			return err
+		}
+
+		s.view = view
+	}
+
+	err = s.params.Storage.ImportMiniBlocks(ctx, blocksToWriteToStorage)
+	if err != nil {
+		s.view = viewBeforeImport
+		return err
+	}
+
+	// TODO: inform subscribes with rate throttling?
+
+	return nil
+}
+
 func (s *streamImpl) applyMiniblockImplNoLock(ctx context.Context, miniblock *MiniblockInfo) error {
 	// Check if the miniblock is already applied.
 	if miniblock.Num <= s.view.LastBlock().Num {
@@ -144,7 +215,7 @@ func (s *streamImpl) applyMiniblockImplNoLock(ctx context.Context, miniblock *Mi
 	// TODO: tests for this.
 
 	// Lets see if this miniblock can be applied.
-	newSV, err := s.view.copyAndApplyBlock(miniblock, s.params.ChainConfig)
+	newSV, err := s.view.copyAndApplyBlock(miniblock, s.params.ChainConfig, false)
 	if err != nil {
 		return err
 	}
@@ -215,6 +286,47 @@ func (s *streamImpl) PromoteCandidate(ctx context.Context, mbHash common.Hash, m
 	}
 
 	return s.applyMiniblockImplNoLock(ctx, miniblock)
+}
+
+func (s *streamImpl) initFromGenesis(
+	ctx context.Context,
+	genesisInfo *MiniblockInfo,
+	genesis *storage.LatestMiniBlock,
+) error {
+	if genesis.Number != 0 {
+		return RiverError(Err_BAD_BLOCK, "init from genesis must be from block with num 0")
+	}
+
+	_, registeredGenesisHash, _, err := s.params.Registry.GetStreamWithGenesis(ctx, genesis.StreamID)
+	if err != nil {
+		return err
+	}
+
+	if registeredGenesisHash != genesisInfo.Hash {
+		return RiverError(Err_BAD_BLOCK, "Invalid genesis block hash").
+			Tags("registryHash", registeredGenesisHash, "blockHash", genesisInfo.Hash).
+			Func("initFromGenesis")
+	}
+
+	if err := s.params.Storage.CreateStreamStorage(ctx, s.streamId, genesis.MiniBlockInfo); err != nil {
+		if AsRiverError(err).Code != Err_ALREADY_EXISTS {
+			return err
+		}
+	}
+
+	view, err := MakeStreamView(
+		ctx,
+		&storage.ReadStreamFromLastSnapshotResult{
+			StartMiniblockNumber: 0,
+			Miniblocks:           [][]byte{genesis.MiniBlockInfo},
+		},
+	)
+	if err != nil {
+		return err
+	}
+	s.view = view
+
+	return nil
 }
 
 func (s *streamImpl) initFromBlockchain(ctx context.Context) error {

--- a/core/node/events/stream_cache.go
+++ b/core/node/events/stream_cache.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/river-build/river/core/contracts/river"
 	. "github.com/river-build/river/core/node/base"
 	"github.com/river-build/river/core/node/crypto"
@@ -50,6 +49,8 @@ type streamCacheImpl struct {
 	// streamImpl can be in unloaded state, in which case it will be loaded on first GetStream call.
 	cache sync.Map
 
+	syncTasks *StreamSyncTasksProcessor
+
 	chainConfig crypto.OnChainConfiguration
 
 	streamCacheSizeGauge     prometheus.Gauge
@@ -62,6 +63,11 @@ func NewStreamCache(
 	ctx context.Context,
 	params *StreamCacheParams,
 ) (*streamCacheImpl, error) {
+	syncTasks, err := NewStreamSyncTasksProcessor()
+	if err != nil {
+		return nil, err
+	}
+
 	s := &streamCacheImpl{
 		params: params,
 		streamCacheSizeGauge: params.Metrics.NewGaugeVecEx(
@@ -79,16 +85,31 @@ func NewStreamCache(
 			params.Wallet.Address.String(),
 		),
 		chainConfig: params.ChainConfig,
+		syncTasks:   syncTasks,
 	}
 
-	streams, err := params.Registry.GetAllStreams(ctx, params.AppliedBlockNum)
-	if err != nil {
+	// schedule sync tasks for all streams that are local to this node.
+	// these tasks sync up the local db with the latest block in the registry.
+	var localStreamResults []*registries.GetStreamResult
+	if err := params.Registry.ForAllStreams(ctx, params.AppliedBlockNum, func(stream *registries.GetStreamResult) bool {
+		nodes := NewStreamNodes(stream.Nodes, params.Wallet.Address)
+		if nodes.IsLocal() {
+			localStreamResults = append(localStreamResults, stream)
+		}
+		return true
+	}); err != nil {
 		return nil, err
 	}
 
-	// TODO: read stream state from storage and schedule required reconciliations.
+	// schedule sync tasks for all local streams in the background
+	go func() {
+		for _, stream := range localStreamResults {
+			s.syncTasks.Submit(ctx, stream, s)
+		}
+	}()
 
-	for _, stream := range streams {
+	// load local streams in-memory cache
+	for _, stream := range localStreamResults {
 		if slices.Contains(stream.Nodes, params.Wallet.Address) {
 			s.cache.Store(stream.StreamId, &streamImpl{
 				params:           params,

--- a/core/node/events/stream_sync_task.go
+++ b/core/node/events/stream_sync_task.go
@@ -1,0 +1,174 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/panjf2000/ants/v2"
+	. "github.com/river-build/river/core/node/base"
+	"github.com/river-build/river/core/node/dlog"
+	"github.com/river-build/river/core/node/nodes"
+	. "github.com/river-build/river/core/node/protocol"
+	"github.com/river-build/river/core/node/registries"
+)
+
+type StreamSyncTasksProcessor struct {
+	pendingTasks sync.Map
+	workerPool   *ants.Pool
+}
+
+// NewStreamSyncTasksProcessor creates a new sync task process that schedules and processes sync stream requests.
+func NewStreamSyncTasksProcessor() (*StreamSyncTasksProcessor, error) {
+	workerPool, err := ants.NewPool(1024)
+	if err != nil {
+		return nil, WrapRiverError(Err_INTERNAL, err).
+			Message("Unable to create stream sync task worker processor").
+			Func("syncDatabaseWithRegistry")
+	}
+
+	proc := &StreamSyncTasksProcessor{
+		workerPool: workerPool,
+	}
+
+	return proc, nil
+}
+
+// Submit schedules a stream sync task if there is not already one for the given stream.
+// This can block when the worker pool is overloaded and returns an indication if the sync task was scheduled.
+// False indicates that there was already stream sync task for the given stream scheduled or in progress.
+func (sst *StreamSyncTasksProcessor) Submit(
+	ctx context.Context,
+	stream *registries.GetStreamResult,
+	cache *streamCacheImpl,
+) bool {
+	task := &streamSyncTask{ctx: ctx, stream: stream, cache: cache}
+
+	_, alreadyScheduled := sst.pendingTasks.LoadOrStore(stream.StreamId, task)
+	if !alreadyScheduled {
+		_ = sst.workerPool.Submit(func() {
+			sst.pendingTasks.Delete(task.stream)
+			task.process()
+		})
+	}
+
+	return !alreadyScheduled
+}
+
+type streamSyncTask struct {
+	ctx    context.Context
+	stream *registries.GetStreamResult
+	cache  *streamCacheImpl
+}
+
+func (task *streamSyncTask) process() {
+	var (
+		start = time.Now()
+		ctx   = task.ctx
+		log   = dlog.FromCtx(ctx)
+	)
+
+	lastBlockInDB, err := task.lastBlockInDB()
+	if err != nil {
+		log.Error("Unable to get last mini block in DB", "stream", task.stream.StreamId)
+		return
+	}
+
+	var (
+		syncFromBlock = lastBlockInDB + 1
+		syncToBlock   = int64(task.stream.LastMiniblockNum) + 1
+	)
+
+	if syncFromBlock == syncToBlock {
+		return // nothing to sync
+	}
+
+	log.Debug("Start stream sync task", "stream", task.stream.StreamId,
+		"fromBlock", syncFromBlock, "toBlock", syncToBlock)
+
+	if err := task.syncStreamsFromPeers(syncFromBlock, syncToBlock); err != nil {
+		fmt.Printf("sync task for stream %s [%d..%d] err: %v\n",
+			task.stream.StreamId, syncFromBlock, syncToBlock, err)
+
+		log.Error("Unable to sync streams from peers", "stream", task.stream.StreamId)
+		return
+	}
+
+	log.Debug("Stream sync task finished", "stream", task.stream.StreamId,
+		"fromBlock", syncFromBlock, "toBlock", syncToBlock, "took", time.Since(start))
+}
+
+func (task *streamSyncTask) lastBlockInDB() (int64, error) {
+	var (
+		lastMiniBlockInDB, err = task.cache.params.Storage.StreamLastMiniBlock(task.ctx, task.stream.StreamId)
+		riverErr               *RiverErrorImpl
+	)
+
+	if err == nil {
+		return lastMiniBlockInDB.Number, nil
+	} else if errors.As(err, &riverErr) && riverErr.Code == Err_NOT_FOUND {
+		return -1, nil
+	}
+
+	return 0, err
+}
+
+// syncStreamsFromPeers syncs the database for the given streamResult by fetching missing blocks from peers
+// participating in the stream.
+func (task *streamSyncTask) syncStreamsFromPeers(
+	fromMiniBlockNum int64, // inclusive
+	toMiniBlockNum int64, // exclusive
+) error {
+	var (
+		log = dlog.FromCtx(task.ctx)
+		ctx = task.ctx
+	)
+
+	stream, err := task.cache.getStreamImpl(ctx, task.stream.StreamId)
+	if err != nil {
+		return err
+	}
+
+	streamNodes := nodes.NewStreamNodes(task.stream.Nodes, task.cache.params.Wallet.Address)
+
+	// retrieve mini-blocks from peers and import them, create the stream if needed
+	for _, peer := range streamNodes.GetRemotes() {
+		miniBlocksStreamOrErr := task.cache.params.RemoteMiniblockProvider.GetMbsStreamed(
+			ctx, peer, task.stream.StreamId, fromMiniBlockNum, toMiniBlockNum)
+
+		var (
+			from           = fromMiniBlockNum
+			blocksToImport []*MiniblockInfo
+		)
+
+		for miniBlockOrErr := range miniBlocksStreamOrErr {
+			if miniBlockOrErr.Err != nil {
+				return miniBlockOrErr.Err
+			}
+
+			miniBlockInfo, err := NewMiniblockInfoFromProto(miniBlockOrErr.Miniblock, NewMiniblockInfoFromProtoOpts{
+				ExpectedBlockNumber: from,
+			})
+			if err != nil {
+				return err
+			}
+
+			blocksToImport = append(blocksToImport, miniBlockInfo)
+
+			from++
+		}
+
+		err = stream.importMiniblocks(ctx, blocksToImport)
+		if err == nil {
+			return nil
+		}
+
+		log.Debug("Unable to retrieve miniblocks from peer for stream reconcilation",
+			"stream", task.stream.StreamId, "peer", peer, "err", err)
+	}
+
+	return RiverError(Err_UNAVAILABLE, "No peer could provide miniblocks for stream reconciliation",
+		"stream", task.stream.StreamId)
+}

--- a/core/node/events/stream_view.go
+++ b/core/node/events/stream_view.go
@@ -334,6 +334,7 @@ func (r *streamViewImpl) makeMiniblockHeader(
 func (r *streamViewImpl) copyAndApplyBlock(
 	miniblock *MiniblockInfo,
 	cfg crypto.OnChainConfiguration,
+	skipMiniblockEventsCheck bool,
 ) (*streamViewImpl, error) {
 	recencyConstraintsGenerations := int(cfg.Get().RecencyConstraintsGen)
 
@@ -379,7 +380,7 @@ func (r *streamViewImpl) copyAndApplyBlock(
 	for _, e := range miniblock.events {
 		if _, ok := remaining[e.Hash]; ok {
 			delete(remaining, e.Hash)
-		} else {
+		} else if !skipMiniblockEventsCheck {
 			return nil, RiverError(Err_BAD_BLOCK, "streamViewImpl: block event not found", "stream", r.streamId, "event_hash", FormatHash(e.Hash))
 		}
 	}

--- a/core/node/events/stream_view_test.go
+++ b/core/node/events/stream_view_test.go
@@ -210,14 +210,14 @@ func TestLoad(t *testing.T) {
 	miniblock, err := NewMiniblockInfoFromParsed(miniblockHeaderEvent, envelopes)
 	assert.NoError(t, err)
 	// with 5 generations (5 blocks kept in memory)
-	newSV1, err := view.copyAndApplyBlock(miniblock, btc.OnChainConfig)
+	newSV1, err := view.copyAndApplyBlock(miniblock, btc.OnChainConfig, false)
 	assert.NoError(t, err)
 	assert.Equal(t, len(newSV1.blocks), 2) // we should have both blocks in memory
 
 	btc.SetConfigValue(t, ctx, crypto.StreamRecencyConstraintsGenerationsConfigKey, crypto.ABIEncodeInt64(0))
 
 	// with 0 generations (0 in memory block history)
-	newSV2, err := view.copyAndApplyBlock(miniblock, btc.OnChainConfig)
+	newSV2, err := view.copyAndApplyBlock(miniblock, btc.OnChainConfig, false)
 	assert.NoError(t, err)
 	assert.Equal(t, len(newSV2.blocks), 1) // we should only have the latest block in memory
 	// add an event with an old hash

--- a/core/node/events/util_test.go
+++ b/core/node/events/util_test.go
@@ -6,9 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
-
+	"github.com/river-build/river/core/node/base"
 	"github.com/river-build/river/core/node/base/test"
 	"github.com/river-build/river/core/node/crypto"
 	"github.com/river-build/river/core/node/infra"
@@ -18,6 +16,8 @@ import (
 	. "github.com/river-build/river/core/node/shared"
 	"github.com/river-build/river/core/node/storage"
 	"github.com/river-build/river/core/node/testutils"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 type cacheTestContext struct {
@@ -291,6 +291,46 @@ func (ctc *cacheTestContext) SaveMbCandidate(
 	}
 
 	return stream.SaveMiniblockCandidate(ctx, mb)
+}
+
+// GetMiniBlocksStreamed returns a range of miniblocks from the given stream.
+func (ctc *cacheTestContext) GetMbsStreamed(
+	ctx context.Context,
+	node common.Address,
+	streamID StreamId,
+	fromMiniBlockNum int64, // inclusive
+	toMiniBlockNum int64, // exclusive
+) <-chan *MbOrError {
+	var mbChanOrErr = make(chan *MbOrError)
+
+	go func() {
+		defer close(mbChanOrErr)
+
+		for _, instance := range ctc.instances {
+			if node == instance.params.Wallet.Address {
+				streamAny, ok := instance.cache.cache.Load(streamID)
+				if !ok {
+					mbChanOrErr <- &MbOrError{
+						Err: base.RiverError(Err_NOT_FOUND, "cacheTestContext::GetMbsStreamed stream not found"),
+					}
+					return
+				}
+				stream := streamAny.(*streamImpl)
+
+				miniBlocks, _, err := stream.GetMiniblocks(ctx, fromMiniBlockNum, toMiniBlockNum)
+				if err != nil {
+					mbChanOrErr <- &MbOrError{Err: err}
+					return
+				}
+
+				for _, miniBlock := range miniBlocks {
+					mbChanOrErr <- &MbOrError{Miniblock: miniBlock}
+				}
+			}
+		}
+	}()
+
+	return mbChanOrErr
 }
 
 func setOnChainStreamConfig(t *testing.T, ctx context.Context, btc *crypto.BlockchainTestContext, p testParams) {

--- a/core/node/rpc/add_event.go
+++ b/core/node/rpc/add_event.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-
 	. "github.com/river-build/river/core/node/base"
 	"github.com/river-build/river/core/node/dlog"
 	. "github.com/river-build/river/core/node/events"

--- a/core/node/rpc/forwarder.go
+++ b/core/node/rpc/forwarder.go
@@ -328,6 +328,7 @@ func (s *Service) GetMiniblocks(
 			LogWarn(log).
 			AsConnectError()
 	}
+
 	log.Debug("GetMiniblocks LEAVE", "response", r.Msg)
 	return r, nil
 }

--- a/core/node/rpc/miniblocks.go
+++ b/core/node/rpc/miniblocks.go
@@ -1,11 +1,9 @@
 package rpc
 
 import (
-	"context"
-
 	"connectrpc.com/connect"
+	"context"
 	"github.com/ethereum/go-ethereum/common"
-
 	. "github.com/river-build/river/core/node/events"
 	. "github.com/river-build/river/core/node/protocol"
 	. "github.com/river-build/river/core/node/shared"
@@ -58,4 +56,47 @@ func (s *Service) SaveMbCandidate(
 	)
 
 	return err
+}
+
+// GetMiniBlocksStreamed returns a range of mini-blocks from the given stream.
+func (s *Service) GetMbsStreamed(
+	ctx context.Context,
+	node common.Address,
+	streamId StreamId,
+	fromInclusive int64, // inclusive
+	toExclusive int64, // exclusive
+) <-chan *MbOrError {
+	miniBlocksOrError := make(chan *MbOrError)
+
+	go func() {
+		defer close(miniBlocksOrError)
+
+		remote, err := s.nodeRegistry.GetStreamServiceClientForAddress(node)
+		if err != nil {
+			miniBlocksOrError <- &MbOrError{Err: err}
+			return
+		}
+
+		for from := fromInclusive; from <= toExclusive; from += 128 {
+			to := min(from+128, toExclusive)
+
+			// TODO: consider to switch over to a streaming call for GetMiniblocks to support large block ranges
+			miniBlocksResp, err := remote.GetMiniblocks(ctx, connect.NewRequest(&GetMiniblocksRequest{
+				StreamId:      streamId[:],
+				FromInclusive: from,
+				ToExclusive:   to,
+			}))
+
+			if err != nil {
+				miniBlocksOrError <- &MbOrError{Err: err}
+				return
+			}
+
+			for _, blk := range miniBlocksResp.Msg.GetMiniblocks() {
+				miniBlocksOrError <- &MbOrError{Miniblock: blk}
+			}
+		}
+	}()
+
+	return miniBlocksOrError
 }

--- a/core/node/rpc/node2node.go
+++ b/core/node/rpc/node2node.go
@@ -141,6 +141,10 @@ func (s *Service) proposeMiniblock(
 		return nil, err
 	}
 
+	if proposal == nil {
+		return nil, RiverError(Err_MINIPOOL_MISSING_EVENTS, "Empty stream minipool")
+	}
+
 	return &ProposeMiniblockResponse{
 		Proposal: proposal,
 	}, nil

--- a/core/node/rpc/repl_test.go
+++ b/core/node/rpc/repl_test.go
@@ -1,11 +1,14 @@
 package rpc
 
 import (
-	"testing"
-
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/river-build/river/core/contracts/river"
 	"github.com/river-build/river/core/node/crypto"
+	"github.com/river-build/river/core/node/events"
 	"github.com/river-build/river/core/node/protocol"
 	"github.com/river-build/river/core/node/testutils"
+	"testing"
+	"time"
 )
 
 func TestReplCreate(t *testing.T) {
@@ -83,4 +86,219 @@ func TestReplMiniblock(t *testing.T) {
 	require.NoError(err)
 	require.EqualValues(1, mbNum)
 	tt.eventuallyCompareStreamDataInStorage(streamId, 2, 0)
+}
+
+// TestStreamReconciliation ensures that a node reconciles local streams on boot
+// that were created when the node was down.
+func TestStreamReconciliationFromGenesis(t *testing.T) {
+	var (
+		opts    = serviceTesterOpts{numNodes: 5, replicationFactor: 5, start: false}
+		tt      = newServiceTester(t, opts)
+		client  = tt.testClient(2)
+		ctx     = tt.ctx
+		require = tt.require
+	)
+
+	tt.initNodeRecords(0, opts.numNodes, river.NodeStatus_Operational)
+	tt.startNodes(0, 4)
+
+	wallet, err := crypto.NewWallet(ctx)
+	require.NoError(err)
+
+	// create a stream, add some events and create a bunch of mini-blocks for the node to catch up to
+	streamId, cookie, _, err := createUserSettingsStream(
+		ctx,
+		wallet,
+		client,
+		&protocol.StreamSettings{
+			DisableMiniblockCreation: true,
+		},
+	)
+	require.NoError(err)
+
+	// create a bunch of mini-blocks and store them in mbChain for later comparison
+	N := 25
+	mbChain := map[int64]common.Hash{0: common.BytesToHash(cookie.PrevMiniblockHash)}
+	latestMbNum := int64(0)
+
+	for range N {
+		require.NoError(addUserBlockedFillerEvent(ctx, wallet, client, streamId, mbChain[latestMbNum].Bytes()))
+		mbHash, mbNum, err := tt.nodes[2].service.mbProducer.TestMakeMiniblock(ctx, streamId, false)
+		require.NoError(err)
+
+		if mbChain[latestMbNum] != mbHash {
+			latestMbNum = mbNum
+			mbChain[mbNum] = mbHash
+		} else {
+			N += 1
+		}
+	}
+
+	// wait till the mini-block is set in the streams registry before booting up last node
+	require.Eventuallyf(func() bool {
+		stream, err := tt.btc.StreamRegistry.GetStream(nil, streamId)
+		require.NoError(err)
+		return stream.LastMiniblockNum == uint64(latestMbNum)
+	}, 20*time.Second, 100*time.Millisecond, "expected to receive latest miniblock")
+
+	// start up last node that must reconcile and load the created stream on boot
+	tt.startNodes(opts.numNodes-1, opts.numNodes)
+	lastStartedNode := tt.nodes[opts.numNodes-1]
+
+	// make sure that node loaded the stream and synced up its local database with the stream registry.
+	// this happens as a background task, therefore wait till all mini-blocks are imported.
+	var (
+		stream events.Stream
+		view   events.StreamView
+	)
+	require.Eventuallyf(func() bool {
+		stream, view, err = lastStartedNode.service.cache.GetStream(ctx, streamId)
+		if err == nil {
+			if miniBlocks, _, err := stream.GetMiniblocks(ctx, 0, latestMbNum+1); err == nil {
+				return len(miniBlocks) == len(mbChain)
+			}
+		}
+		return false
+	}, 20*time.Second, 1000*time.Millisecond, "catching up with stream failed within reasonable time")
+
+	// verify that loaded miniblocks match with blocks in expected mbChain
+	miniBlocks, _, err := stream.GetMiniblocks(ctx, 0, latestMbNum+1)
+	require.NoError(err, "unable to get mini-blocks")
+	fetchedMbChain := make(map[int64]common.Hash)
+	for i, blk := range miniBlocks {
+		fetchedMbChain[int64(i)] = common.BytesToHash(blk.GetHeader().GetHash())
+	}
+
+	require.Equal(mbChain, fetchedMbChain, "unexpected mini-block chain")
+	require.Equal(latestMbNum, view.LastBlock().Num, "unexpected last mini-block num")
+	require.Equal(mbChain[latestMbNum], view.LastBlock().Hash, "unexpected last mini-block hash")
+}
+
+// TestStreamReconciliationForKnownStreams ensures that a node reconciles local streams that it already knows
+// but advanced when the node was down.
+func TestStreamReconciliationForKnownStreams(t *testing.T) {
+	var (
+		opts    = serviceTesterOpts{numNodes: 5, replicationFactor: 5, start: true}
+		tt      = newServiceTester(t, opts)
+		client  = tt.testClient(2)
+		ctx     = tt.ctx
+		require = tt.require
+	)
+
+	wallet, err := crypto.NewWallet(ctx)
+	require.NoError(err)
+
+	// create a stream, add some events and create a bunch of mini-blocks for the node to catch up to
+	streamId, cookie, _, err := createUserSettingsStream(
+		ctx,
+		wallet,
+		client,
+		&protocol.StreamSettings{
+			DisableMiniblockCreation: true,
+		},
+	)
+	require.NoError(err)
+
+	// create a bunch of mini-blocks and store them in mbChain for later comparison
+	N := 10
+	mbChain := map[int64]common.Hash{0: common.BytesToHash(cookie.PrevMiniblockHash)}
+	latestMbNum := int64(0)
+
+	for range N {
+		require.NoError(addUserBlockedFillerEvent(ctx, wallet, client, streamId, mbChain[latestMbNum].Bytes()))
+		mbHash, mbNum, err := tt.nodes[2].service.mbProducer.TestMakeMiniblock(ctx, streamId, false)
+		require.NoError(err)
+
+		if mbChain[latestMbNum] != mbHash {
+			latestMbNum = mbNum
+			mbChain[mbNum] = mbHash
+		} else {
+			N += 1
+		}
+	}
+
+	// ensure that the node we bring down has at least 1 mini-block for the test stream
+	require.Eventuallyf(func() bool {
+		_, view, err := tt.nodes[opts.numNodes-1].service.cache.GetStream(ctx, streamId)
+		require.NoError(err)
+		return view.LastBlock().Num >= 1
+	}, 20*time.Second, 100*time.Millisecond, "expected to receive latest miniblock")
+
+	// bring node down
+	nodeAddress := tt.nodes[opts.numNodes-1].address
+	tt.nodes[opts.numNodes-1].address = common.Address{}
+	tt.nodes[opts.numNodes-1].Close(ctx, tt.dbUrl)
+	tt.nodes[opts.numNodes-1].address = nodeAddress
+
+	// create extra mini-blocks
+	N = 10
+	for range N {
+		require.NoError(addUserBlockedFillerEvent(ctx, wallet, client, streamId, mbChain[latestMbNum].Bytes()))
+		mbHash, mbNum, err := tt.nodes[2].service.mbProducer.TestMakeMiniblock(ctx, streamId, false)
+		require.NoError(err)
+
+		if mbChain[latestMbNum] != mbHash {
+			latestMbNum = mbNum
+			mbChain[mbNum] = mbHash
+		} else {
+			N += 1
+		}
+	}
+
+	// ensure that the stream has the new blocks
+	require.Eventuallyf(func() bool {
+		stream, err := tt.btc.StreamRegistry.GetStream(nil, streamId)
+		require.NoError(err)
+		return stream.LastMiniblockNum == uint64(latestMbNum)
+	}, 20*time.Second, 100*time.Millisecond, "last miniblock not registered")
+
+	require.NoError(tt.startSingle(len(tt.nodes) - 1))
+	restartedNode := tt.nodes[opts.numNodes-1]
+
+	_, _, err = restartedNode.service.cache.GetStream(ctx, streamId)
+	require.NoError(err)
+
+	// create a new instance of a stream cache for the last node and ensure that when it is created it syncs stream
+	// that advanced several mini-blocks.
+	streamCache := restartedNode.service.cache
+
+	// wait till stream cache has finish reconciliation for the stream
+	var (
+		stream             events.Stream
+		receivedMiniblocks []*protocol.Miniblock
+	)
+
+	// grab mini-blocks from node that is already up and running and ensure that the just restarted node has the
+	// same miniblocks after it catches up.
+	stream, _, err = tt.nodes[opts.numNodes-2].service.cache.GetStream(ctx, streamId)
+	require.NoError(err)
+	expectedMiniblocks, _, err := stream.GetMiniblocks(ctx, 0, latestMbNum+1)
+	require.NoError(err)
+
+	require.Eventuallyf(func() bool {
+		syncStream, err := streamCache.GetSyncStream(ctx, streamId)
+		if err != nil {
+			return false
+		}
+
+		if receivedMiniblocks, _, err = syncStream.GetMiniblocks(ctx, 0, latestMbNum+1); err == nil {
+			return len(receivedMiniblocks) == len(expectedMiniblocks)
+		}
+		return false
+	}, 20*time.Second, 100*time.Millisecond, "expected to sync stream")
+
+	// make sure that node loaded the stream and synced up its local database with the streams registry
+	//miniBlocks, _, err := stream.GetMiniblocks(ctx, 0, latestMbNum+1)
+	//require.NoError(err, "unable to get mini-blocks")
+	fetchedMbChain := make(map[int64]common.Hash)
+	for i, blk := range receivedMiniblocks {
+		fetchedMbChain[int64(i)] = common.BytesToHash(blk.GetHeader().GetHash())
+	}
+
+	_, view, err := streamCache.GetStream(ctx, streamId)
+	require.NoError(err)
+
+	require.Equal(mbChain, fetchedMbChain, "unexpected mini-block chain")
+	require.Equal(latestMbNum, view.LastBlock().Num, "unexpected last mini-block num")
+	require.Equal(mbChain[latestMbNum], view.LastBlock().Hash, "unexpected last mini-block hash")
 }

--- a/core/node/storage/storage.go
+++ b/core/node/storage/storage.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-
 	"github.com/ethereum/go-ethereum/common"
 
 	. "github.com/river-build/river/core/node/shared"
@@ -106,7 +105,22 @@ type StreamStorage interface {
 		streamId StreamId,
 	) (*DebugReadStreamDataResult, error)
 
+	// StreamLastMiniBlock returns the last mini-block number for the given stream from storage.
+	StreamLastMiniBlock(ctx context.Context, streamID StreamId) (*LatestMiniBlock, error)
+
+	// ImportMiniBlocks imports raw blocks into the database.
+	//
+	// This bypasses the mini-block candidate/promotion approach and is meant to catch up the storage with the
+	// streams registry after the node was down.
+	ImportMiniBlocks(ctx context.Context, miniBlocks []*LatestMiniBlock) error
+
 	Close(ctx context.Context)
+}
+
+type LatestMiniBlock struct {
+	StreamID      StreamId
+	Number        int64
+	MiniBlockInfo []byte
 }
 
 type MiniblockDescriptor struct {

--- a/core/node/storage/storage.go
+++ b/core/node/storage/storage.go
@@ -106,18 +106,18 @@ type StreamStorage interface {
 	) (*DebugReadStreamDataResult, error)
 
 	// StreamLastMiniBlock returns the last mini-block number for the given stream from storage.
-	StreamLastMiniBlock(ctx context.Context, streamID StreamId) (*LatestMiniBlock, error)
+	StreamLastMiniBlock(ctx context.Context, streamID StreamId) (*MiniblockData, error)
 
-	// ImportMiniBlocks imports raw blocks into the database.
+	// ImportMiniblocks imports raw blocks into the database.
 	//
 	// This bypasses the mini-block candidate/promotion approach and is meant to catch up the storage with the
 	// streams registry after the node was down.
-	ImportMiniBlocks(ctx context.Context, miniBlocks []*LatestMiniBlock) error
+	ImportMiniblocks(ctx context.Context, miniBlocks []*MiniblockData) error
 
 	Close(ctx context.Context)
 }
 
-type LatestMiniBlock struct {
+type MiniblockData struct {
 	StreamID      StreamId
 	Number        int64
 	MiniBlockInfo []byte


### PR DESCRIPTION
With stream replications it is possible that a local stream advances when the node is down. 

This change adds support to the node that at boots it will compare streams from its local database with the streams registry. When the database is out of sync the node requests missing blocks from peers and write them to the database bringing the database and contract in sync.

closes #494 