### PR TITLE
happy path cache headers for stream-metadata service

### DIFF
--- a/packages/stream-metadata/src/routes/profileImage.ts
+++ b/packages/stream-metadata/src/routes/profileImage.ts
@@ -67,7 +67,15 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 			profileImage.streamId
 		}?key=${bin_toHexString(key)}&iv=${bin_toHexString(iv)}`
 
-		return reply.redirect(redirectUrl)
+		return (
+			reply
+				.redirect(redirectUrl)
+				/**
+				 * public: The response may be cached by any cache, including shared caches like a CDN.
+				 * max-age=300: The response may be cached by the client for 300 seconds (5 minutes).
+				 */
+				.header('Cache-Control', 'public, max-age=300')
+		)
 	} catch (error) {
 		logger.error(
 			{

--- a/packages/stream-metadata/src/routes/spaceImage.ts
+++ b/packages/stream-metadata/src/routes/spaceImage.ts
@@ -75,7 +75,15 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 			spaceImage.streamId
 		}?key=${bin_toHexString(key)}&iv=${bin_toHexString(iv)}`
 
-		return reply.redirect(redirectUrl)
+		return (
+			reply
+				.redirect(redirectUrl)
+				/**
+				 * public: The response may be cached by any cache, including shared caches like a CDN.
+				 * max-age=300: The response may be cached by the client for 300 seconds (5 minutes).
+				 */
+				.header('Cache-Control', 'public, max-age=300')
+		)
 	} catch (error) {
 		logger.error(
 			{
@@ -85,7 +93,7 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 			},
 			'Failed to get encryption key or iv',
 		)
-		return reply.code(422).send('Failed to get encryption key or iv')
+		return reply.code(500).send('Failed to get encryption key or iv')
 	}
 }
 


### PR DESCRIPTION
this pr adds `Cache-Control` to the the happy paths of stream-metadata service core routes:

a) successful profile image redirects: 5 minutes
b) successful space image redirects: 5 minutes
c) successful media resolution: 1 year

Work remains on the following routes
- `/space/:spaceAddress`
- `/space/:spaceAddress/refresh`
- `/user/:userId/bio`
- `/user/:userId/refresh`

And edge cases (4xx & 5xx on all routes)