### PR TITLE
fetch e2ekeys _after_ generating fallback keys

### DIFF
--- a/packages/encryption/src/encryptionDevice.ts
+++ b/packages/encryption/src/encryptionDevice.ts
@@ -140,8 +140,8 @@ export class EncryptionDevice {
                 }
                 await this.initializeAccount(account)
             }
-            e2eKeys = JSON.parse(account.identity_keys())
             await this.generateFallbackKeyIfNeeded()
+            e2eKeys = JSON.parse(account.identity_keys())
             this.fallbackKey = await this.getFallbackKey()
         } finally {
             account.free()


### PR DESCRIPTION
i believe that this _could_ be the source of the `BAD_MESSAGE_KEY_ID` errors we've seen in prod lately.
The `e2ekeys` depend on the account identity keys, which in turn depend on the result of `generateFallbackKeyIfNeeded()`.

<img width="952" alt="image" src="https://github.com/user-attachments/assets/fb6aace3-c072-4c2a-a3bc-39d5d85da3ca">

I didn't actually run this, but this looks suspicious to me!

if correct, this was introduced in #616 on Aug 6.