### PR TITLE
fix(contract): refactor space URI validation to allow empty URIs

### DIFF
--- a/contracts/src/spaces/facets/owner/SpaceOwnerBase.sol
+++ b/contracts/src/spaces/facets/owner/SpaceOwnerBase.sol
@@ -48,6 +48,7 @@ abstract contract SpaceOwnerBase is ISpaceOwnerBase {
     string memory longDescription
   ) internal {
     Validator.checkLength(name, 2);
+    // if the space uri is empty, it will default to `${defaultUri}/${spaceAddress}`
     Validator.checkLength(uri, 0);
     Validator.checkAddress(space);
 
@@ -74,7 +75,8 @@ abstract contract SpaceOwnerBase is ISpaceOwnerBase {
     string memory longDescription
   ) internal {
     Validator.checkLength(name, 2);
-    Validator.checkLength(uri, 1);
+    // if the space uri is empty, it will default to `${defaultUri}/${spaceAddress}`
+    Validator.checkLength(uri, 0);
 
     SpaceOwnerStorage.Layout storage ds = SpaceOwnerStorage.layout();
 

--- a/contracts/test/spaces/owner/SpaceOwner.t.sol
+++ b/contracts/test/spaces/owner/SpaceOwner.t.sol
@@ -147,19 +147,34 @@ contract SpaceOwnerTest is ISpaceOwnerBase, IOwnableBase, BaseSetup {
     );
   }
 
-  function test_updateSpace_revert_invalidUri() external {
+  function test_updateSpace_emptyUri() external {
+    string memory defaultUri = "ipfs://default-uri";
+
+    vm.prank(deployer);
+    spaceOwnerToken.setDefaultUri(defaultUri);
+
     address spaceAddress = _randomAddress();
 
     mintSpace(uri, spaceAddress);
 
     vm.prank(spaceFactory);
-    vm.expectRevert(Validator__InvalidStringLength.selector);
     spaceOwnerToken.updateSpaceInfo(
       spaceAddress,
       "New Name",
       "",
       "new short description",
       "new long description"
+    );
+
+    Space memory space = spaceOwnerToken.getSpaceInfo(spaceAddress);
+    string memory tokenUri = spaceOwnerToken.tokenURI(space.tokenId);
+
+    assertEq(space.uri, "");
+    assertTrue(
+      LibString.endsWith(
+        LibString.toCase(tokenUri, false),
+        LibString.toHexString(spaceAddress)
+      )
     );
   }
 


### PR DESCRIPTION
Updated space URI validation to accept empty URIs, defaulting to `${defaultUri}/${spaceAddress}`. Modified the test case to handle the new behavior and added assertions to verify the correct default URI is set.

Fully solves https://github.com/HereNotThere/harmony/pull/7942.