### PR TITLE
stream-metadata: remove cache for 404 (stream not found/image not found)

### DIFF
--- a/packages/stream-metadata/src/routes/profileImage.ts
+++ b/packages/stream-metadata/src/routes/profileImage.ts
@@ -17,7 +17,8 @@ const paramsSchema = z.object({
 
 const CACHE_CONTROL = {
 	307: 'public, max-age=30, s-maxage=3600, stale-while-revalidate=3600',
-	'4xx': 'public, max-age=30, s-maxage=3600',
+	400: 'public, max-age=30, s-maxage=3600',
+	422: 'public, max-age=30, s-maxage=3600',
 }
 
 export async function fetchUserProfileImage(request: FastifyRequest, reply: FastifyReply) {
@@ -29,7 +30,7 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 		logger.info(errorMessage)
 		return reply
 			.code(400)
-			.header('Cache-Control', CACHE_CONTROL['4xx'])
+			.header('Cache-Control', CACHE_CONTROL[400])
 			.send({ error: 'Bad Request', message: errorMessage })
 	}
 
@@ -48,19 +49,14 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 			},
 			'Failed to get stream',
 		)
-		return reply
-			.code(404)
-			.header('Cache-Control', CACHE_CONTROL['4xx'])
-			.send('Stream not found')
+		return reply.code(404).send('Stream not found')
 	}
 
 	// get the image metadata from the stream
 	const profileImage = await getUserProfileImage(stream)
 	if (!profileImage) {
-		return reply
-			.header('Cache-Control', CACHE_CONTROL['4xx'])
-			.code(404)
-			.send('profileImage not found')
+		logger.error({ userId, streamId: stream.streamId }, 'profileImage not found')
+		return reply.code(404).send('profileImage not found')
 	}
 
 	try {
@@ -76,8 +72,8 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 				'Invalid key or iv',
 			)
 			return reply
-				.header('Cache-Control', CACHE_CONTROL['4xx'])
 				.code(422)
+				.header('Cache-Control', CACHE_CONTROL[422])
 				.send('Failed to get encryption key or iv')
 		}
 		const redirectUrl = `${config.streamMetadataBaseUrl}/media/${
@@ -102,7 +98,7 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 		)
 		return reply
 			.code(422)
-			.header('Cache-Control', CACHE_CONTROL['4xx'])
+			.header('Cache-Control', CACHE_CONTROL[422])
 			.send('Failed to get encryption key or iv')
 	}
 }

--- a/packages/stream-metadata/src/routes/spaceImage.ts
+++ b/packages/stream-metadata/src/routes/spaceImage.ts
@@ -20,7 +20,8 @@ const paramsSchema = z.object({
 
 const CACHE_CONTROL = {
 	307: 'public, max-age=30, s-maxage=3600, stale-while-revalidate=3600',
-	'4xx': 'public, max-age=30, s-maxage=3600',
+	400: 'public, max-age=30, s-maxage=3600',
+	422: 'public, max-age=30, s-maxage=3600',
 }
 
 export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyReply) {
@@ -33,7 +34,7 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 		logger.info(errorMessage)
 		return reply
 			.code(400)
-			.header('Cache-Control', CACHE_CONTROL['4xx'])
+			.header('Cache-Control', CACHE_CONTROL[400])
 			.send({ error: 'Bad Request', message: errorMessage })
 	}
 
@@ -52,19 +53,14 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 			},
 			'Failed to get stream',
 		)
-		return reply
-			.code(404)
-			.header('Cache-Control', CACHE_CONTROL['4xx'])
-			.send('Stream not found')
+		return reply.code(404).send('Stream not found')
 	}
 
 	// get the image metatdata from the stream
 	const spaceImage = await getSpaceImage(stream)
 	if (!spaceImage) {
-		return reply
-			.code(404)
-			.header('Cache-Control', CACHE_CONTROL['4xx'])
-			.send('spaceImage not found')
+		logger.error({ spaceAddress, streamId: stream.streamId }, 'spaceImage not found')
+		return reply.code(404).send('spaceImage not found')
 	}
 
 	try {
@@ -81,7 +77,7 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 			)
 			return reply
 				.code(422)
-				.header('Cache-Control', CACHE_CONTROL['4xx'])
+				.header('Cache-Control', CACHE_CONTROL[422])
 				.send('Failed to get encryption key or iv')
 		}
 		const redirectUrl = `${config.streamMetadataBaseUrl}/media/${
@@ -100,7 +96,7 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 		)
 		return reply
 			.code(422)
-			.header('Cache-Control', CACHE_CONTROL['4xx'])
+			.header('Cache-Control', CACHE_CONTROL['422'])
 			.send('Failed to get encryption key or iv')
 	}
 }

--- a/packages/stream-metadata/src/routes/userBio.ts
+++ b/packages/stream-metadata/src/routes/userBio.ts
@@ -45,6 +45,7 @@ export async function fetchUserBio(request: FastifyRequest, reply: FastifyReply)
 
 	const protobufBio = await getUserBio(stream)
 	if (!protobufBio) {
+		logger.info({ userId, streamId: stream.streamId }, 'bio not found')
 		return reply.code(404).send('bio not found')
 	}
 	const bio = protobufBio.bio


### PR DESCRIPTION
We create the space on-chain before creating the stream.
With the 404 cache, we could accidentally hit `/space/{spaceAddress}/image` before the stream creation, causing and error and caching it. We don't want this for now.