### PR TITLE
formatting stream-metadata log levels as strings instead of numbers

### DIFF
--- a/packages/stream-metadata/src/logger.ts
+++ b/packages/stream-metadata/src/logger.ts
@@ -13,6 +13,11 @@ const pretty: TransportSingleOptions = {
 const pinoOptions: LoggerOptions = {
 	transport: config.log.pretty ? pretty : undefined,
 	level: config.log.level,
+	formatters: {
+		level(level) {
+			return { level }
+		},
+	},
 }
 
 const baseLogger = pino(pinoOptions)


### PR DESCRIPTION
pino log levels were showing up as `30` for `info` and `50` for `error`, but this causes all logs to appear as if they were info logs. this pr formats the level field so that we can properly categorize and visualize all error logs.