### PR TITLE
stream-metadata: fix base url in space metadata endpoint

### DIFF
--- a/packages/stream-metadata/src/routes/spaceMetadata.ts
+++ b/packages/stream-metadata/src/routes/spaceMetadata.ts
@@ -6,7 +6,7 @@ import { config } from '../environment'
 import { isValidEthereumAddress } from '../validators'
 import { spaceDapp } from '../contract-utils'
 
-export const spaceMetadataBaseUrl = `${config.streamMetadataBaseUrl}space`.toLowerCase()
+export const spaceMetadataBaseUrl = `${config.streamMetadataBaseUrl}/space`.toLowerCase()
 
 const paramsSchema = z.object({
 	spaceAddress: z.string().min(1, 'spaceAddress parameter is required'),


### PR DESCRIPTION
Previously:
```json
{
  "name": "My fancy space",
  "description": "idk ;-;",
  "image": "https://gamma.river.deliveryspace/0x9e5318618c141f3f9949250bf73fb98a9b22b03e/image"
}
```

This PR fix the url