### PR TITLE
Update AND and OR operation evaluation to properly propagate errors

### DIFF
--- a/core/xchain/entitlement/check_operation.go
+++ b/core/xchain/entitlement/check_operation.go
@@ -179,11 +179,14 @@ func (e *Evaluator) evaluateMockOperation(
 	if result != nil {
 		return false, result
 	}
-	if op.ChainID.Sign() != 0 {
-		return true, nil
-	} else {
-		return false, nil
+
+	if (op.ContractAddress != common.Address{}) {
+		// Grab last two digits of contract address as a unique identifier of which check
+		// caused the error, for ease of reading.
+		code := fmt.Sprintf("%v", op.ContractAddress)[40:]
+		return false, fmt.Errorf("intentional failure (%v)", code)
 	}
+	return op.ChainID.Sign() != 0, nil
 }
 
 func (e *Evaluator) evaluateIsEntitledOperation(

--- a/core/xchain/entitlement/check_operation.go
+++ b/core/xchain/entitlement/check_operation.go
@@ -182,7 +182,7 @@ func (e *Evaluator) evaluateMockOperation(
 
 	if (op.ContractAddress != common.Address{}) {
 		// Grab last two digits of contract address as a unique identifier of which check
-		// caused the error, for ease of reading.
+		// caused the error, for ease of debugging test cases.
 		code := fmt.Sprintf("%v", op.ContractAddress)[40:]
 		return false, fmt.Errorf("intentional failure (%v)", code)
 	}

--- a/core/xchain/entitlement/check_operation.go
+++ b/core/xchain/entitlement/check_operation.go
@@ -181,10 +181,9 @@ func (e *Evaluator) evaluateMockOperation(
 	}
 
 	if (op.ContractAddress != common.Address{}) {
-		// Grab last two digits of contract address as a unique identifier of which check
+		// Grab last byte of contract address as a unique identifier of which check
 		// caused the error, for ease of debugging test cases.
-		code := fmt.Sprintf("%v", op.ContractAddress)[40:]
-		return false, fmt.Errorf("intentional failure (%v)", code)
+		return false, fmt.Errorf("intentional failure (%.2x)", op.ContractAddress[19])
 	}
 	return op.ChainID.Sign() != 0, nil
 }

--- a/core/xchain/entitlement/entitlement.go
+++ b/core/xchain/entitlement/entitlement.go
@@ -199,7 +199,7 @@ func awaitTimeout(ctx context.Context, f func() error) error {
 	select {
 	case <-ctx.Done():
 		// If the context was cancelled or expired, return an error
-		return ctx.Err()
+		return fmt.Errorf("operation cancelled: %w", ctx.Err())
 	case err := <-doneCh:
 		// If the function finished executing, return its result
 		return err

--- a/core/xchain/entitlement/entitlement.go
+++ b/core/xchain/entitlement/entitlement.go
@@ -27,8 +27,9 @@ func (e *Evaluator) EvaluateRuleData(
 	return e.evaluateOp(ctx, opTree, linkedWallets)
 }
 
-// Ignore context cancellations, which can occur when a logical operation evaluation short-circuits
-// because one child returns a definitive answer.
+// isEntitlementEvaluationError returns true iff the error is the result of a failure when evaluating
+// an entitlement. It ignores context cancellations, which can occur when a operation evaluation
+// short-circuits because the other child returned a definitive answer.
 func isEntitlementEvaluationError(err error) bool {
 	return err != nil && !errors.Is(err, context.Canceled)
 }

--- a/core/xchain/entitlement/entitlement.go
+++ b/core/xchain/entitlement/entitlement.go
@@ -61,7 +61,7 @@ func (e *Evaluator) evaluateAndOperation(
 	defer rightCancel()
 	go func() {
 		leftResult, leftErr = e.evaluateOp(leftCtx, op.LeftOperation, linkedWallets)
-		if !leftResult && isNilOrCancelled(leftErr) {
+		if !leftResult && leftErr == nil {
 			// cancel the other goroutine if the left result is false, since we know
 			// the user is unentitled
 			rightCancel()
@@ -71,7 +71,7 @@ func (e *Evaluator) evaluateAndOperation(
 
 	go func() {
 		rightResult, rightErr = e.evaluateOp(rightCtx, op.RightOperation, linkedWallets)
-		if !rightResult && isNilOrCancelled(rightErr) {
+		if !rightResult && rightErr == nil {
 			// cancel the other goroutine if the right result is false, since we know
 			// the user is unentitled
 			leftCancel()

--- a/core/xchain/entitlement/entitlement_test.go
+++ b/core/xchain/entitlement/entitlement_test.go
@@ -347,6 +347,11 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+var (
+	errSlow = fmt.Errorf("intentional failure (02)")
+	errFast = fmt.Errorf("intentional failure (01)")
+)
+
 func TestAndOperation(t *testing.T) {
 	testCases := []struct {
 		description  string
@@ -398,7 +403,7 @@ func TestAndOperation(t *testing.T) {
 		},
 	}
 
-	for idx, tc := range testCases {
+	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			tree := &AndOperation{
 				OpType:         LOGICAL,
@@ -424,16 +429,11 @@ func TestAndOperation(t *testing.T) {
 				expectedDuration,
 				timingThreshold,
 			) {
-				t.Errorf("evaluateAndOperation(%v) took %v; want %v", idx, elapsedTime, expectedDuration)
+				t.Errorf("evaluateAndOperation(%v) took %v; want %v", tc.description, elapsedTime, expectedDuration)
 			}
 		})
 	}
 }
-
-var (
-	errSlow = fmt.Errorf("intentional failure (02)")
-	errFast = fmt.Errorf("intentional failure (01)")
-)
 
 func TestOrOperation(t *testing.T) {
 	testCases := []struct {
@@ -486,7 +486,7 @@ func TestOrOperation(t *testing.T) {
 		},
 	}
 
-	for idx, tc := range testCases {
+	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			tree := &OrOperation{
 				OpType:         LOGICAL,
@@ -512,7 +512,7 @@ func TestOrOperation(t *testing.T) {
 				expectedDuration,
 				timingThreshold,
 			) {
-				t.Errorf("evaluateOrOperation(%v) took %v; want %v", idx, elapsedTime, expectedDuration)
+				t.Errorf("evaluateOrOperation(%v) took %v; want %v", tc.description, elapsedTime, expectedDuration)
 			}
 		})
 	}


### PR DESCRIPTION
Logical AND and ORs were dropping errors and causing false negatives for entitlement evaluations. This PR makes changes Logical operand evaluation to ignore errors only when we definitely know the user was or was not entitled.

specifically, for AND operations:
- if a single child evaluates to false, return false
- otherwise, if either errors, return an error

For OR operations:
- if a single child evaluates to true, return true
- otherwise, if either child operation errors, return an error