### PR TITLE
sdk: allow retry in db operation failure

### DIFF
--- a/packages/sdk/src/rpcInterceptors.ts
+++ b/packages/sdk/src/rpcInterceptors.ts
@@ -316,6 +316,8 @@ function getRetryDelay(error: unknown, attempts: number, retryParams: RetryParam
             return retryDelay
         } else if (errorContains(error, Err.DEBUG_ERROR)) {
             return retryDelay
+        } else if (errorContains(error, Err.DB_OPERATION_FAILURE)) {
+            return retryDelay
         }
     }
     return -1


### PR DESCRIPTION
This updates cause the retryInterceptor to retry if we find a `DB_OPERATION_FAILURE` error