### PR TITLE
Kerem/stream metadata cache errors

### DIFF
--- a/packages/stream-metadata/src/check-cache-control.ts
+++ b/packages/stream-metadata/src/check-cache-control.ts
@@ -17,14 +17,14 @@ export function addCacheControlCheck(
 	},
 ) {
 	const { skippedRoutes } = options
-	srv.addHook('onSend', (request, reply, payload, done) => {
+	srv.addHook('onResponse', (request, reply, done) => {
 		const shouldCheck = !skippedRoutes.some((route) => request.url.includes(route))
 
 		if (shouldCheck) {
 			const cacheControlHeader = reply.getHeader('Cache-Control')
 			if (isEmptyHeader(cacheControlHeader)) {
 				const headers = reply.getHeaders()
-				request.log.warn({ headers, payload }, 'Missing Cache-Control header')
+				request.log.warn({ headers }, 'Missing Cache-Control header')
 			}
 		}
 

--- a/packages/stream-metadata/src/check-cache-control.ts
+++ b/packages/stream-metadata/src/check-cache-control.ts
@@ -1,0 +1,33 @@
+import type { Server } from './node'
+
+const isEmptyHeader = (header: string | number | string[] | undefined) => {
+	if (!header) return true
+	if (Array.isArray(header)) return header.length === 0
+	if (typeof header === 'string') return header === ''
+	if (typeof header === 'number') return header === 0
+
+	return false
+}
+
+// Adds a hook to check if the Cache-Control header is missing
+export function addCacheControlCheck(
+	srv: Server,
+	options: {
+		skippedRoutes: string[]
+	},
+) {
+	const { skippedRoutes } = options
+	srv.addHook('onSend', (request, reply, payload, done) => {
+		const shouldCheck = !skippedRoutes.some((route) => request.url.includes(route))
+
+		if (shouldCheck) {
+			const cacheControlHeader = reply.getHeader('Cache-Control')
+			if (isEmptyHeader(cacheControlHeader)) {
+				const headers = reply.getHeaders()
+				request.log.warn({ headers, payload }, 'Missing Cache-Control header')
+			}
+		}
+
+		done()
+	})
+}

--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -80,10 +80,14 @@ export function setupRoutes(srv: Server) {
 
 	// not cached
 	srv.get('/health', checkHealth)
+
+	// should be cached, but not before implementing /refresh on metadata routes
 	srv.get('/space/:spaceAddress', fetchSpaceMetadata)
+	srv.get('/user/:userId/bio', fetchUserBio)
+
+	// should be rate-limited, but not yet
 	srv.get('/space/:spaceAddress/refresh', spaceRefresh)
 	srv.get('/user/:userId/refresh', userRefresh)
-	srv.get('/user/:userId/bio', fetchUserBio)
 
 	// Fastify will return 404 for any unmatched routes
 }

--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -73,7 +73,7 @@ export function setupRoutes(srv: Server) {
 	 * Routes
 	 */
 	srv.get('/health', checkHealth)
-	srv.get('/space/:spaceAddress', async (request, reply) => fetchSpaceMetadata(request, reply))
+	srv.get('/space/:spaceAddress', fetchSpaceMetadata)
 	srv.get('/space/:spaceAddress/image', fetchSpaceImage)
 	srv.get('/space/:spaceAddress/refresh', spaceRefresh)
 	srv.get('/user/:userId/image', fetchUserProfileImage)

--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -78,12 +78,12 @@ export function setupRoutes(srv: Server) {
 	srv.get('/media/:mediaStreamId', fetchMedia)
 	srv.get('/user/:userId/image', fetchUserProfileImage)
 	srv.get('/space/:spaceAddress/image', fetchSpaceImage)
+	srv.get('/space/:spaceAddress', fetchSpaceMetadata)
 
 	// not cached
 	srv.get('/health', checkHealth)
 
 	// should be cached, but not before implementing /refresh on metadata routes
-	srv.get('/space/:spaceAddress', fetchSpaceMetadata)
 	srv.get('/user/:userId/bio', fetchUserBio)
 
 	// should be rate-limited, but not yet

--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -72,14 +72,18 @@ export function setupRoutes(srv: Server) {
 	/*
 	 * Routes
 	 */
+
+	// cached
+	srv.get('/media/:mediaStreamId', fetchMedia)
+	srv.get('/user/:userId/image', fetchUserProfileImage)
+	srv.get('/space/:spaceAddress/image', fetchSpaceImage)
+
+	// not cached
 	srv.get('/health', checkHealth)
 	srv.get('/space/:spaceAddress', fetchSpaceMetadata)
-	srv.get('/space/:spaceAddress/image', fetchSpaceImage)
 	srv.get('/space/:spaceAddress/refresh', spaceRefresh)
-	srv.get('/user/:userId/image', fetchUserProfileImage)
 	srv.get('/user/:userId/refresh', userRefresh)
 	srv.get('/user/:userId/bio', fetchUserBio)
-	srv.get('/media/:mediaStreamId', fetchMedia)
 
 	// Fastify will return 404 for any unmatched routes
 }

--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -15,6 +15,7 @@ import { fetchUserBio } from './routes/userBio'
 import { fetchMedia } from './routes/media'
 import { spaceRefresh } from './routes/spaceRefresh'
 import { userRefresh } from './routes/userRefresh'
+import { addCacheControlCheck } from './check-cache-control'
 
 // Set the process title to 'stream-metadata' so it can be easily identified
 // or killed with `pkill stream-metadata`
@@ -118,6 +119,9 @@ async function main() {
 	try {
 		await registerPlugins(server)
 		setupRoutes(server)
+		addCacheControlCheck(server, {
+			skippedRoutes: ['/refresh', '/health'],
+		})
 		await server.listen({
 			port: config.port,
 			host: config.host,

--- a/packages/stream-metadata/src/routes/media.ts
+++ b/packages/stream-metadata/src/routes/media.ts
@@ -28,7 +28,7 @@ const querySchema = z.object({
 
 const CACHE_CONTROL = {
 	200: 'public, max-age=31536000',
-	'4xx': 'public, max-age=30, s-maxage=300',
+	'4xx': 'public, max-age=30, s-maxage=3600',
 }
 
 export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {

--- a/packages/stream-metadata/src/routes/media.ts
+++ b/packages/stream-metadata/src/routes/media.ts
@@ -28,9 +28,7 @@ const querySchema = z.object({
 
 const CACHE_CONTROL = {
 	200: 'public, max-age=31536000',
-	400: 'public, max-age=30, s-maxage=300',
-	404: 'public, max-age=30, s-maxage=300',
-	422: 'public, max-age=30, s-maxage=300',
+	'4xx': 'public, max-age=30, s-maxage=300',
 }
 
 export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
@@ -43,7 +41,7 @@ export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 		logger.info(errorMessage)
 		return reply
 			.code(400)
-			.header('Cache-Control', CACHE_CONTROL[400])
+			.header('Cache-Control', CACHE_CONTROL['4xx'])
 			.send({ error: 'Bad Request', message: errorMessage })
 	}
 	if (!queryResult.success) {
@@ -51,7 +49,7 @@ export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 		logger.info(errorMessage)
 		return reply
 			.code(400)
-			.header('Cache-Control', CACHE_CONTROL[400])
+			.header('Cache-Control', CACHE_CONTROL['4xx'])
 			.send({ error: 'Bad Request', message: errorMessage })
 	}
 
@@ -73,7 +71,7 @@ export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 			)
 			return reply
 				.code(422)
-				.header('Cache-Control', CACHE_CONTROL[422])
+				.header('Cache-Control', CACHE_CONTROL['4xx'])
 				.send('Invalid data or mimeType')
 		}
 
@@ -88,7 +86,7 @@ export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 		// And return a 500 here, and again, give it a proper cache-control header.
 		return reply
 			.code(404)
-			.header('Cache-Control', CACHE_CONTROL[404])
+			.header('Cache-Control', CACHE_CONTROL['4xx'])
 			.send({ error: 'Not Found', message: 'Failed to fetch media stream content' })
 	}
 }

--- a/packages/stream-metadata/src/routes/media.ts
+++ b/packages/stream-metadata/src/routes/media.ts
@@ -26,6 +26,13 @@ const querySchema = z.object({
 		.transform((value) => bin_fromHexString(value)),
 })
 
+const FETCH_MEDIA_CACHE_CONTROL = {
+	200: 'public, max-age=31536000',
+	400: 'public, max-age=30, s-maxage=300',
+	404: 'public, max-age=30, s-maxage=300',
+	422: 'public, max-age=30, s-maxage=300',
+}
+
 export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 	const logger = request.log.child({ name: fetchMedia.name })
 
@@ -34,12 +41,18 @@ export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 	if (!paramsResult.success) {
 		const errorMessage = paramsResult.error?.errors[0]?.message || 'Invalid parameters'
 		logger.info(errorMessage)
-		return reply.code(400).send({ error: 'Bad Request', message: errorMessage })
+		return reply
+			.code(400)
+			.header('Cache-Control', FETCH_MEDIA_CACHE_CONTROL[400])
+			.send({ error: 'Bad Request', message: errorMessage })
 	}
 	if (!queryResult.success) {
 		const errorMessage = queryResult.error?.errors[0]?.message || 'Invalid parameters'
 		logger.info(errorMessage)
-		return reply.code(400).send({ error: 'Bad Request', message: errorMessage })
+		return reply
+			.code(400)
+			.header('Cache-Control', FETCH_MEDIA_CACHE_CONTROL[400])
+			.send({ error: 'Bad Request', message: errorMessage })
 	}
 
 	const { mediaStreamId } = paramsResult.data
@@ -58,19 +71,16 @@ export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 				},
 				'Invalid data or mimeType',
 			)
-			return reply.code(422).send('Invalid data or mimeType')
+			return reply
+				.code(422)
+				.header('Cache-Control', FETCH_MEDIA_CACHE_CONTROL[422])
+				.send('Invalid data or mimeType')
 		}
 
-		return (
-			reply
-				.header('Content-Type', mimeType)
-				/**
-				 * public: The response may be cached by any cache, including shared caches like a CDN.
-				 * max-age=31536000: The response may be cached for up to 1 year. This is the maximum value for max-age.
-				 */
-				.header('Cache-Control', 'public, max-age=31536000')
-				.send(Buffer.from(data))
-		)
+		return reply
+			.header('Content-Type', mimeType)
+			.header('Cache-Control', FETCH_MEDIA_CACHE_CONTROL[200])
+			.send(Buffer.from(data))
 	} catch (error) {
 		logger.error({ mediaStreamId, error }, 'Failed to fetch media stream content')
 		// TODO: this should be a 500, not a 404.
@@ -78,6 +88,7 @@ export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 		// And return a 500 here, and again, give it a proper cache-control header.
 		return reply
 			.code(404)
+			.header('Cache-Control', FETCH_MEDIA_CACHE_CONTROL[404])
 			.send({ error: 'Not Found', message: 'Failed to fetch media stream content' })
 	}
 }

--- a/packages/stream-metadata/src/routes/media.ts
+++ b/packages/stream-metadata/src/routes/media.ts
@@ -26,7 +26,7 @@ const querySchema = z.object({
 		.transform((value) => bin_fromHexString(value)),
 })
 
-const FETCH_MEDIA_CACHE_CONTROL = {
+const CACHE_CONTROL = {
 	200: 'public, max-age=31536000',
 	400: 'public, max-age=30, s-maxage=300',
 	404: 'public, max-age=30, s-maxage=300',
@@ -43,7 +43,7 @@ export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 		logger.info(errorMessage)
 		return reply
 			.code(400)
-			.header('Cache-Control', FETCH_MEDIA_CACHE_CONTROL[400])
+			.header('Cache-Control', CACHE_CONTROL[400])
 			.send({ error: 'Bad Request', message: errorMessage })
 	}
 	if (!queryResult.success) {
@@ -51,7 +51,7 @@ export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 		logger.info(errorMessage)
 		return reply
 			.code(400)
-			.header('Cache-Control', FETCH_MEDIA_CACHE_CONTROL[400])
+			.header('Cache-Control', CACHE_CONTROL[400])
 			.send({ error: 'Bad Request', message: errorMessage })
 	}
 
@@ -73,13 +73,13 @@ export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 			)
 			return reply
 				.code(422)
-				.header('Cache-Control', FETCH_MEDIA_CACHE_CONTROL[422])
+				.header('Cache-Control', CACHE_CONTROL[422])
 				.send('Invalid data or mimeType')
 		}
 
 		return reply
 			.header('Content-Type', mimeType)
-			.header('Cache-Control', FETCH_MEDIA_CACHE_CONTROL[200])
+			.header('Cache-Control', CACHE_CONTROL[200])
 			.send(Buffer.from(data))
 	} catch (error) {
 		logger.error({ mediaStreamId, error }, 'Failed to fetch media stream content')
@@ -88,7 +88,7 @@ export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 		// And return a 500 here, and again, give it a proper cache-control header.
 		return reply
 			.code(404)
-			.header('Cache-Control', FETCH_MEDIA_CACHE_CONTROL[404])
+			.header('Cache-Control', CACHE_CONTROL[404])
 			.send({ error: 'Not Found', message: 'Failed to fetch media stream content' })
 	}
 }

--- a/packages/stream-metadata/src/routes/profileImage.ts
+++ b/packages/stream-metadata/src/routes/profileImage.ts
@@ -16,7 +16,7 @@ const paramsSchema = z.object({
 })
 
 const CACHE_CONTROL = {
-	307: 'public, max-age=30, s-maxage=300',
+	307: 'public, max-age=30, s-maxage=3600',
 	'4xx': 'public, max-age=30, s-maxage=3600',
 }
 

--- a/packages/stream-metadata/src/routes/profileImage.ts
+++ b/packages/stream-metadata/src/routes/profileImage.ts
@@ -15,6 +15,13 @@ const paramsSchema = z.object({
 	}),
 })
 
+const CACHE_CONTROL = {
+	307: 'public, max-age=30, s-maxage=300',
+	400: 'public, max-age=30, s-maxage=300',
+	404: 'public, max-age=30, s-maxage=300',
+	422: 'public, max-age=30, s-maxage=300',
+}
+
 export async function fetchUserProfileImage(request: FastifyRequest, reply: FastifyReply) {
 	const logger = request.log.child({ name: fetchUserProfileImage.name })
 	const parseResult = paramsSchema.safeParse(request.params)
@@ -22,7 +29,10 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 	if (!parseResult.success) {
 		const errorMessage = parseResult.error.errors[0]?.message || 'Invalid parameters'
 		logger.info(errorMessage)
-		return reply.code(400).send({ error: 'Bad Request', message: errorMessage })
+		return reply
+			.code(400)
+			.header('Cache-Control', CACHE_CONTROL[400])
+			.send({ error: 'Bad Request', message: errorMessage })
 	}
 
 	const { userId } = parseResult.data
@@ -40,13 +50,16 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 			},
 			'Failed to get stream',
 		)
-		return reply.code(404).send('Stream not found')
+		return reply.code(404).header('Cache-Control', CACHE_CONTROL[404]).send('Stream not found')
 	}
 
 	// get the image metadata from the stream
 	const profileImage = await getUserProfileImage(stream)
 	if (!profileImage) {
-		return reply.code(404).send('profileImage not found')
+		return reply
+			.header('Cache-Control', CACHE_CONTROL[404])
+			.code(404)
+			.send('profileImage not found')
 	}
 
 	try {
@@ -61,7 +74,10 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 				},
 				'Invalid key or iv',
 			)
-			return reply.code(422).send('Failed to get encryption key or iv')
+			return reply
+				.header('Cache-Control', CACHE_CONTROL[422])
+				.code(422)
+				.send('Failed to get encryption key or iv')
 		}
 		const redirectUrl = `${config.streamMetadataBaseUrl}/media/${
 			profileImage.streamId
@@ -71,7 +87,7 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 			reply
 				// client should cache the image for 30 seconds, and the CDN for 5 minutes
 				// after 30 seconds, the client will check the CDN for a new image
-				.header('Cache-Control', 'public, max-age=30, s-maxage=300')
+				.header('Cache-Control', CACHE_CONTROL[307])
 				.redirect(redirectUrl, 307)
 		)
 	} catch (error) {
@@ -83,7 +99,10 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 			},
 			'Failed to get encryption key or iv',
 		)
-		return reply.code(422).send('Failed to get encryption key or iv')
+		return reply
+			.code(422)
+			.header('Cache-Control', CACHE_CONTROL[422])
+			.send('Failed to get encryption key or iv')
 	}
 }
 

--- a/packages/stream-metadata/src/routes/profileImage.ts
+++ b/packages/stream-metadata/src/routes/profileImage.ts
@@ -17,9 +17,7 @@ const paramsSchema = z.object({
 
 const CACHE_CONTROL = {
 	307: 'public, max-age=30, s-maxage=300',
-	400: 'public, max-age=30, s-maxage=300',
-	404: 'public, max-age=30, s-maxage=300',
-	422: 'public, max-age=30, s-maxage=300',
+	'4xx': 'public, max-age=30, s-maxage=3000',
 }
 
 export async function fetchUserProfileImage(request: FastifyRequest, reply: FastifyReply) {
@@ -31,7 +29,7 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 		logger.info(errorMessage)
 		return reply
 			.code(400)
-			.header('Cache-Control', CACHE_CONTROL[400])
+			.header('Cache-Control', CACHE_CONTROL['4xx'])
 			.send({ error: 'Bad Request', message: errorMessage })
 	}
 
@@ -50,14 +48,17 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 			},
 			'Failed to get stream',
 		)
-		return reply.code(404).header('Cache-Control', CACHE_CONTROL[404]).send('Stream not found')
+		return reply
+			.code(404)
+			.header('Cache-Control', CACHE_CONTROL['4xx'])
+			.send('Stream not found')
 	}
 
 	// get the image metadata from the stream
 	const profileImage = await getUserProfileImage(stream)
 	if (!profileImage) {
 		return reply
-			.header('Cache-Control', CACHE_CONTROL[404])
+			.header('Cache-Control', CACHE_CONTROL['4xx'])
 			.code(404)
 			.send('profileImage not found')
 	}
@@ -75,7 +76,7 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 				'Invalid key or iv',
 			)
 			return reply
-				.header('Cache-Control', CACHE_CONTROL[422])
+				.header('Cache-Control', CACHE_CONTROL['4xx'])
 				.code(422)
 				.send('Failed to get encryption key or iv')
 		}
@@ -101,7 +102,7 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 		)
 		return reply
 			.code(422)
-			.header('Cache-Control', CACHE_CONTROL[422])
+			.header('Cache-Control', CACHE_CONTROL['4xx'])
 			.send('Failed to get encryption key or iv')
 	}
 }

--- a/packages/stream-metadata/src/routes/profileImage.ts
+++ b/packages/stream-metadata/src/routes/profileImage.ts
@@ -17,7 +17,7 @@ const paramsSchema = z.object({
 
 const CACHE_CONTROL = {
 	307: 'public, max-age=30, s-maxage=300',
-	'4xx': 'public, max-age=30, s-maxage=3000',
+	'4xx': 'public, max-age=30, s-maxage=3600',
 }
 
 export async function fetchUserProfileImage(request: FastifyRequest, reply: FastifyReply) {

--- a/packages/stream-metadata/src/routes/spaceImage.ts
+++ b/packages/stream-metadata/src/routes/spaceImage.ts
@@ -19,7 +19,7 @@ const paramsSchema = z.object({
 })
 
 const CACHE_CONTROL = {
-	307: 'public, max-age=30, s-maxage=300',
+	307: 'public, max-age=30, s-maxage=3600',
 	'4xx': 'public, max-age=30, s-maxage=3600',
 	'5xx': 'public, max-age=30, s-maxage=300', // TODO: should we cache the 500s?
 }

--- a/packages/stream-metadata/src/routes/spaceImage.ts
+++ b/packages/stream-metadata/src/routes/spaceImage.ts
@@ -21,7 +21,6 @@ const paramsSchema = z.object({
 const CACHE_CONTROL = {
 	307: 'public, max-age=30, s-maxage=3600',
 	'4xx': 'public, max-age=30, s-maxage=3600',
-	'5xx': 'public, max-age=30, s-maxage=300', // TODO: should we cache the 500s?
 }
 
 export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyReply) {
@@ -107,8 +106,8 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 			'Failed to get encryption key or iv',
 		)
 		return reply
-			.code(500)
-			.header('Cache-Control', CACHE_CONTROL['5xx'])
+			.code(422)
+			.header('Cache-Control', CACHE_CONTROL['4xx'])
 			.send('Failed to get encryption key or iv')
 	}
 }

--- a/packages/stream-metadata/src/routes/spaceMetadata.ts
+++ b/packages/stream-metadata/src/routes/spaceMetadata.ts
@@ -19,8 +19,8 @@ export interface SpaceMetadataResponse {
 }
 
 const CACHE_CONTROL = {
-	200: 'public, max-age=30, s-maxage=300',
-	307: 'public, max-age=3600', // NOTE: this is called when the space uses a different image service than ours. So it makes sense to keep a high cache time. We're setting both client and cdn cache time to 1 hour for now. We can adjust this later if needed.
+	200: 'public, max-age=30, s-maxage=3600',
+	307: 'public, max-age=30, s-max-age=3600', // NOTE: this is called when the space uses a different image service than ours, but a client is requesting the image from our service.
 	'4xx': 'public, max-age=30, s-maxage=3600',
 }
 

--- a/packages/stream-metadata/src/routes/spaceMetadata.ts
+++ b/packages/stream-metadata/src/routes/spaceMetadata.ts
@@ -18,6 +18,12 @@ export interface SpaceMetadataResponse {
 	image: string
 }
 
+const CACHE_CONTROL = {
+	200: 'public, max-age=30, s-maxage=300',
+	307: 'public, max-age=3600', // NOTE: this is called when the space uses a different image service than ours. So it makes sense to keep a high cache time. We're setting both client and cdn cache time to 1 hour for now. We can adjust this later if needed.
+	'4xx': 'public, max-age=30, s-maxage=3600',
+}
+
 export async function fetchSpaceMetadata(request: FastifyRequest, reply: FastifyReply) {
 	const logger = request.log.child({ name: fetchSpaceMetadata.name })
 
@@ -26,7 +32,10 @@ export async function fetchSpaceMetadata(request: FastifyRequest, reply: Fastify
 	if (!parseResult.success) {
 		const errorMessage = parseResult.error.errors[0]?.message || 'Invalid parameters'
 		logger.info(errorMessage)
-		return reply.code(400).send({ error: 'Bad Request', message: errorMessage })
+		return reply
+			.code(400)
+			.header('Cache-Control', CACHE_CONTROL['4xx'])
+			.send({ error: 'Bad Request', message: errorMessage })
 	}
 
 	const { spaceAddress } = parseResult.data
@@ -36,6 +45,7 @@ export async function fetchSpaceMetadata(request: FastifyRequest, reply: Fastify
 		logger.info({ spaceAddress }, 'Invalid spaceAddress format')
 		return reply
 			.code(400)
+			.header('Cache-Control', CACHE_CONTROL['4xx'])
 			.send({ error: 'Bad Request', message: 'Invalid spaceAddress format' })
 	}
 
@@ -46,12 +56,16 @@ export async function fetchSpaceMetadata(request: FastifyRequest, reply: Fastify
 		logger.error({ spaceAddress, error }, 'Failed to fetch space contract info')
 		return reply
 			.code(404)
+			.header('Cache-Control', CACHE_CONTROL['4xx'])
 			.send({ error: 'Not Found', message: 'Failed to fetch space contract info' })
 	}
 
 	if (!spaceInfo) {
 		logger.error({ spaceAddress }, 'Space contract not found')
-		return reply.code(404).send({ error: 'Not Found', message: 'Space contract not found' })
+		return reply
+			.code(404)
+			.header('Cache-Control', CACHE_CONTROL['4xx'])
+			.send({ error: 'Not Found', message: 'Space contract not found' })
 	}
 
 	// Normalize the contractUri for case-insensitive comparison and handle empty string
@@ -68,12 +82,15 @@ export async function fetchSpaceMetadata(request: FastifyRequest, reply: Fastify
 			image,
 		}
 
-		return reply.header('Content-Type', 'application/json').send(spaceMetadata)
+		return reply
+			.header('Content-Type', 'application/json')
+			.header('Cache-Control', CACHE_CONTROL[200])
+			.send(spaceMetadata)
 	}
 
 	// Not using the default space image service
 	// redirect to the space contract's uri
-	return reply.redirect(spaceInfo.uri)
+	return reply.header('Cache-Control', CACHE_CONTROL[307]).redirect(spaceInfo.uri)
 }
 
 function getSpaceDecription({ shortDescription, longDescription }: SpaceInfo): string {


### PR DESCRIPTION
This PR adds default cache control headers for error responses on `/media`, `/space/.../image` and `/user/.../image` routes.
It also introduces a hook to help us track routes with missing cache-control headers.