### PR TITLE
stream-metadata: add retry to rpc client

### DIFF
--- a/packages/stream-metadata/src/riverStreamRpcClient.ts
+++ b/packages/stream-metadata/src/riverStreamRpcClient.ts
@@ -2,6 +2,7 @@ import {
 	ParsedStreamResponse,
 	StreamStateView,
 	decryptAESGCM,
+	retryInterceptor,
 	streamIdAsBytes,
 	streamIdAsString,
 	unpackStream,
@@ -25,6 +26,9 @@ function makeStreamRpcClient(logger: FastifyBaseLogger, url: string): StreamRpcC
 	const options: ConnectTransportOptions = {
 		httpVersion: '2',
 		baseUrl: url,
+		interceptors: [
+			retryInterceptor({ maxAttempts: 3, initialRetryDelay: 2000, maxRetryDelay: 6000 }),
+		],
 	}
 
 	const transport = createConnectTransport(options)


### PR DESCRIPTION
Wait a bit and retry if we get ~~any error~~ a bad connection error from the rpc node. 
This will introduce a overhead in the unhappy path, but hopefully we can convert some possible unhappy response to happy responses :D (especially around the `getStream` errors)