### PR TITLE
Add /token/:tokenId to the end of the space member tokenUri

### DIFF
--- a/contracts/src/spaces/facets/membership/metadata/MembershipMetadata.sol
+++ b/contracts/src/spaces/facets/membership/metadata/MembershipMetadata.sol
@@ -6,6 +6,7 @@ import {IERC721A} from "contracts/src/diamond/facets/token/ERC721A/IERC721A.sol"
 
 // libraries
 import {TokenOwnableStorage} from "contracts/src/diamond/facets/ownable/token/TokenOwnableStorage.sol";
+import {LibString} from "solady/utils/LibString.sol";
 
 // contracts
 import {ERC721ABase} from "contracts/src/diamond/facets/token/ERC721A/ERC721ABase.sol";
@@ -15,6 +16,8 @@ contract MembershipMetadata is ERC721ABase, Facet {
   function tokenURI(uint256 tokenId) public view returns (string memory) {
     if (!_exists(tokenId)) revert URIQueryForNonexistentToken();
     TokenOwnableStorage.Layout storage ds = TokenOwnableStorage.layout();
-    return IERC721A(ds.collection).tokenURI(ds.tokenId);
+    string memory baseURI = IERC721A(ds.collection).tokenURI(ds.tokenId);
+    string memory tokenIdStr = LibString.toString(ds.tokenId);
+    return string.concat(baseURI, "/token/", tokenIdStr);
   }
 }

--- a/contracts/src/spaces/facets/membership/metadata/MembershipMetadata.sol
+++ b/contracts/src/spaces/facets/membership/metadata/MembershipMetadata.sol
@@ -17,7 +17,7 @@ contract MembershipMetadata is ERC721ABase, Facet {
     if (!_exists(tokenId)) revert URIQueryForNonexistentToken();
     TokenOwnableStorage.Layout storage ds = TokenOwnableStorage.layout();
     string memory baseURI = IERC721A(ds.collection).tokenURI(ds.tokenId);
-    string memory tokenIdStr = LibString.toString(ds.tokenId);
+    string memory tokenIdStr = LibString.toString(tokenId);
     return string.concat(baseURI, "/token/", tokenIdStr);
   }
 }

--- a/packages/sdk/src/spaceDapp.test.ts
+++ b/packages/sdk/src/spaceDapp.test.ts
@@ -46,6 +46,6 @@ describe('spaceDappTests', () => {
         expect(uri).toBe(`http://localhost:3002/${spaceAddress}`) // hardcoded in InteractSetDefaultUriLocalhost.s.sol
 
         const memberURI = await spaceDapp.memberTokenURI(spaceId, membership2.tokenId)
-        expect(memberURI).toBe(`http://localhost:3002/${spaceAddress}`) // hardcoded in InteractSetDefaultUriLocalhost.s.sol
+        expect(memberURI).toBe(`http://localhost:3002/${spaceAddress}/token/${membership2.tokenId}`) // hardcoded in InteractSetDefaultUriLocalhost.s.sol
     })
 })


### PR DESCRIPTION
So that we can render the member metadata for each member properly

the service returns this
```
return {
		name: `${name} - Member`,
		description: `Member of ${name}`,
		image: `${config.streamMetadataBaseUrl}/space/${spaceAddress}/image`,
		attributes: [
			{
				trait_type: 'Renewal Price',
				display_type: 'number',
				value: renewalPrice.toNumber(),
			},
			{
				trait_type: 'Membership Expiration',
				display_type: 'date',
				value: membershipExpiration.toNumber(),
			},
			{
				trait_type: 'Membership Banned',
				display_type: 'string',
				value: String(isBanned),
			},
		],
	}
```