### PR TITLE
Fix media entitlement test that mistakenly always created legacy spaces

### DIFF
--- a/packages/sdk/src/mediaWithEntitlements.test.ts
+++ b/packages/sdk/src/mediaWithEntitlements.test.ts
@@ -183,7 +183,8 @@ describe('mediaWithEntitlements', () => {
         }
 
         log('transaction start bob creating space')
-        const transaction = await spaceDapp.createLegacySpace(
+        const transaction = await createVersionedSpace(
+            spaceDapp,
             {
                 spaceName: 'space-name',
                 uri: 'http://bobs-space-metadata.com',


### PR DESCRIPTION
One stray test was not migrated to branch on which space version to create depending on test suite, and is always making legacy spaces. This PR fixes that test to use the space determined by environment variables to E2E suites run locally and in CI can correctly exercise both legacy and v2 spaces.