### PR TITLE
Increase connections count for local postgres to support local dev

### DIFF
--- a/core/scripts/docker-compose.yml
+++ b/core/scripts/docker-compose.yml
@@ -7,7 +7,7 @@ services:
             - POSTGRES_USER=postgres
             - POSTGRES_PASSWORD=postgres
             - PGUSER=postgres
-        command: postgres -c max_connections=1000
+        command: postgres -c max_connections=30000
         logging:
             options:
                 max-size: 10m


### PR DESCRIPTION
Background: individual deployments (e.g. multi) deploy up to 10 servers at once, and each is provisioned to expect solo access to it's own database with 1000 connection limit.

Increase max connections on local postgres to 30k to accommodate up to 30 nodes deployed and in high usage simultaneously.