### PR TITLE
Fix missing channelId hex prefix in space dapp

### DIFF
--- a/packages/web3/src/v3/SpaceDapp.ts
+++ b/packages/web3/src/v3/SpaceDapp.ts
@@ -208,8 +208,9 @@ export class SpaceDapp implements ISpaceDapp {
         if (!space) {
             throw new Error(`Space with spaceId "${spaceId}" is not found.`)
         }
+        const channelId = ensureHexPrefix(channelNetworkId)
         return wrapTransaction(
-            () => space.Channels.write(signer).addRoleToChannel(channelNetworkId, roleId),
+            () => space.Channels.write(signer).addRoleToChannel(channelId, roleId),
             txnOpts,
         )
     }


### PR DESCRIPTION
causes
```
invalid arrayify value (argument="value", value="20f05e4ad4edbd5480a3602f249abd3dc767327dbd0000000000000000000000", code=INVALID_ARGUMENT, version=bytes/5.7.0)
```
Not sure how we missed this, maybe the client is converting it somewhere? anywho.