### PR TITLE
add workflow dispatch rule on gh actions

### DIFF
--- a/.github/workflows/Bytecode_diff_report.yml
+++ b/.github/workflows/Bytecode_diff_report.yml
@@ -1,0 +1,4 @@
+name: Bytecode diff report
+
+on:
+    workflow_dispatch:

--- a/.github/workflows/Upgrade_network_facets.yml
+++ b/.github/workflows/Upgrade_network_facets.yml
@@ -1,0 +1,4 @@
+name: Upgrade network facets
+
+on:
+    workflow_dispatch:


### PR DESCRIPTION
To prevent these actions from running on every branch in ci. They will be replaced / implemented in https://github.com/river-build/river/pull/1008/files.