### PR TITLE
Kerem/cloudfront invalidation optimization

### DIFF
--- a/packages/stream-metadata/src/environment.ts
+++ b/packages/stream-metadata/src/environment.ts
@@ -35,7 +35,8 @@ function makeConfig() {
 	const cloudfront = envMain.CLOUDFRONT_DISTRIBUTION_ID
 		? {
 				distributionId: envMain.CLOUDFRONT_DISTRIBUTION_ID,
-				invalidationConfirmationWait: 5000, // wait 5 seconds between each invalidation attempt
+				invalidationConfirmationWait: 30 * 1000,
+				// wait 30 seconds between each invalidation attempt
 				invalidationConfirmationMaxAttempts: 10, // maximum of 10 attempts
 		  }
 		: undefined

--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -13,7 +13,7 @@ import { fetchSpaceMetadata } from './routes/spaceMetadata'
 import { fetchUserProfileImage } from './routes/profileImage'
 import { fetchUserBio } from './routes/userBio'
 import { fetchMedia } from './routes/media'
-import { spaceRefresh } from './routes/spaceRefresh'
+import { spaceRefresh, spaceRefreshOnResponse } from './routes/spaceRefresh'
 import { userRefresh } from './routes/userRefresh'
 import { addCacheControlCheck } from './check-cache-control'
 
@@ -87,7 +87,7 @@ export function setupRoutes(srv: Server) {
 	srv.get('/user/:userId/bio', fetchUserBio)
 
 	// should be rate-limited, but not yet
-	srv.get('/space/:spaceAddress/refresh', spaceRefresh)
+	srv.get('/space/:spaceAddress/refresh', { onResponse: spaceRefreshOnResponse }, spaceRefresh)
 	srv.get('/user/:userId/refresh', userRefresh)
 
 	// Fastify will return 404 for any unmatched routes

--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -14,7 +14,7 @@ import { fetchUserProfileImage } from './routes/profileImage'
 import { fetchUserBio } from './routes/userBio'
 import { fetchMedia } from './routes/media'
 import { spaceRefresh, spaceRefreshOnResponse } from './routes/spaceRefresh'
-import { userRefresh } from './routes/userRefresh'
+import { userRefresh, userRefreshOnResponse } from './routes/userRefresh'
 import { addCacheControlCheck } from './check-cache-control'
 
 // Set the process title to 'stream-metadata' so it can be easily identified
@@ -88,7 +88,7 @@ export function setupRoutes(srv: Server) {
 
 	// should be rate-limited, but not yet
 	srv.get('/space/:spaceAddress/refresh', { onResponse: spaceRefreshOnResponse }, spaceRefresh)
-	srv.get('/user/:userId/refresh', userRefresh)
+	srv.get('/user/:userId/refresh', { onResponse: userRefreshOnResponse }, userRefresh)
 
 	// Fastify will return 404 for any unmatched routes
 }

--- a/packages/stream-metadata/src/routes/spaceRefresh.ts
+++ b/packages/stream-metadata/src/routes/spaceRefresh.ts
@@ -14,6 +14,7 @@ const paramsSchema = z.object({
 		}),
 })
 
+// This route handler validates the refresh request and quickly returns a 200 response.
 export async function spaceRefresh(request: FastifyRequest, reply: FastifyReply) {
 	const logger = request.log.child({ name: spaceRefresh.name })
 
@@ -25,8 +26,18 @@ export async function spaceRefresh(request: FastifyRequest, reply: FastifyReply)
 		return reply.code(400).send({ error: 'Bad Request', message: errorMessage })
 	}
 
-	const { spaceAddress } = parseResult.data
-	logger.info({ spaceAddress }, 'Refreshing space')
+	return reply.code(200).send({ ok: true })
+}
+
+// This onResponse hook does the actual heavy lifting of invalidating the CloudFront cache and refreshing OpenSea.
+export async function spaceRefreshOnResponse(
+	request: FastifyRequest,
+	reply: FastifyReply,
+	done: () => void,
+) {
+	const logger = request.log.child({ name: spaceRefreshOnResponse.name })
+
+	const { spaceAddress } = paramsSchema.parse(request.params)
 
 	try {
 		const path = `/space/${spaceAddress}/image`
@@ -36,8 +47,6 @@ export async function spaceRefresh(request: FastifyRequest, reply: FastifyReply)
 			waitUntilFinished: true,
 		})
 		await refreshOpenSea({ spaceAddress, logger })
-
-		return reply.code(200).send({ ok: true })
 	} catch (error) {
 		logger.error(
 			{
@@ -46,6 +55,7 @@ export async function spaceRefresh(request: FastifyRequest, reply: FastifyReply)
 			},
 			'Failed to refresh space',
 		)
-		return reply.code(500).send({ error: 'Failed to refresh space' })
 	}
+
+	done()
 }

--- a/packages/stream-metadata/src/routes/spaceRefresh.ts
+++ b/packages/stream-metadata/src/routes/spaceRefresh.ts
@@ -39,6 +39,8 @@ export async function spaceRefreshOnResponse(
 
 	const { spaceAddress } = paramsSchema.parse(request.params)
 
+	logger.info({ spaceAddress }, 'Refreshing space')
+
 	try {
 		const path = `/space/${spaceAddress}/image`
 		await CloudfrontManager.createCloudfrontInvalidation({

--- a/packages/stream-metadata/src/routes/userRefresh.ts
+++ b/packages/stream-metadata/src/routes/userRefresh.ts
@@ -21,23 +21,32 @@ export async function userRefresh(request: FastifyRequest, reply: FastifyReply) 
 		return reply.code(400).send({ error: 'Bad Request', message: errorMessage })
 	}
 
-	const { userId } = parseResult.data
+	return reply.code(200).send({ ok: true })
+}
+
+export async function userRefreshOnResponse(
+	request: FastifyRequest,
+	reply: FastifyReply,
+	done: () => void,
+) {
+	const logger = request.log.child({ name: userRefreshOnResponse.name })
+
+	const { userId } = paramsSchema.parse(request.params)
+
 	logger.info({ userId }, 'Refreshing user')
 
 	try {
 		const path = `/user/${userId}/image`
-
-		// Refresh CloudFront cache
 		await CloudfrontManager.createCloudfrontInvalidation({ path, logger })
-
-		return reply.code(200).send({ ok: true })
 	} catch (error) {
 		logger.error(
 			{
 				error,
+				userId,
 			},
 			'Failed to refresh user',
 		)
-		return reply.code(500).send('Failed to refresh user')
 	}
+
+	done()
 }

--- a/packages/stream-metadata/src/routes/userRefresh.ts
+++ b/packages/stream-metadata/src/routes/userRefresh.ts
@@ -10,6 +10,7 @@ const paramsSchema = z.object({
 	}),
 })
 
+// This route handler validates the refresh request and quickly returns a 200 response.
 export async function userRefresh(request: FastifyRequest, reply: FastifyReply) {
 	const logger = request.log.child({ name: userRefresh.name })
 
@@ -24,6 +25,7 @@ export async function userRefresh(request: FastifyRequest, reply: FastifyReply) 
 	return reply.code(200).send({ ok: true })
 }
 
+// This onResponse hook does the actual heavy lifting of invalidating the CloudFront cache.
 export async function userRefreshOnResponse(
 	request: FastifyRequest,
 	reply: FastifyReply,


### PR DESCRIPTION
This PR introduces `onResponse` hooks to the stream metadata service, which allows us avoid having the client wait cf invalidations and opensea refreshes.