### PR TITLE
Increase justfile timeout

### DIFF
--- a/core/justfile
+++ b/core/justfile
@@ -226,7 +226,7 @@ _wait-node $INSTANCE_NUM $INSTANCE_DIR:
     source ${ENV_FILE}
     source ${INSTANCE_DIR}/config/config.env
     cd ..
-    yarn wait-on https://localhost:${RIVER_PORT}/status?blockchain=1 --timeout=60000
+    yarn wait-on https://localhost:${RIVER_PORT}/status?blockchain=1 --timeout=300000
 
 _wait-ctrl-c:
     #!/usr/bin/env -S bash {{BASH_OPTS}}

--- a/core/justfile
+++ b/core/justfile
@@ -226,7 +226,7 @@ _wait-node $INSTANCE_NUM $INSTANCE_DIR:
     source ${ENV_FILE}
     source ${INSTANCE_DIR}/config/config.env
     cd ..
-    yarn wait-on https://localhost:${RIVER_PORT}/status?blockchain=1 --timeout=300000
+    yarn wait-on https://localhost:${RIVER_PORT}/status?blockchain=1 --timeout=900000 --i=5000
 
 _wait-ctrl-c:
     #!/usr/bin/env -S bash {{BASH_OPTS}}

--- a/core/justfile
+++ b/core/justfile
@@ -226,7 +226,7 @@ _wait-node $INSTANCE_NUM $INSTANCE_DIR:
     source ${ENV_FILE}
     source ${INSTANCE_DIR}/config/config.env
     cd ..
-    yarn wait-on https://localhost:${RIVER_PORT}/status?blockchain=1 --timeout=900000 --i=5000
+    yarn wait-on https://localhost:${RIVER_PORT}/debug/multi --timeout=900000 --i=5000
 
 _wait-ctrl-c:
     #!/usr/bin/env -S bash {{BASH_OPTS}}


### PR DESCRIPTION
To deal with spuriously failing CI.

Current limit to wait for a stream node to come up is 60s. Increase to 5m to give enough time.