### PR TITLE
Increase timeout for e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,7 @@ jobs:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_multinode_ent
         runs-on: ubuntu-latest-8-cores
-        timeout-minutes: 30
+        timeout-minutes: 40
         services:
             postgres-core:
                 image: postgres:latest
@@ -431,7 +431,7 @@ jobs:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_multinode_ent_legacy
         runs-on: ubuntu-latest-8-cores
-        timeout-minutes: 30
+        timeout-minutes: 40
         services:
             postgres-core:
                 image: postgres:latest


### PR DESCRIPTION
Tests are failing again due to 30min timeout after I extended E2E tests for ETH balance. Earlier last week, I discussed this issue with Austin - this was the recommendation.