### PR TITLE
Playground: remove unnecessary check

### DIFF
--- a/packages/sdk/src/sync-agent/spaces/models/space.ts
+++ b/packages/sdk/src/sync-agent/spaces/models/space.ts
@@ -111,9 +111,6 @@ export class Space extends PersistedObservable<SpaceModel> {
     }
 
     getChannel(channelId: string): Channel {
-        if (!this.data.channelIds.includes(channelId)) {
-            throw new Error(`channel ${channelId} not found in space ${this.data.id}`)
-        }
         if (!this.channels[channelId]) {
             this.channels[channelId] = new Channel(
                 channelId,


### PR DESCRIPTION
Because we want to pre load everything, we should allow the system to make channel objects even if we don’t have local data for them yet. We do the same thing with members.