### PR TITLE
stream metadata service - internal api improvements

### DIFF
--- a/packages/stream-metadata/src/riverStreamRpcClient.ts
+++ b/packages/stream-metadata/src/riverStreamRpcClient.ts
@@ -158,14 +158,7 @@ export async function getStream(
 	logger: FastifyBaseLogger,
 	streamId: string,
 ): Promise<StreamStateView> {
-	const result = await getStreamClient(logger, `0x${streamId}`)
-	const client = result.client
-	const lastMiniblockNum = result.lastMiniblockNum
-
-	if (!client) {
-		logger.error({ streamId }, 'Failed to get client for stream')
-		throw new Error(`Failed to get client for stream ${streamId}`)
-	}
+	const { client, lastMiniblockNum } = await getStreamClient(logger, `0x${streamId}`)
 	logger.info(
 		{
 			nodeUrl: client.url,

--- a/packages/stream-metadata/src/riverStreamRpcClient.ts
+++ b/packages/stream-metadata/src/riverStreamRpcClient.ts
@@ -35,19 +35,10 @@ function makeStreamRpcClient(logger: FastifyBaseLogger, url: string): StreamRpcC
 
 async function getStreamClient(logger: FastifyBaseLogger, streamId: `0x${string}`) {
 	const node = await getNodeForStream(logger, streamId)
-	let url = node?.url
-	if (!clients.has(url)) {
-		const client = makeStreamRpcClient(logger, url)
-		clients.set(client.url!, client)
-		url = client.url!
-	}
-	logger.info({ url }, 'client connected to node')
+	const client = clients.get(node.url) || makeStreamRpcClient(logger, node.url)
+	clients.set(node.url, client)
 
-	const client = clients.get(url)
-	if (!client) {
-		logger.error({ url }, 'Failed to get client for url')
-		throw new Error('Failed to get client for url')
-	}
+	logger.info({ url: node.url }, 'client connected to node')
 
 	return { client, lastMiniblockNum: node.lastMiniblockNum }
 }

--- a/packages/stream-metadata/src/riverStreamRpcClient.ts
+++ b/packages/stream-metadata/src/riverStreamRpcClient.ts
@@ -207,10 +207,9 @@ export async function getMediaStreamContent(
 	fullStreamId: StreamIdHex,
 	secret: Uint8Array,
 	iv: Uint8Array,
-): Promise<MediaContent | { data: null; mimeType: null }> {
+): Promise<MediaContent> {
 	const streamId = stripHexPrefix(fullStreamId)
 	const sv = await getStream(logger, streamId)
 	const result = await mediaContentFromStreamView(logger, sv, secret, iv)
-
 	return result
 }

--- a/packages/stream-metadata/src/riverStreamRpcClient.ts
+++ b/packages/stream-metadata/src/riverStreamRpcClient.ts
@@ -210,12 +210,6 @@ export async function getMediaStreamContent(
 ): Promise<MediaContent | { data: null; mimeType: null }> {
 	const streamId = stripHexPrefix(fullStreamId)
 	const sv = await getStream(logger, streamId)
-
-	if (!sv) {
-		logger.error({ streamId }, 'Failed to get stream')
-		throw new Error(`Failed to get stream ${streamId}`)
-	}
-
 	const result = await mediaContentFromStreamView(logger, sv, secret, iv)
 
 	return result

--- a/packages/stream-metadata/src/routes/profileImage.ts
+++ b/packages/stream-metadata/src/routes/profileImage.ts
@@ -36,7 +36,7 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 	const { userId } = parseResult.data
 
 	logger.info({ userId }, 'Fetching user image')
-	let stream: StreamStateView | undefined
+	let stream: StreamStateView
 	try {
 		const userMetadataStreamId = makeStreamId(StreamPrefix.UserMetadata, userId)
 		stream = await getStream(logger, userMetadataStreamId)

--- a/packages/stream-metadata/src/routes/spaceImage.ts
+++ b/packages/stream-metadata/src/routes/spaceImage.ts
@@ -40,7 +40,7 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 	const { spaceAddress } = parseResult.data
 	logger.info({ spaceAddress }, 'Fetching space image')
 
-	let stream: StreamStateView | undefined
+	let stream: StreamStateView
 	try {
 		const streamId = makeStreamId(StreamPrefix.Space, spaceAddress)
 		stream = await getStream(logger, streamId)
@@ -52,13 +52,6 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 			},
 			'Failed to get stream',
 		)
-		return reply
-			.code(404)
-			.header('Cache-Control', CACHE_CONTROL['4xx'])
-			.send('Stream not found')
-	}
-
-	if (!stream) {
 		return reply
 			.code(404)
 			.header('Cache-Control', CACHE_CONTROL['4xx'])

--- a/packages/stream-metadata/src/routes/userBio.ts
+++ b/packages/stream-metadata/src/routes/userBio.ts
@@ -28,7 +28,7 @@ export async function fetchUserBio(request: FastifyRequest, reply: FastifyReply)
 
 	logger.info({ userId }, 'Fetching user bio')
 
-	let stream: StreamStateView | undefined
+	let stream: StreamStateView
 	try {
 		const userMetadataStreamId = makeStreamId(StreamPrefix.UserMetadata, userId)
 		stream = await getStream(logger, userMetadataStreamId)
@@ -40,10 +40,6 @@ export async function fetchUserBio(request: FastifyRequest, reply: FastifyReply)
 			},
 			'Failed to get stream',
 		)
-		return reply.code(404).send('Stream not found')
-	}
-
-	if (!stream) {
 		return reply.code(404).send('Stream not found')
 	}
 


### PR DESCRIPTION
This PR improves our `undefined` and `try-catch` hygiene. I originally intended this PR to take care of various http status codes and cache-control header edge cases. But that work-item requires a good understanding of our varying failure modes - which this PR aims to simplify. A common theme: the differences between expected errors, unexpected errors, and the meaning of missing data. A followup PR will improve error handling by having library code communicate its error modes to the api layer not via throws but via extended return types. This will help with custom cache-control and http status handling, instead of blanket 404'ing on everything with the exact same cache control headers.


a) The type information on `sv: StreamStateView` indicates that it can't be undefined. And in the past month, "failed to get stream" is only logged at /profile and /space routes and never on the /media route. These indicate that it's safe to remove the undefined check on `riverStreamRpcClient.ts`.

<img width="1337" alt="image" src="https://github.com/user-attachments/assets/4efc6223-04a5-49ef-964b-c482a5ea54b2">
<img width="672" alt="image" src="https://github.com/user-attachments/assets/6cd620e0-931f-4f8e-98d3-8522374d7a68">

b) `| { data: null; mimeType: null }` on the return type isn't used, so i'm removing it.

c) The type information on `result.client` via `getStreamClient()` in `riverStreamRpcClient.ts` indicate that the client can't be undefined - and the same throw-check is happening inside `getStreamClient`. So i'm removing this secondary throw-check.

<img width="780" alt="image" src="https://github.com/user-attachments/assets/6e2e1758-d926-4c7c-9ad6-53bb3f35f91f">
<img width="770" alt="image" src="https://github.com/user-attachments/assets/c2161f53-0f30-4376-b8d7-17494a77683f">

d) Type type information on `getStream()` indicates that it never returns undefined, so all these `404` checks can go away.

<img width="765" alt="image" src="https://github.com/user-attachments/assets/07e08918-65c7-4e16-b485-388c06a510dd">

e) `makeStreamRpcClient` had a dead-code throw-check just to satisfy the compiler. Removing it:

<img width="761" alt="image" src="https://github.com/user-attachments/assets/a5e1541c-44f6-4d52-ad17-c03a7f530996">
