### PR TITLE
fix level of csb:persistence

### DIFF
--- a/packages/sdk/src/persistenceStore.ts
+++ b/packages/sdk/src/persistenceStore.ts
@@ -12,7 +12,7 @@ import { isDefined } from './check'
 
 const DEFAULT_RETRY_COUNT = 2
 const log = dlog('csb:persistence')
-const logError = dlogError('csb:persistence')
+const logError = dlogError('csb:persistence:error')
 
 async function fnReadRetryer<T>(
     fn: () => Promise<T | undefined>,


### PR DESCRIPTION
the error log was overwriting the log level of the log log.