### PR TITLE
Fix race in syncAgent store

### DIFF
--- a/packages/sdk/src/observable/persistedObservable.ts
+++ b/packages/sdk/src/observable/persistedObservable.ts
@@ -65,8 +65,8 @@ export class PersistedObservable<T extends Identifiable>
             (error: Error) => {
                 super.setValue({ status: 'error', data: this.data, error })
             },
-            async () => {
-                await this.onLoaded()
+            () => {
+                this.onLoaded()
             },
         )
     }
@@ -98,20 +98,18 @@ export class PersistedObservable<T extends Identifiable>
                 (e) => {
                     super.setValue({ status: 'error', data: prevData, error: e })
                 },
-                async () => {
-                    await this.onSaved()
+                () => {
+                    this.onSaved()
                 },
             )
         })
     }
 
-    protected async onLoaded() {
+    protected onLoaded() {
         // abstract
-        return Promise.resolve()
     }
 
-    protected async onSaved() {
+    protected onSaved() {
         // abstract
-        return Promise.resolve()
     }
 }

--- a/packages/sdk/src/sync-agent/members/members.ts
+++ b/packages/sdk/src/sync-agent/members/members.ts
@@ -23,7 +23,7 @@ export class Members extends PersistedObservable<MembersModel> {
         this.members = {}
     }
 
-    protected override async onLoaded() {
+    protected override onLoaded() {
         this.riverConnection.registerView((client) => {
             if (
                 client.streams.has(this.data.id) &&

--- a/packages/sdk/src/sync-agent/river-connection/models/riverChain.ts
+++ b/packages/sdk/src/sync-agent/river-connection/models/riverChain.ts
@@ -34,7 +34,7 @@ export class RiverChain extends PersistedObservable<RiverChainModel> {
     }
 
     // implement start function then wire it up from parent
-    override async onLoaded() {
+    protected override onLoaded() {
         this.withInfiniteRetries(() => this.fetchUrls())
         this.withInfiniteRetries(() => this.fetchStreamExists(makeUserStreamId(this.userId)))
     }

--- a/packages/sdk/src/sync-agent/river-connection/riverConnection.ts
+++ b/packages/sdk/src/sync-agent/river-connection/riverConnection.ts
@@ -68,7 +68,7 @@ export class RiverConnection extends PersistedObservable<RiverConnectionModel> {
         this.riverChain = new RiverChain(store, riverRegistryDapp, this.userId)
     }
 
-    override async onLoaded() {
+    protected override onLoaded() {
         //
     }
 

--- a/packages/sdk/src/sync-agent/spaces/models/channel.ts
+++ b/packages/sdk/src/sync-agent/spaces/models/channel.ts
@@ -34,7 +34,7 @@ export class Channel extends PersistedObservable<ChannelModel> {
         this.members = new Members(id, riverConnection, store)
     }
 
-    protected override async onLoaded() {
+    protected override onLoaded() {
         this.riverConnection.registerView((client) => {
             if (
                 client.streams.has(this.data.id) &&

--- a/packages/sdk/src/sync-agent/spaces/models/space.ts
+++ b/packages/sdk/src/sync-agent/spaces/models/space.ts
@@ -41,7 +41,7 @@ export class Space extends PersistedObservable<SpaceModel> {
         this.members = new Members(id, riverConnection, store)
     }
 
-    protected override async onLoaded() {
+    protected override onLoaded() {
         this.riverConnection.registerView((client) => {
             if (
                 client.streams.has(this.data.id) &&

--- a/packages/sdk/src/sync-agent/spaces/spaces.ts
+++ b/packages/sdk/src/sync-agent/spaces/spaces.ts
@@ -34,7 +34,7 @@ export class Spaces extends PersistedObservable<SpacesModel> {
         super({ id: '0', spaceIds: [] }, store, LoadPriority.high)
     }
 
-    protected override async onLoaded() {
+    protected override onLoaded() {
         this.userMemberships.subscribe(
             (value) => {
                 this.onUserMembershipsChanged(value)

--- a/packages/sdk/src/sync-agent/user/models/userInbox.ts
+++ b/packages/sdk/src/sync-agent/user/models/userInbox.ts
@@ -28,7 +28,7 @@ export class UserInbox extends PersistedObservable<UserInboxModel> {
         )
     }
 
-    protected override async onLoaded() {
+    protected override onLoaded() {
         this.riverConnection.registerView(this.onClientStarted)
     }
 

--- a/packages/sdk/src/sync-agent/user/models/userMemberships.ts
+++ b/packages/sdk/src/sync-agent/user/models/userMemberships.ts
@@ -37,7 +37,7 @@ export class UserMemberships extends PersistedObservable<UserMembershipsModel> {
         this.riverConnection = riverConnection
     }
 
-    override async onLoaded() {
+    protected override onLoaded() {
         this.riverConnection.registerView(this.onClientStarted)
     }
 

--- a/packages/sdk/src/sync-agent/user/models/userMetadata.ts
+++ b/packages/sdk/src/sync-agent/user/models/userMetadata.ts
@@ -28,7 +28,7 @@ export class UserMetadata extends PersistedObservable<UserMetadataModel> {
         )
     }
 
-    protected override async onLoaded() {
+    protected override onLoaded() {
         this.riverConnection.registerView(this.onClientStarted)
     }
 

--- a/packages/sdk/src/sync-agent/user/models/userSettings.ts
+++ b/packages/sdk/src/sync-agent/user/models/userSettings.ts
@@ -25,7 +25,7 @@ export class UserSettings extends PersistedObservable<UserSettingsModel> {
         )
     }
 
-    protected override async onLoaded() {
+    protected override onLoaded() {
         this.riverConnection.registerView(this.onClientStarted)
     }
 


### PR DESCRIPTION
a transaction can have side effects which can spawn a new transaction, in the meantime a new transaction group could have been started already. Just piggyback on the existing transaction group if it exists.