### PR TITLE
stream-metadata: fix opensea invalidation url

### DIFF
--- a/packages/stream-metadata/src/opensea.ts
+++ b/packages/stream-metadata/src/opensea.ts
@@ -5,16 +5,20 @@ import { FastifyBaseLogger } from 'fastify'
 import { config } from './environment'
 import { spaceDapp } from './contract-utils'
 
-const getOpenSeaAPIUrl = (space: SpaceInfo) => {
+const getOpenSeaAPIUrl = (logger: FastifyBaseLogger, space: SpaceInfo) => {
 	const spaceOwnerAddress = config.web3Config.base.addresses.spaceOwner
+	const chainId = config.web3Config.base.chainId
 	const tokenId = BigNumber.from(space.tokenId).toString()
 
-	if (space.networkId === String(BASE_MAINNET)) {
+	if (chainId === BASE_MAINNET) {
 		return `https://api.opensea.io/api/v2/chain/base/contract/${spaceOwnerAddress}/nfts/${tokenId}/refresh`
-	} else if (space.networkId === String(BASE_SEPOLIA)) {
+	} else if (chainId === BASE_SEPOLIA) {
+		return `https://testnets-api.opensea.io/api/v2/chain/base_sepolia/contract/${spaceOwnerAddress}/nfts/${tokenId}/refresh`
+	} else if (chainId === 31337) {
 		return `https://testnets-api.opensea.io/api/v2/chain/base_sepolia/contract/${spaceOwnerAddress}/nfts/${tokenId}/refresh`
 	} else {
-		throw new Error('Unsupported network')
+		logger.error({ chainId }, 'Unsupported network')
+		throw new Error(`Unsupported network ${chainId}`)
 	}
 }
 
@@ -40,7 +44,7 @@ export const refreshOpenSea = async ({
 		throw new Error('Space not found')
 	}
 
-	const url = getOpenSeaAPIUrl(space)
+	const url = getOpenSeaAPIUrl(logger, space)
 	logger.info({ url, spaceAddress }, 'refreshing openSea')
 
 	const response = await fetch(url, {


### PR DESCRIPTION
I was using the networkId by mistake, the chainId prop from the `web3Config.base` is the right one.