### PR TITLE
stream-metadata: space member metadata

### DIFF
--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -16,6 +16,7 @@ import { fetchMedia } from './routes/media'
 import { spaceRefresh } from './routes/spaceRefresh'
 import { userRefresh } from './routes/userRefresh'
 import { addCacheControlCheck } from './check-cache-control'
+import { fetchSpaceMemberMetadata } from './routes/spaceMemberMetadata'
 
 // Set the process title to 'stream-metadata' so it can be easily identified
 // or killed with `pkill stream-metadata`
@@ -79,6 +80,7 @@ export function setupRoutes(srv: Server) {
 	srv.get('/user/:userId/image', fetchUserProfileImage)
 	srv.get('/space/:spaceAddress/image', fetchSpaceImage)
 	srv.get('/space/:spaceAddress', fetchSpaceMetadata)
+	srv.get('/space/:spaceAddress/token/:tokenId', fetchSpaceMemberMetadata)
 
 	// not cached
 	srv.get('/health', checkHealth)

--- a/packages/stream-metadata/src/routes/spaceMemberMetadata.ts
+++ b/packages/stream-metadata/src/routes/spaceMemberMetadata.ts
@@ -13,7 +13,7 @@ const paramsSchema = z.object({
 	tokenId: z.string().min(1, 'tokenId parameter is required'),
 })
 
-interface SpaceMemberMetadataResponse {
+export interface SpaceMemberMetadataResponse {
 	name: string
 	description: string
 	image: string

--- a/packages/stream-metadata/src/routes/spaceMemberMetadata.ts
+++ b/packages/stream-metadata/src/routes/spaceMemberMetadata.ts
@@ -1,0 +1,102 @@
+import { FastifyReply, FastifyRequest } from 'fastify'
+import { z } from 'zod'
+
+import { config } from '../environment'
+import { isValidEthereumAddress } from '../validators'
+import { spaceDapp } from '../contract-utils'
+
+const paramsSchema = z.object({
+	spaceAddress: z
+		.string()
+		.min(1, 'spaceAddress parameter is required')
+		.refine(isValidEthereumAddress, 'Invalid spaceAddress format'),
+	tokenId: z.string().min(1, 'tokenId parameter is required'),
+})
+
+interface SpaceMemberMetadataResponse {
+	name: string
+	description: string
+	image: string
+	attributes: {
+		trait_type: string
+		display_type?: 'date' | 'number' | 'string'
+		value: string | number
+	}[]
+}
+
+const CACHE_CONTROL = {
+	200: 'public, max-age=30, s-maxage=3600',
+	307: 'public, max-age=30, s-max-age=3600', // NOTE: this is called when the space uses a different image service than ours, but a client is requesting the image from our service.
+	'4xx': 'public, max-age=30, s-maxage=3600',
+}
+
+export async function fetchSpaceMemberMetadata(request: FastifyRequest, reply: FastifyReply) {
+	const logger = request.log.child({ name: fetchSpaceMemberMetadata.name })
+
+	const parseResult = paramsSchema.safeParse(request.params)
+
+	if (!parseResult.success) {
+		const errorMessage = parseResult.error.errors[0]?.message || 'Invalid parameters'
+		logger.info(errorMessage)
+		return reply
+			.code(400)
+			.header('Cache-Control', CACHE_CONTROL['4xx'])
+			.send({ error: 'Bad Request', message: errorMessage })
+	}
+
+	const { spaceAddress, tokenId } = parseResult.data
+
+	try {
+		const metadata = await getSpaceMemberMetadata(spaceAddress, tokenId)
+		return reply
+			.header('Content-Type', 'application/json')
+			.header('Cache-Control', CACHE_CONTROL[200])
+			.send(metadata)
+	} catch (error) {
+		logger.error({ spaceAddress, tokenId, error }, 'Failed to fetch space contract info')
+		return reply
+			.code(404)
+			.header('Cache-Control', CACHE_CONTROL['4xx'])
+			.send({ error: 'Not Found', message: 'Space contract not found' })
+	}
+}
+
+const getSpaceMemberMetadata = async (
+	spaceAddress: string,
+	tokenId: string,
+): Promise<SpaceMemberMetadataResponse> => {
+	const space = spaceDapp.getSpace(spaceAddress)
+	if (!space) {
+		throw new Error('Space contract not found')
+	}
+
+	const [name, renewalPrice, membershipExpiration, isBanned] = await Promise.all([
+		space.SpaceOwner.read.getSpaceInfo(spaceAddress).then((spaceInfo) => spaceInfo.name),
+		space.Membership.read.getMembershipRenewalPrice(tokenId),
+		space.Membership.read.expiresAt(tokenId),
+		space.Banning.read.isBanned(tokenId),
+	])
+
+	return {
+		name: `${name} - Member`,
+		description: `Member of ${name}`,
+		image: `${config.streamMetadataBaseUrl}/space/${spaceAddress}/image`,
+		attributes: [
+			{
+				trait_type: 'Renewal Price',
+				display_type: 'number',
+				value: renewalPrice.toNumber(),
+			},
+			{
+				trait_type: 'Membership Expiration',
+				display_type: 'date',
+				value: membershipExpiration.toNumber(),
+			},
+			{
+				trait_type: 'Membership Banned',
+				display_type: 'string',
+				value: String(isBanned),
+			},
+		],
+	}
+}

--- a/packages/stream-metadata/tests/integration/spaceMemberMetadata.test.ts
+++ b/packages/stream-metadata/tests/integration/spaceMemberMetadata.test.ts
@@ -1,0 +1,108 @@
+import axios from 'axios'
+import { dlog } from '@river-build/dlog'
+import { ethers } from 'ethers'
+import { Client } from '@river-build/sdk'
+
+import {
+	getTestServerUrl,
+	makeCreateSpaceParams,
+	makeEthersProvider,
+	makeTestClient,
+	SpaceMetadataParams,
+} from '../testUtils'
+import { SpaceMemberMetadataResponse } from '../../src/routes/spaceMemberMetadata'
+import { spaceDapp } from '../../src/contract-utils'
+
+const log = dlog('stream-metadata:test:spaceMemberMetadata', {
+	allowJest: true,
+	defaultEnabled: true,
+})
+
+describe('integration/space/:spaceAddress/token/:tokenId', () => {
+	const baseURL = getTestServerUrl()
+	log('baseURL', baseURL)
+
+	let bobsClient: Client
+	let bobsWallet: ethers.Wallet
+
+	beforeEach(async () => {
+		bobsWallet = ethers.Wallet.createRandom()
+		bobsClient = await makeTestClient(bobsWallet)
+		await bobsClient.initializeUser()
+		bobsClient.startSync()
+	})
+
+	afterEach(async () => {
+		await bobsClient.stopSync()
+	})
+
+	async function createSpace(spaceMetadata: SpaceMetadataParams) {
+		const createSpaceParams = await makeCreateSpaceParams(
+			bobsClient.userId,
+			spaceDapp,
+			spaceMetadata,
+		)
+		const provider = makeEthersProvider(bobsWallet)
+		await provider.fundWallet()
+
+		const tx = await spaceDapp.createLegacySpace(createSpaceParams, provider.signer)
+		const receipt = await tx.wait()
+		expect(receipt.status).toBe(1)
+
+		const spaceAddress = spaceDapp.getSpaceAddress(receipt)
+		expect(spaceAddress).toBeDefined()
+		const spaceStreamId = await bobsClient.createSpace(spaceAddress!)
+		expect(spaceStreamId).toBeDefined()
+		return spaceAddress!
+	}
+
+	async function runTest(
+		spaceAddress: string,
+		tokenId: number,
+		spaceMetadata: SpaceMetadataParams,
+	) {
+		const route = `space/${spaceAddress}/token/${tokenId}`
+		const response = await axios.get<SpaceMemberMetadataResponse>(`${baseURL}/${route}`)
+
+		const { name, description, image, attributes } = response.data
+		expect(response.status).toBe(200)
+		expect(response.headers['content-type']).toContain('application/json')
+		expect(name).toEqual(`${spaceMetadata.name} - Member`)
+		expect(description).toEqual(`Member of ${spaceMetadata.name}`)
+		expect(image).toBe(`${baseURL}/space/${spaceAddress}/image`)
+
+		const renewalPrice = attributes.find((attr) => attr.trait_type === 'Renewal Price')
+		expect(renewalPrice).toBeDefined()
+		const membershipExpiration = attributes.find(
+			(attr) => attr.trait_type === 'Membership Expiration',
+		)
+		expect(membershipExpiration).toBeDefined()
+		const membershipBanned = attributes.find((attr) => attr.trait_type === 'Membership Banned')
+		expect(membershipBanned?.value).toBe('false')
+	}
+
+	it('pass with valid space address and token id', async () => {
+		const metadata = {
+			name: 'Alice Space',
+			uri: baseURL,
+			shortDescription: 'This is a test space',
+			longDescription: 'This is a test space',
+		}
+		const spaceAddress = await createSpace(metadata)
+		await runTest(spaceAddress, 0, metadata)
+	})
+
+	it('should return 404 /space/:spaceAddress/token/42069', async () => {
+		const metadata = {
+			name: 'Alice Space',
+			uri: baseURL,
+			shortDescription: 'This is a test space',
+			longDescription: 'This is a test space',
+		}
+		const spaceAddress = await createSpace(metadata)
+		const response = await axios.get<SpaceMemberMetadataResponse>(
+			`${baseURL}/space/${spaceAddress}/token/42069`,
+		)
+		expect(response.status).toBe(404)
+	})
+})


### PR DESCRIPTION
Should close TOWNS-12131

Example:
https://testnets.opensea.io/assets/base-sepolia/0xfc4c8ab90d7b43e1a3b316c400e53b53640f132b/0

```json
{
  "name": "pls opensea - Member",
  "description": "Member of pls opensea",
  "image": "<stream-metadata-service>/space/0xfc4c8ab90d7b43e1a3b316c400e53b53640f132b/image",
  "attributes": [
    {
      "trait_type": "Renewal Price",
      "display_type": "number",
      "value": 0
    },
    {
      "trait_type": "Membership Expiration",
      "display_type": "date",
      "value": 0
    },
    {
      "trait_type": "Membership Banned",
      "display_type": "string",
      "value": "false"
    }
  ]
}
```

https://testnets.opensea.io/assets/base-sepolia/0x9bd136d3155316d5d6dfcd4f87d5ee1a3ea8f22d/755
```json
{
  "name": "HNT ALPHA - Member",
  "description": "Member of HNT ALPHA",
  "image": "<stream-metadata-service>/space/0x9bd136d3155316d5d6dfcd4f87d5ee1a3ea8f22d/image",
  "attributes": [
    {
      "trait_type": "Renewal Price",
      "display_type": "number",
      "value": 0
    },
    {
      "trait_type": "Membership Expiration",
      "display_type": "date",
      "value": 1758056762
    },
    {
      "trait_type": "Membership Banned",
      "display_type": "string",
      "value": "false"
    }
  ]
}
```

Previous impl used as reference: https://github.com/river-build/river/pull/1047/files