### PR TITLE
sdk: allow empty bio in UserBio by adding updatedAt field

### DIFF
--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -1066,4 +1066,24 @@ describe('clientTest', () => {
         const decrypted = await bobsClient.getUserBio(bobsClient.userId)
         expect(decrypted).toStrictEqual(bio)
     })
+
+    test('setUserBio empty', async () => {
+        await expect(await bobsClient.initializeUser()).toResolve()
+        bobsClient.startSync()
+        const streamId = bobsClient.userMetadataStreamId!
+        const userMetadataStream = await bobsClient.waitForStream(streamId)
+
+        expect(userMetadataStream).toBeDefined()
+        expect(
+            userMetadataStream.view.snapshot?.content.case === 'userMetadataContent' &&
+                userMetadataStream.view.snapshot?.content.value.profileImage === undefined,
+        ).toBe(true)
+
+        const bio = new UserBio({ bio: '' })
+        const { eventId } = await bobsClient.setUserBio(bio)
+        expect(await waitFor(() => userMetadataStream.view.events.has(eventId))).toBe(true)
+
+        const decrypted = await bobsClient.getUserBio(bobsClient.userId)
+        expect(decrypted).toStrictEqual(bio)
+    })
 })

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -950,6 +950,7 @@ export class Client
         // encrypt the chunked media
         // use the lowercased userId as the key phrase
         const { key, iv } = await deriveKeyAndIV(context)
+        bio.updatedAt = BigInt(Date.now())
         const bioBinary = bio.toBinary()
         const { ciphertext } = await encryptAESGCM(bioBinary, key, iv)
         const encryptedData = new EncryptedData({

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -950,7 +950,7 @@ export class Client
         // encrypt the chunked media
         // use the lowercased userId as the key phrase
         const { key, iv } = await deriveKeyAndIV(context)
-        bio.updatedAt = BigInt(Date.now())
+        bio.updatedAtEpochMs = BigInt(Date.now())
         const bioBinary = bio.toBinary()
         const { ciphertext } = await encryptAESGCM(bioBinary, key, iv)
         const encryptedData = new EncryptedData({

--- a/protocol/payloads.proto
+++ b/protocol/payloads.proto
@@ -188,7 +188,7 @@ message ChunkedMedia {
 
 message UserBio {
     string bio = 1;
-    optional uint64 updated_at = 2;
+    optional uint64 updated_at_epoch_ms = 2;
 }
 
 // a client created with an bearer token cannot make blockchain transactions, but can add events to the river nodes

--- a/protocol/payloads.proto
+++ b/protocol/payloads.proto
@@ -188,6 +188,7 @@ message ChunkedMedia {
 
 message UserBio {
     string bio = 1;
+    optional uint64 updated_at = 2;
 }
 
 // a client created with an bearer token cannot make blockchain transactions, but can add events to the river nodes


### PR DESCRIPTION
Without the `updated_at` field, protobuf with empty bio field was failing to encrypt.