### PR TITLE
fix: add /space prefix to space owner default tokenURI

### DIFF
--- a/contracts/scripts/interactions/InteractSetDefaultUriLocalhost.s.sol
+++ b/contracts/scripts/interactions/InteractSetDefaultUriLocalhost.s.sol
@@ -6,7 +6,7 @@ import {ISpaceOwner} from "contracts/src/spaces/facets/owner/ISpaceOwner.sol";
 import {Interaction} from "../common/Interaction.s.sol";
 
 contract InteractSetDefaultUriLocalhost is Interaction {
-  string internal constant URI = "http://localhost:3002/space";
+  string internal constant URI = "http://localhost:3002/";
 
   function __interact(address deployer) internal override {
     address spaceOwner = getDeployment("spaceOwner");

--- a/contracts/scripts/interactions/InteractSetDefaultUriLocalhost.s.sol
+++ b/contracts/scripts/interactions/InteractSetDefaultUriLocalhost.s.sol
@@ -6,7 +6,7 @@ import {ISpaceOwner} from "contracts/src/spaces/facets/owner/ISpaceOwner.sol";
 import {Interaction} from "../common/Interaction.s.sol";
 
 contract InteractSetDefaultUriLocalhost is Interaction {
-  string internal constant URI = "http://localhost:3002/";
+  string internal constant URI = "http://localhost:3002/space";
 
   function __interact(address deployer) internal override {
     address spaceOwner = getDeployment("spaceOwner");

--- a/contracts/src/spaces/facets/owner/SpaceOwnerUriBase.sol
+++ b/contracts/src/spaces/facets/owner/SpaceOwnerUriBase.sol
@@ -25,7 +25,7 @@ abstract contract SpaceOwnerUriBase is ISpaceOwnerBase {
     return SpaceOwnerStorage.layout().defaultUri;
   }
 
-  /// @dev Returns `${space.uri}` or `${defaultUri}/${spaceAddress}`
+  /// @dev Returns `${space.uri}` or `${defaultUri}/space/${spaceAddress}`
   function _render(
     uint256 tokenId
   ) internal view virtual returns (string memory) {
@@ -48,9 +48,18 @@ abstract contract SpaceOwnerUriBase is ISpaceOwnerBase {
       // the ASCII code for "/" is 0x2f
       if (bytes(defaultUri)[length - 1] != 0x2f) {
         return
-          string.concat(defaultUri, "/", spaceAddress.toHexStringChecksummed());
+          string.concat(
+            defaultUri,
+            "/space/",
+            spaceAddress.toHexStringChecksummed()
+          );
       } else {
-        return string.concat(defaultUri, spaceAddress.toHexStringChecksummed());
+        return
+          string.concat(
+            defaultUri,
+            "space/",
+            spaceAddress.toHexStringChecksummed()
+          );
       }
     }
   }

--- a/contracts/test/spaces/owner/SpaceOwner.t.sol
+++ b/contracts/test/spaces/owner/SpaceOwner.t.sol
@@ -265,7 +265,7 @@ contract SpaceOwnerTest is ISpaceOwnerBase, IOwnableBase, BaseSetup {
     string memory tokenUri = spaceOwnerToken.tokenURI(tokenId);
     string memory expectedUri = string.concat(
       defaultUri,
-      "/",
+      "/space/",
       Strings.toHexString(spaceAddress)
     );
     assertEq(LibString.toCase(tokenUri, false), expectedUri);
@@ -283,6 +283,7 @@ contract SpaceOwnerTest is ISpaceOwnerBase, IOwnableBase, BaseSetup {
     string memory tokenUri = spaceOwnerToken.tokenURI(tokenId);
     string memory expectedUri = string.concat(
       uriWithSlash,
+      "space/",
       Strings.toHexString(spaceAddress)
     );
     assertEq(LibString.toCase(tokenUri, false), expectedUri);

--- a/packages/sdk/src/spaceDapp.test.ts
+++ b/packages/sdk/src/spaceDapp.test.ts
@@ -43,9 +43,11 @@ describe('spaceDappTests', () => {
         }
 
         const uri = await spaceDapp.tokenURI(spaceId)
-        expect(uri).toBe(`http://localhost:3002/${spaceAddress}`) // hardcoded in InteractSetDefaultUriLocalhost.s.sol
+        expect(uri).toBe(`http://localhost:3002/space/${spaceAddress}`) // hardcoded in InteractSetDefaultUriLocalhost.s.sol
 
         const memberURI = await spaceDapp.memberTokenURI(spaceId, membership2.tokenId)
-        expect(memberURI).toBe(`http://localhost:3002/${spaceAddress}/token/${membership2.tokenId}`) // hardcoded in InteractSetDefaultUriLocalhost.s.sol
+        expect(memberURI).toBe(
+            `http://localhost:3002/space/${spaceAddress}/token/${membership2.tokenId}`,
+        ) // hardcoded in InteractSetDefaultUriLocalhost.s.sol
     })
 })


### PR DESCRIPTION
#1156 set this as `/{spaceAddress}` and `/{spaceAddress}/token/{tokenId}`

but the endpoint on the stream metadata service uses the `/space` prefix

so its supposed to be: `/space/{spaceAddress}` and `/space/{spaceAddress}/token/{tokenId}`