### PR TITLE
Kerem/stream metatada fix cache headers

### DIFF
--- a/packages/stream-metadata/src/routes/media.ts
+++ b/packages/stream-metadata/src/routes/media.ts
@@ -67,8 +67,10 @@ export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 				/**
 				 * public: The response must be cached by any cache, including shared caches like a CDN.
 				 * max-age=31536000: The response must be cached for up to 1 year. This is the maximum value for max-age.
+				 * s-maxage=31536000: The response must be cached for up to 1 year by shared caches like a CDN.
+				 * immutable: The response is immutable and won't change over time.
 				 */
-				.header('Cache-Control', 'public, max-age=31536000, immutable')
+				.header('Cache-Control', 'public, max-age=31536000, s-maxage=31536000, immutable')
 				.send(Buffer.from(data))
 		)
 	} catch (error) {

--- a/packages/stream-metadata/src/routes/media.ts
+++ b/packages/stream-metadata/src/routes/media.ts
@@ -65,12 +65,10 @@ export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 			reply
 				.header('Content-Type', mimeType)
 				/**
-				 * public: The response must be cached by any cache, including shared caches like a CDN.
-				 * max-age=31536000: The response must be cached for up to 1 year. This is the maximum value for max-age.
-				 * s-maxage=31536000: The response must be cached for up to 1 year by shared caches like a CDN.
-				 * immutable: The response is immutable and won't change over time.
+				 * public: The response may be cached by any cache, including shared caches like a CDN.
+				 * max-age=31536000: The response may be cached for up to 1 year. This is the maximum value for max-age.
 				 */
-				.header('Cache-Control', 'public, max-age=31536000, s-maxage=31536000, immutable')
+				.header('Cache-Control', 'public, max-age=31536000')
 				.send(Buffer.from(data))
 		)
 	} catch (error) {

--- a/packages/stream-metadata/src/routes/media.ts
+++ b/packages/stream-metadata/src/routes/media.ts
@@ -65,10 +65,10 @@ export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 			reply
 				.header('Content-Type', mimeType)
 				/**
-				 * public: The response may be cached by any cache, including shared caches like a CDN.
-				 * max-age=31536000: The response may be cached for up to 1 year. This is the maximum value for max-age.
+				 * public: The response must be cached by any cache, including shared caches like a CDN.
+				 * max-age=31536000: The response must be cached for up to 1 year. This is the maximum value for max-age.
 				 */
-				.header('Cache-Control', 'public, max-age=31536000')
+				.header('Cache-Control', 'public, max-age=31536000, immutable')
 				.send(Buffer.from(data))
 		)
 	} catch (error) {

--- a/packages/stream-metadata/src/routes/profileImage.ts
+++ b/packages/stream-metadata/src/routes/profileImage.ts
@@ -74,7 +74,7 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 				 * max-age=300: The response may be cached by the client for 300 seconds (5 minutes).
 				 */
 				.header('Cache-Control', 'public, max-age=300')
-				.redirect(redirectUrl)
+				.redirect(redirectUrl, 307)
 		)
 	} catch (error) {
 		logger.error(

--- a/packages/stream-metadata/src/routes/profileImage.ts
+++ b/packages/stream-metadata/src/routes/profileImage.ts
@@ -69,12 +69,12 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 
 		return (
 			reply
-				.redirect(redirectUrl)
 				/**
 				 * public: The response may be cached by any cache, including shared caches like a CDN.
 				 * max-age=300: The response may be cached by the client for 300 seconds (5 minutes).
 				 */
 				.header('Cache-Control', 'public, max-age=300')
+				.redirect(redirectUrl)
 		)
 	} catch (error) {
 		logger.error(

--- a/packages/stream-metadata/src/routes/profileImage.ts
+++ b/packages/stream-metadata/src/routes/profileImage.ts
@@ -69,11 +69,9 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 
 		return (
 			reply
-				/**
-				 * public: The response may be cached by any cache, including shared caches like a CDN.
-				 * max-age=300: The response may be cached by the client for 300 seconds (5 minutes).
-				 */
-				.header('Cache-Control', 'public, max-age=300')
+				// client should cache the image for 30 seconds, and the CDN for 5 minutes
+				// after 30 seconds, the client will check the CDN for a new image
+				.header('Cache-Control', 'public, max-age=30, s-maxage=300')
 				.redirect(redirectUrl, 307)
 		)
 	} catch (error) {

--- a/packages/stream-metadata/src/routes/spaceImage.ts
+++ b/packages/stream-metadata/src/routes/spaceImage.ts
@@ -77,12 +77,12 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 
 		return (
 			reply
-				.redirect(redirectUrl)
 				/**
 				 * public: The response may be cached by any cache, including shared caches like a CDN.
 				 * max-age=300: The response may be cached by the client for 300 seconds (5 minutes).
 				 */
 				.header('Cache-Control', 'public, max-age=300')
+				.redirect(redirectUrl)
 		)
 	} catch (error) {
 		logger.error(

--- a/packages/stream-metadata/src/routes/spaceImage.ts
+++ b/packages/stream-metadata/src/routes/spaceImage.ts
@@ -77,11 +77,9 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 
 		return (
 			reply
-				/**
-				 * public: The response may be cached by any cache, including shared caches like a CDN.
-				 * max-age=300: The response may be cached by the client for 300 seconds (5 minutes).
-				 */
-				.header('Cache-Control', 'public, max-age=300')
+				// client should cache the image for 30 seconds, and the CDN for 5 minutes
+				// after 30 seconds, the client will check the CDN for a new image
+				.header('Cache-Control', 'public, max-age=30, s-maxage=300')
 				.redirect(redirectUrl, 307)
 		)
 	} catch (error) {

--- a/packages/stream-metadata/src/routes/spaceImage.ts
+++ b/packages/stream-metadata/src/routes/spaceImage.ts
@@ -82,7 +82,7 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 				 * max-age=300: The response may be cached by the client for 300 seconds (5 minutes).
 				 */
 				.header('Cache-Control', 'public, max-age=300')
-				.redirect(redirectUrl)
+				.redirect(redirectUrl, 307)
 		)
 	} catch (error) {
 		logger.error(


### PR DESCRIPTION
setting the cache-control header before calling `redirect` as required by fastify