### PR TITLE
Space, channel isEnabled errors propagate back to caller

### DIFF
--- a/core/node/auth/auth_impl.go
+++ b/core/node/auth/auth_impl.go
@@ -294,12 +294,6 @@ func (ca *chainAuth) checkSpaceEnabled(ctx context.Context, cfg *config.Config, 
 	}
 
 	return isEnabled.IsAllowed(), nil
-
-	// if isEnabled.IsAllowed() {
-	// 	return nil
-	// } else {
-	// 	return RiverError(Err_SPACE_DISABLED, "Space is disabled", "spaceId", spaceId).Func("isEntitledToSpace")
-	// }
 }
 
 func (ca *chainAuth) isChannelEnabledUncached(

--- a/core/node/auth/auth_impl.go
+++ b/core/node/auth/auth_impl.go
@@ -277,7 +277,7 @@ func (ca *chainAuth) isSpaceEnabledUncached(
 	return &boolCacheResult{allowed: !isDisabled}, err
 }
 
-func (ca *chainAuth) checkSpaceEnabled(ctx context.Context, cfg *config.Config, spaceId shared.StreamId) error {
+func (ca *chainAuth) checkSpaceEnabled(ctx context.Context, cfg *config.Config, spaceId shared.StreamId) (bool, error) {
 	isEnabled, cacheHit, err := ca.entitlementCache.executeUsingCache(
 		ctx,
 		cfg,
@@ -285,7 +285,7 @@ func (ca *chainAuth) checkSpaceEnabled(ctx context.Context, cfg *config.Config, 
 		ca.isSpaceEnabledUncached,
 	)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if cacheHit {
 		ca.isSpaceEnabledCacheHit.Inc()
@@ -293,11 +293,13 @@ func (ca *chainAuth) checkSpaceEnabled(ctx context.Context, cfg *config.Config, 
 		ca.isSpaceEnabledCacheMiss.Inc()
 	}
 
-	if isEnabled.IsAllowed() {
-		return nil
-	} else {
-		return RiverError(Err_SPACE_DISABLED, "Space is disabled", "spaceId", spaceId).Func("isEntitledToSpace")
-	}
+	return isEnabled.IsAllowed(), nil
+
+	// if isEnabled.IsAllowed() {
+	// 	return nil
+	// } else {
+	// 	return RiverError(Err_SPACE_DISABLED, "Space is disabled", "spaceId", spaceId).Func("isEntitledToSpace")
+	// }
 }
 
 func (ca *chainAuth) isChannelEnabledUncached(
@@ -315,7 +317,7 @@ func (ca *chainAuth) checkChannelEnabled(
 	cfg *config.Config,
 	spaceId shared.StreamId,
 	channelId shared.StreamId,
-) error {
+) (bool, error) {
 	isEnabled, cacheHit, err := ca.entitlementCache.executeUsingCache(
 		ctx,
 		cfg,
@@ -323,7 +325,7 @@ func (ca *chainAuth) checkChannelEnabled(
 		ca.isChannelEnabledUncached,
 	)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if cacheHit {
 		ca.isChannelEnabledCacheHit.Inc()
@@ -331,11 +333,7 @@ func (ca *chainAuth) checkChannelEnabled(
 		ca.isChannelEnabledCacheMiss.Inc()
 	}
 
-	if isEnabled.IsAllowed() {
-		return nil
-	} else {
-		return RiverError(Err_CHANNEL_DISABLED, "Channel is disabled", "spaceId", spaceId, "channelId", channelId).Func("checkChannelEnabled")
-	}
+	return isEnabled.IsAllowed(), nil
 }
 
 // CacheResult is the result of a cache lookup.
@@ -704,6 +702,28 @@ func (ca *chainAuth) checkMembership(
 	}
 }
 
+func (ca *chainAuth) checkStreamIsEnabled(
+	ctx context.Context,
+	cfg *config.Config,
+	args *ChainAuthArgs,
+) (bool, error) {
+	if args.kind == chainAuthKindSpace || args.kind == chainAuthKindIsSpaceMember {
+		isEnabled, err := ca.checkSpaceEnabled(ctx, cfg, args.spaceId)
+		if err != nil {
+			return false, err
+		}
+		return isEnabled, nil
+	} else if args.kind == chainAuthKindChannel {
+		isEnabled, err := ca.checkChannelEnabled(ctx, cfg, args.spaceId, args.channelId)
+		if err != nil {
+			return false, err
+		}
+		return isEnabled, nil
+	} else {
+		return false, RiverError(Err_INTERNAL, "Unknown chain auth kind").Func("checkEntitlement")
+	}
+}
+
 /** checkEntitlement checks if the user is entitled to the space / channel.
  * It checks the entitlments for the root key and all the wallets linked to it in parallel.
  * If any of the wallets is entitled, the user is entitled and all inflight requests are cancelled.
@@ -720,18 +740,11 @@ func (ca *chainAuth) checkEntitlement(
 	ctx, cancel := context.WithTimeout(ctx, time.Millisecond*time.Duration(ca.contractCallsTimeoutMs))
 	defer cancel()
 
-	if args.kind == chainAuthKindSpace || args.kind == chainAuthKindIsSpaceMember {
-		err := ca.checkSpaceEnabled(ctx, cfg, args.spaceId)
-		if err != nil {
-			return &boolCacheResult{allowed: false}, nil
-		}
-	} else if args.kind == chainAuthKindChannel {
-		err := ca.checkChannelEnabled(ctx, cfg, args.spaceId, args.channelId)
-		if err != nil {
-			return &boolCacheResult{allowed: false}, nil
-		}
-	} else {
-		return &boolCacheResult{allowed: false}, RiverError(Err_INTERNAL, "Unknown chain auth kind").Func("isWalletEntitled")
+	isEnabled, err := ca.checkStreamIsEnabled(ctx, cfg, args)
+	if err != nil {
+		return &boolCacheResult{allowed: false}, err
+	} else if !isEnabled {
+		return &boolCacheResult{allowed: false}, nil
 	}
 
 	// Get all linked wallets.

--- a/core/node/auth/auth_impl.go
+++ b/core/node/auth/auth_impl.go
@@ -714,7 +714,7 @@ func (ca *chainAuth) checkStreamIsEnabled(
 		}
 		return isEnabled, nil
 	} else {
-		return false, RiverError(Err_INTERNAL, "Unknown chain auth kind").Func("checkEntitlement")
+		return false, RiverError(Err_INTERNAL, "Unknown chain auth kind").Func("checkStreamIsEnabled")
 	}
 }
 

--- a/packages/sdk/src/disableChannel.test.ts
+++ b/packages/sdk/src/disableChannel.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @group with-entitlements
+ */
+
+import { NoopRuleData } from '@river-build/web3'
+import { expectUserCanJoinChannel, setupChannelWithCustomRole } from './util.test'
+
+describe('disableChannel', () => {
+    test('User cannot post events to a channel after it is disabled', async () => {
+        const { alice, carol, bobProvider, aliceSpaceDapp, bobSpaceDapp, spaceId, channelId } =
+            await setupChannelWithCustomRole(['alice', 'carol'], NoopRuleData)
+
+        await expectUserCanJoinChannel(alice, aliceSpaceDapp, spaceId, channelId!)
+
+        // Disable the channel
+        const txn = await bobSpaceDapp.setChannelAccess(
+            spaceId,
+            channelId!,
+            true,
+            bobProvider.wallet,
+        )
+        await bobProvider.waitForTransaction(txn.hash)
+        const channelDetails = await bobSpaceDapp.getChannelDetails(spaceId, channelId!)
+        expect(channelDetails).toBeDefined()
+        expect(channelDetails!.disabled).toBeTruthy()
+
+        // Wait 5 seconds for the positive channel enabled cache entry to expire
+        await new Promise((f) => setTimeout(f, 5000))
+
+        // Stream node should not allow the join
+        // TODO: SpaceDapp also should not allow the join, but it currently does not
+        // check for channel enabled. Fix and replace below logic with
+        // await expectUserCanJoinChannel(
+        //     carol,
+        //     carolSpaceDapp,
+        //     spaceId,
+        //     channelId!,
+        // )
+        await expect(carol.joinStream(channelId!)).rejects.toThrow(/7:PERMISSION_DENIED/)
+    })
+})

--- a/packages/sdk/src/disableSpace.test.ts
+++ b/packages/sdk/src/disableSpace.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @group with-entitlements
+ */
+
+import { NoopRuleData } from '@river-build/web3'
+import {
+    expectUserCanJoin,
+    createTownWithRequirements,
+    createUserStreamAndSyncClient,
+    everyoneMembershipStruct,
+} from './util.test'
+
+describe('disableSpace', () => {
+    test('User cannot join a space after it is disabled', async () => {
+        const {
+            alice,
+            carol,
+            alicesWallet,
+            aliceProvider,
+            bobProvider,
+            carolProvider,
+            aliceSpaceDapp,
+            bobSpaceDapp,
+            carolSpaceDapp,
+            spaceId,
+            channelId,
+        } = await createTownWithRequirements({
+            everyone: true,
+            users: [],
+            ruleData: NoopRuleData,
+        })
+
+        await expectUserCanJoin(
+            spaceId,
+            channelId,
+            'alice',
+            alice,
+            aliceSpaceDapp,
+            alicesWallet.address,
+            aliceProvider.wallet,
+        )
+
+        // Disable the channel
+        const txn = await bobSpaceDapp.setSpaceAccess(spaceId, true, bobProvider.wallet)
+        await bobProvider.waitForTransaction(txn.hash)
+        const spaceInfo = await bobSpaceDapp.getSpaceInfo(spaceId)
+        expect(spaceInfo).toBeDefined()
+        expect(spaceInfo?.disabled).toBeTruthy()
+
+        // Wait 5 seconds for the positive space enabled cache entry to expire
+        await new Promise((f) => setTimeout(f, 5000))
+
+        // Have carol create a user stream attached to her own space.
+        // Then she will attempt to join the space from the client, which should fail.
+        await createUserStreamAndSyncClient(
+            carol,
+            carolSpaceDapp,
+            'carol',
+            await everyoneMembershipStruct(carolSpaceDapp, carol),
+            carolProvider.wallet,
+        )
+
+        // Expect user cannot join the space.
+        // TODO: the spaceDapp does not check for space enabled when evaluating if user
+        // is eligible to join the space. Fix and replace the below logic with
+        // await expectUserCannotJoinSpace(
+        //     spaceId,
+        //     carol,
+        //     carolSpaceDapp,
+        //     carolsWallet.address
+        // )
+        await expect(carol.joinStream(spaceId)).rejects.toThrow(/PERMISSION_DENIED/)
+    })
+})


### PR DESCRIPTION
In authorization checks:
- update space and channel isEnabled check to propogated isEnabled, error state back to entitlement check
- in entitlement check, only return a disallowed result if the space or channel is disabled. If there was an error in evaluating either state, return the error.

These changes should prevent users from being booted from channels in the event of partial or total base availability outages.

As part of this PR, I added some happy path e2e tests for disabled channels and spaces. This does not check the specific bug I was fixing but should help prevent regressions in general.