### PR TITLE
remove extra transferVotingUnits call in base River

### DIFF
--- a/contracts/src/tokens/river/base/River.sol
+++ b/contracts/src/tokens/river/base/River.sol
@@ -225,9 +225,6 @@ contract River is
     }
 
     super._update(from, to, value);
-
-    // TODO: bug?
-    _transferVotingUnits(from, to, value);
   }
 
   function _getVotingUnits(

--- a/contracts/test/river/token/base/RiverBase.t.sol
+++ b/contracts/test/river/token/base/RiverBase.t.sol
@@ -203,6 +203,9 @@ contract RiverBaseTest is BaseSetup, ILockBase, IOwnableBase {
   {
     vm.assume(alice != bob);
 
+    vm.expectEmit();
+    emit IVotes.DelegateVotesChanged(space, 0, stakeRequirement);
+
     vm.prank(bob);
     riverFacet.delegate(space);
 
@@ -221,14 +224,6 @@ contract RiverBaseTest is BaseSetup, ILockBase, IOwnableBase {
       space,
       stakeRequirement,
       2 * stakeRequirement
-    );
-
-    // duplicate delegate votes change
-    vm.expectEmit();
-    emit IVotes.DelegateVotesChanged(
-      space,
-      2 * stakeRequirement,
-      3 * stakeRequirement
     );
 
     vm.prank(alice);


### PR DESCRIPTION
- remove extra transferVotingUnits call in River.sol _update hook.
- updates test

