### PR TITLE
Add waiting for the stream replica to be created with timeout

### DIFF
--- a/core/node/events/stream_cache.go
+++ b/core/node/events/stream_cache.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"time"
 
@@ -35,7 +36,6 @@ type StreamCache interface {
 	Params() *StreamCacheParams
 	GetStream(ctx context.Context, streamId StreamId) (SyncStream, StreamView, error)
 	GetSyncStream(ctx context.Context, streamId StreamId) (SyncStream, error)
-	CreateStream(ctx context.Context, streamId StreamId) (SyncStream, StreamView, error)
 	ForceFlushAll(ctx context.Context)
 	GetLoadedViews(ctx context.Context) []StreamView
 	GetMbCandidateStreams(ctx context.Context) []*streamImpl
@@ -89,12 +89,11 @@ func NewStreamCache(
 	// TODO: read stream state from storage and schedule required reconciliations.
 
 	for _, stream := range streams {
-		nodes := NewStreamNodes(stream.Nodes, params.Wallet.Address)
-		if nodes.IsLocal() {
+		if slices.Contains(stream.Nodes, params.Wallet.Address) {
 			s.cache.Store(stream.StreamId, &streamImpl{
 				params:           params,
 				streamId:         stream.StreamId,
-				nodes:            nodes,
+				nodes:            NewStreamNodes(stream.Nodes, params.Wallet.Address),
 				lastAccessedTime: time.Now(),
 			})
 		}
@@ -117,6 +116,18 @@ func NewStreamCache(
 }
 
 func (s *streamCacheImpl) onStreamAllocated(ctx context.Context, event *river.StreamRegistryV1StreamAllocated) {
+	if slices.Contains(event.Nodes, s.params.Wallet.Address) {
+		stream := &streamImpl{
+			params:           s.params,
+			streamId:         StreamId(event.StreamId),
+			nodes:            NewStreamNodes(event.Nodes, s.params.Wallet.Address),
+			lastAccessedTime: time.Now(),
+		}
+		_, err := s.tryLoadStreamRecordImpl(ctx, stream, event.GenesisMiniblock)
+		if err != nil {
+			dlog.FromCtx(ctx).Error("onStreamAllocated: failed to create stream", "err", err)
+		}
+	}
 }
 
 func (s *streamCacheImpl) onStreamLastMiniblockUpdated(
@@ -214,21 +225,40 @@ func (s *streamCacheImpl) CacheCleanup(ctx context.Context, enabled bool, expira
 func (s *streamCacheImpl) tryLoadStreamRecord(
 	ctx context.Context,
 	streamId StreamId,
-	loadView bool,
-) (SyncStream, StreamView, error) {
-	// Same code is called for GetStream, GetSyncStream and CreateStream.
+) (*streamImpl, error) {
 	// For GetStream the fact that record is not in cache means that there is race to get it during creation:
 	// Blockchain record is already created, but this fact is not reflected yet in local storage.
 	// This may happen if somebody observes record allocation on blockchain and tries to get stream
 	// while local storage is being initialized.
 	record, _, mb, err := s.params.Registry.GetStreamWithGenesis(ctx, streamId)
 	if err != nil {
-		return nil, nil, err
+		// Loop here waiting for record to be created.
+		// This is less optimal than implementing pub/sub, but given that this is rare codepath,
+		// it is not worth over-engineering.
+		ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+		defer cancel()
+		delay := time.Millisecond * 20
+		for {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+				entry, _ := s.cache.Load(streamId)
+				if entry != nil {
+					return entry.(*streamImpl), nil
+				}
+				record, _, mb, err = s.params.Registry.GetStreamWithGenesis(ctx, streamId)
+				if err == nil {
+					break
+				}
+				delay *= 2
+			}
+		}
 	}
 
 	nodes := NewStreamNodes(record.Nodes, s.params.Wallet.Address)
 	if !nodes.IsLocal() {
-		return nil, nil, RiverError(
+		return nil, RiverError(
 			Err_INTERNAL,
 			"tryLoadStreamRecord: Stream is not local",
 			"streamId", streamId,
@@ -239,7 +269,7 @@ func (s *streamCacheImpl) tryLoadStreamRecord(
 
 	if record.LastMiniblockNum > 0 {
 		// TODO: reconcile from other nodes.
-		return nil, nil, RiverError(
+		return nil, RiverError(
 			Err_INTERNAL,
 			"tryLoadStreamRecord: Stream is past genesis",
 			"streamId",
@@ -256,26 +286,31 @@ func (s *streamCacheImpl) tryLoadStreamRecord(
 		lastAccessedTime: time.Now(),
 	}
 
+	return s.tryLoadStreamRecordImpl(ctx, stream, mb)
+}
+
+func (s *streamCacheImpl) tryLoadStreamRecordImpl(
+	ctx context.Context,
+	stream *streamImpl,
+	mb []byte,
+) (*streamImpl, error) {
 	// Lock stream, so parallel creators have to wait for the stream to be intialized.
 	stream.mu.Lock()
 	defer stream.mu.Unlock()
-
-	entry, loaded := s.cache.LoadOrStore(streamId, stream)
+	entry, loaded := s.cache.LoadOrStore(stream.streamId, stream)
 	if !loaded {
 		// Our stream won the race, put into storage.
-		err := s.params.Storage.CreateStreamStorage(ctx, streamId, mb)
+		err := s.params.Storage.CreateStreamStorage(ctx, stream.streamId, mb)
 		if err != nil {
 			if AsRiverError(err).Code == Err_ALREADY_EXISTS {
-				if loadView {
-					// Attempt to load stream from storage. Might as well do it while under lock.
-					if err = stream.loadInternal(ctx); err == nil {
-						return stream, stream.view, nil
-					}
-					return nil, nil, err
+				// Attempt to load stream from storage. Might as well do it while under lock.
+				err = stream.loadInternal(ctx)
+				if err != nil {
+					return nil, err
 				}
-				return stream, nil, err
+				return stream, nil
 			}
-			return nil, nil, err
+			return nil, err
 		}
 
 		// Successfully put data into storage, init stream view.
@@ -287,41 +322,31 @@ func (s *streamCacheImpl) tryLoadStreamRecord(
 			},
 		)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		stream.view = view
-		return stream, view, nil
+		return stream, nil
 	} else {
 		// There was another record in the cache, use it.
 		if entry == nil {
-			return nil, nil, RiverError(Err_INTERNAL, "tryLoadStreamRecord: Cache corruption", "streamId", streamId)
+			return nil, RiverError(Err_INTERNAL, "tryLoadStreamRecord: Cache corruption", "streamId", stream.streamId)
 		}
 		stream = entry.(*streamImpl)
-		if !loadView {
-			return stream, nil, err
-		}
-
-		view, err := stream.GetView(ctx)
-		if err != nil {
-			return nil, nil, err
-		}
-		return stream, view, nil
+		return stream, nil
 	}
 }
 
 func (s *streamCacheImpl) GetStream(ctx context.Context, streamId StreamId) (SyncStream, StreamView, error) {
-	entry, _ := s.cache.Load(streamId)
-	if entry == nil {
-		return s.tryLoadStreamRecord(ctx, streamId, true)
+	stream, err := s.getStreamImpl(ctx, streamId)
+	if err != nil {
+		return nil, nil, err
 	}
-	stream := entry.(*streamImpl)
 
 	streamView, err := stream.GetView(ctx)
 
 	if err == nil {
 		return stream, streamView, nil
 	} else {
-		// TODO: if stream is not present in local storage, schedule reconciliation.
 		return nil, nil, err
 	}
 }
@@ -329,27 +354,17 @@ func (s *streamCacheImpl) GetStream(ctx context.Context, streamId StreamId) (Syn
 func (s *streamCacheImpl) getStreamImpl(ctx context.Context, streamId StreamId) (*streamImpl, error) {
 	entry, _ := s.cache.Load(streamId)
 	if entry == nil {
-		syncStream, _, err := s.tryLoadStreamRecord(ctx, streamId, false)
-		return syncStream.(*streamImpl), err
+		return s.tryLoadStreamRecord(ctx, streamId)
 	}
 	return entry.(*streamImpl), nil
 }
 
 func (s *streamCacheImpl) GetSyncStream(ctx context.Context, streamId StreamId) (SyncStream, error) {
-	entry, _ := s.cache.Load(streamId)
-	if entry == nil {
-		syncStream, _, err := s.tryLoadStreamRecord(ctx, streamId, false)
-		return syncStream, err
+	stream, err := s.getStreamImpl(ctx, streamId)
+	if err != nil {
+		return nil, err
 	}
-	return entry.(*streamImpl), nil
-}
-
-func (s *streamCacheImpl) CreateStream(
-	ctx context.Context,
-	streamId StreamId,
-) (SyncStream, StreamView, error) {
-	// Same logic as in GetStream: read from blockchain, create if present.
-	return s.GetStream(ctx, streamId)
+	return stream, nil
 }
 
 func (s *streamCacheImpl) ForceFlushAll(ctx context.Context) {

--- a/core/node/events/stream_cache.go
+++ b/core/node/events/stream_cache.go
@@ -123,7 +123,7 @@ func (s *streamCacheImpl) onStreamAllocated(ctx context.Context, event *river.St
 			nodes:            NewStreamNodes(event.Nodes, s.params.Wallet.Address),
 			lastAccessedTime: time.Now(),
 		}
-		_, err := s.tryLoadStreamRecordImpl(ctx, stream, event.GenesisMiniblock)
+		_, err := s.createStreamStorage(ctx, stream, event.GenesisMiniblock)
 		if err != nil {
 			dlog.FromCtx(ctx).Error("onStreamAllocated: failed to create stream", "err", err)
 		}
@@ -286,10 +286,10 @@ func (s *streamCacheImpl) tryLoadStreamRecord(
 		lastAccessedTime: time.Now(),
 	}
 
-	return s.tryLoadStreamRecordImpl(ctx, stream, mb)
+	return s.createStreamStorage(ctx, stream, mb)
 }
 
-func (s *streamCacheImpl) tryLoadStreamRecordImpl(
+func (s *streamCacheImpl) createStreamStorage(
 	ctx context.Context,
 	stream *streamImpl,
 	mb []byte,

--- a/core/node/events/stream_cache.go
+++ b/core/node/events/stream_cache.go
@@ -238,6 +238,7 @@ func (s *streamCacheImpl) tryLoadStreamRecord(
 		ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 		defer cancel()
 		delay := time.Millisecond * 20
+	forLoop:
 		for {
 			select {
 			case <-ctx.Done():
@@ -249,7 +250,7 @@ func (s *streamCacheImpl) tryLoadStreamRecord(
 				}
 				record, _, mb, err = s.params.Registry.GetStreamWithGenesis(ctx, streamId)
 				if err == nil {
-					break
+					break forLoop
 				}
 				delay *= 2
 			}

--- a/core/node/events/util_test.go
+++ b/core/node/events/util_test.go
@@ -160,7 +160,7 @@ func (ctc *cacheTestContext) createReplStream() (StreamId, []common.Address, []b
 	ctc.require.Len(nodes, ctc.testParams.replFactor)
 
 	for _, n := range nodes {
-		_, _, err = ctc.instancesByAddr[n].cache.CreateStream(ctc.ctx, streamId)
+		_, _, err = ctc.instancesByAddr[n].cache.GetStream(ctc.ctx, streamId)
 		ctc.require.NoError(err)
 	}
 
@@ -214,7 +214,7 @@ func (ctc *cacheTestContext) createStream(
 	genesisMiniblock *Miniblock,
 ) (SyncStream, StreamView) {
 	ctc.createStreamNoCache(streamId, genesisMiniblock)
-	s, v, err := ctc.instances[0].cache.CreateStream(ctc.ctx, streamId)
+	s, v, err := ctc.instances[0].cache.GetStream(ctc.ctx, streamId)
 	ctc.require.NoError(err)
 	return s, v
 }

--- a/core/node/rpc/create_stream.go
+++ b/core/node/rpc/create_stream.go
@@ -158,7 +158,7 @@ func (s *Service) createReplicatedStream(
 	var localSyncCookie *SyncCookie
 	if nodes.IsLocal() {
 		sender.GoLocal(func() error {
-			_, sv, err := s.cache.CreateStream(ctx, streamId)
+			_, sv, err := s.cache.GetStream(ctx, streamId)
 			if err != nil {
 				return err
 			}

--- a/core/node/rpc/node2node.go
+++ b/core/node/rpc/node2node.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+
 	"github.com/river-build/river/core/node/utils"
 
 	"connectrpc.com/connect"
@@ -39,7 +40,7 @@ func (s *Service) allocateStream(ctx context.Context, req *AllocateStreamRequest
 
 	// TODO: check request is signed by correct node
 	// TODO: all checks that should be done on create?
-	_, view, err := s.cache.CreateStream(ctx, streamId)
+	_, view, err := s.cache.GetStream(ctx, streamId)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
River chain provider frontend used by node B can be behind frontend used by node A, so even if tx is observed as committed by node A, it's not necessary true for node B yet. This adds waiting with timeout for record to get initialized if requested stream is unknown.

Fixes #1059