### PR TITLE
Add tags message to StreamEvent, populate with channel message data

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -29,6 +29,7 @@ import {
     AddEventResponse_Error,
     ChunkedMedia,
     UserBio,
+    Tags,
 } from '@river-build/proto'
 import {
     bin_fromHexString,
@@ -140,12 +141,14 @@ import { SyncedStream } from './syncedStream'
 import { SyncedStreamsExtension } from './syncedStreamsExtension'
 import { SignerContext } from './signerContext'
 import { decryptAESGCM, deriveKeyAndIV, encryptAESGCM, uint8ArrayToBase64 } from './crypto_utils'
+import { makeTags } from './tags'
 
 export type ClientEvents = StreamEvents & DecryptionEvents
 
 type SendChannelMessageOptions = {
     beforeSendEventHook?: Promise<void>
     onLocalEventAppended?: (localId: string) => void
+    disableTags?: boolean // if true, tags will not be added to the message
 }
 
 export class Client
@@ -1351,13 +1354,16 @@ export class Client
         if (opts?.beforeSendEventHook) {
             await opts?.beforeSendEventHook
         }
-        return this.makeAndSendChannelMessageEvent(streamId, payload, localId)
+        return this.makeAndSendChannelMessageEvent(streamId, payload, localId, {
+            disableTags: opts?.disableTags,
+        })
     }
 
     private async makeAndSendChannelMessageEvent(
         streamId: string,
         payload: ChannelMessage,
         localId?: string,
+        opts?: { disableTags?: boolean },
     ) {
         const stream = this.stream(streamId)
         check(isDefined(stream), 'stream not found')
@@ -1402,6 +1408,7 @@ export class Client
             }
         }
 
+        const tags = opts?.disableTags === true ? undefined : makeTags(payload, stream.view)
         const cleartext = payload.toJsonString()
         const message = await this.encryptGroupEvent(payload, streamId)
         message.refEventId = getRefEventIdFromChannelMessage(payload)
@@ -1413,19 +1420,22 @@ export class Client
             return this.makeEventAndAddToStream(streamId, make_ChannelPayload_Message(message), {
                 method: 'sendMessage',
                 localId,
-                cleartext: cleartext,
+                cleartext,
+                tags,
             })
         } else if (isDMChannelStreamId(streamId)) {
             return this.makeEventAndAddToStream(streamId, make_DMChannelPayload_Message(message), {
                 method: 'sendMessageDM',
                 localId,
-                cleartext: cleartext,
+                cleartext,
+                tags,
             })
         } else if (isGDMChannelStreamId(streamId)) {
             return this.makeEventAndAddToStream(streamId, make_GDMChannelPayload_Message(message), {
                 method: 'sendMessageGDM',
                 localId,
-                cleartext: cleartext,
+                cleartext,
+                tags,
             })
         } else {
             throw new Error(`invalid streamId: ${streamId}`)
@@ -1978,7 +1988,13 @@ export class Client
     async makeEventAndAddToStream(
         streamId: string | Uint8Array,
         payload: PlainMessage<StreamEvent>['payload'],
-        options: { method?: string; localId?: string; cleartext?: string; optional?: boolean } = {},
+        options: {
+            method?: string
+            localId?: string
+            cleartext?: string
+            optional?: boolean
+            tags?: PlainMessage<Tags>
+        } = {},
     ): Promise<{ eventId: string; error?: AddEventResponse_Error }> {
         // TODO: filter this.logged payload for PII reasons
         this.logCall(
@@ -2006,6 +2022,7 @@ export class Client
             options.optional,
             options.localId,
             options.cleartext,
+            options.tags,
         )
         return { eventId, error }
     }
@@ -2017,6 +2034,7 @@ export class Client
         optional?: boolean,
         localId?: string,
         cleartext?: string,
+        tags?: PlainMessage<Tags>,
         retryCount?: number,
     ): Promise<{ prevMiniblockHash: Uint8Array; eventId: string; error?: AddEventResponse_Error }> {
         const event = await makeEvent(this.signerContext, payload, prevMiniblockHash)
@@ -2066,6 +2084,7 @@ export class Client
                     optional,
                     isDefined(localId) ? eventId : undefined,
                     cleartext,
+                    tags,
                     retryCount + 1,
                 )
             } else {

--- a/packages/sdk/src/sign.ts
+++ b/packages/sdk/src/sign.ts
@@ -9,6 +9,7 @@ import {
     Miniblock,
     StreamAndCookie,
     SyncCookie,
+    Tags,
 } from '@river-build/proto'
 import { assertBytes } from 'ethereum-cryptography/utils'
 import { recoverPublicKey, signSync, verify } from 'ethereum-cryptography/secp256k1'
@@ -21,6 +22,7 @@ export const _impl_makeEvent_impl_ = async (
     context: SignerContext,
     payload: PlainMessage<StreamEvent>['payload'],
     prevMiniblockHash?: Uint8Array,
+    tags?: PlainMessage<Tags>,
 ): Promise<Envelope> => {
     const streamEvent = new StreamEvent({
         creatorAddress: context.creatorAddress,
@@ -28,6 +30,7 @@ export const _impl_makeEvent_impl_ = async (
         prevMiniblockHash,
         payload,
         createdAtEpochMs: BigInt(Date.now()),
+        tags,
     })
     if (context.delegateSig !== undefined) {
         streamEvent.delegateSig = context.delegateSig
@@ -45,6 +48,7 @@ export const makeEvent = async (
     context: SignerContext,
     payload: PlainMessage<StreamEvent>['payload'],
     prevMiniblockHash?: Uint8Array,
+    tags?: PlainMessage<Tags>,
 ): Promise<Envelope> => {
     // const pl: Payload = payload instanceof Payload ? payload : new Payload(payload)
     const pl = payload // todo check this
@@ -62,7 +66,7 @@ export const makeEvent = async (
         )
     }
 
-    return _impl_makeEvent_impl_(context, pl, prevMiniblockHash)
+    return _impl_makeEvent_impl_(context, pl, prevMiniblockHash, tags)
 }
 
 export const makeEvents = async (

--- a/packages/sdk/src/tags.test.ts
+++ b/packages/sdk/src/tags.test.ts
@@ -96,7 +96,7 @@ describe('makeTags', () => {
         expect(tags.messageInteractionType).toBe(MessageInteractionType.REACTION)
         expect(tags.groupMentionTypes).toEqual([])
         expect(tags.mentionedUserAddresses).toEqual([])
-        expect(tags.participatingUserIds).toEqual([user2.address])
+        expect(tags.participatingUserAddresses).toEqual([user2.address])
     })
 
     it('should create tags for a reply message', () => {
@@ -228,6 +228,10 @@ describe('makeTags', () => {
         expect(tags.messageInteractionType).toBe(MessageInteractionType.REPLY)
         expect(tags.groupMentionTypes).toEqual([GroupMentionType.AT_CHANNEL])
         expect(tags.mentionedUserAddresses).toEqual([user1.address])
-        expect(tags.participatingUserIds).toEqual([user2.address, user3.address, user4.address])
+        expect(tags.participatingUserAddresses).toEqual([
+            user2.address,
+            user3.address,
+            user4.address,
+        ])
     })
 })

--- a/packages/sdk/src/tags.test.ts
+++ b/packages/sdk/src/tags.test.ts
@@ -94,7 +94,7 @@ describe('makeTags', () => {
         const tags = makeTags(reactionMessage, mockStreamView)
 
         expect(tags.messageInteractionType).toBe(MessageInteractionType.REACTION)
-        expect(tags.groupMentionType).toBe(GroupMentionType.UNSPECIFIED)
+        expect(tags.groupMentionTypes).toEqual([])
         expect(tags.mentionedUserAddresses).toEqual([])
         expect(tags.participatingUserIds).toEqual([user2.address])
     })
@@ -226,7 +226,7 @@ describe('makeTags', () => {
         const tags = makeTags(replyMessage, mockStreamView)
 
         expect(tags.messageInteractionType).toBe(MessageInteractionType.REPLY)
-        expect(tags.groupMentionType).toBe(GroupMentionType.AT_CHANNEL)
+        expect(tags.groupMentionTypes).toEqual([GroupMentionType.AT_CHANNEL])
         expect(tags.mentionedUserAddresses).toEqual([user1.address])
         expect(tags.participatingUserIds).toEqual([user2.address, user3.address, user4.address])
     })

--- a/packages/sdk/src/tags.test.ts
+++ b/packages/sdk/src/tags.test.ts
@@ -1,0 +1,233 @@
+/**
+ * @group main
+ */
+import {
+    ChannelMessage,
+    GroupMentionType,
+    MessageInteractionType,
+    StreamEvent,
+} from '@river-build/proto'
+import { makeTags } from './tags'
+import { IStreamStateView, StreamStateView } from './streamStateView'
+import { addressFromUserId, genIdBlob, makeUniqueChannelStreamId, userIdFromAddress } from './id'
+import { PlainMessage } from '@bufbuild/protobuf'
+import { ethers } from 'ethers'
+import { makeUniqueSpaceStreamId } from './util.test'
+import { makeSignerContext, SignerContext } from './signerContext'
+import { makeParsedEvent } from './sign'
+import { makeRemoteTimelineEvent } from './types'
+
+// Mock the IStreamStateView interface
+
+interface TagsTestUser {
+    userId: string
+    address: Uint8Array
+    context: SignerContext
+    wallet: ethers.Wallet
+}
+
+describe('makeTags', () => {
+    const spaceId = makeUniqueSpaceStreamId()
+    const streamId = makeUniqueChannelStreamId(spaceId)
+    let mockStreamView: IStreamStateView
+
+    let user1: TagsTestUser
+    let user2: TagsTestUser
+    let user3: TagsTestUser
+    let user4: TagsTestUser
+
+    beforeAll(async () => {
+        const makeUser = async () => {
+            const wallet = ethers.Wallet.createRandom()
+            const delegateWallet = ethers.Wallet.createRandom()
+            const context = await makeSignerContext(wallet, delegateWallet)
+            return {
+                userId: wallet.address,
+                address: addressFromUserId(wallet.address),
+                context,
+                wallet,
+            } satisfies TagsTestUser
+        }
+        user1 = await makeUser()
+        user2 = await makeUser()
+        user3 = await makeUser()
+        user4 = await makeUser()
+
+        mockStreamView = new StreamStateView(userIdFromAddress(user1.address), streamId)
+    })
+
+    beforeEach(() => {
+        mockStreamView.events.clear()
+    })
+
+    it('should create tags for a reaction message', () => {
+        const reactionMessage: PlainMessage<ChannelMessage> = {
+            payload: {
+                case: 'reaction',
+                value: {
+                    refEventId: 'event1',
+                    reaction: '👍',
+                },
+            },
+        }
+
+        mockStreamView.events.set(
+            'event1',
+            makeRemoteTimelineEvent({
+                parsedEvent: makeParsedEvent(
+                    new StreamEvent({
+                        creatorAddress: user2.context.creatorAddress,
+                        salt: genIdBlob(),
+                        prevMiniblockHash: undefined,
+                        payload: { case: undefined, value: undefined },
+                        createdAtEpochMs: BigInt(Date.now()),
+                        tags: undefined,
+                    }),
+                ),
+                eventNum: 0n,
+                miniblockNum: 0n,
+                confirmedEventNum: 0n,
+            }),
+        )
+        mockStreamView.timeline.push(mockStreamView.events.get('event1')!)
+
+        const tags = makeTags(reactionMessage, mockStreamView)
+
+        expect(tags.messageInteractionType).toBe(MessageInteractionType.REACTION)
+        expect(tags.groupMentionType).toBe(GroupMentionType.UNSPECIFIED)
+        expect(tags.mentionedUserAddresses).toEqual([])
+        expect(tags.participatingUserIds).toEqual([user2.address])
+    })
+
+    it('should create tags for a reply message', () => {
+        const replyMessage: PlainMessage<ChannelMessage> = {
+            payload: {
+                case: 'post',
+                value: {
+                    threadId: 'thread1',
+                    content: {
+                        case: 'text',
+                        value: {
+                            body: 'hello world',
+                            mentions: [
+                                {
+                                    userId: user1.userId,
+                                    displayName: 'User 1',
+                                    mentionBehavior: { case: undefined },
+                                },
+                                {
+                                    userId: 'atChannel',
+                                    displayName: 'atChannel',
+                                    mentionBehavior: { case: 'atChannel', value: {} },
+                                },
+                            ],
+                            attachments: [],
+                        },
+                    },
+                },
+            },
+        }
+
+        mockStreamView.events.set('thread1', {
+            ...makeRemoteTimelineEvent({
+                parsedEvent: makeParsedEvent(
+                    new StreamEvent({
+                        creatorAddress: user2.context.creatorAddress,
+                        salt: genIdBlob(),
+                        prevMiniblockHash: undefined,
+                        payload: { case: undefined, value: undefined },
+                        createdAtEpochMs: BigInt(Date.now()),
+                        tags: undefined,
+                    }),
+                ),
+                eventNum: 0n,
+                miniblockNum: 0n,
+                confirmedEventNum: 0n,
+            }),
+        })
+        mockStreamView.timeline.push(mockStreamView.events.get('thread1')!)
+
+        mockStreamView.events.set('event1', {
+            ...makeRemoteTimelineEvent({
+                parsedEvent: makeParsedEvent(
+                    new StreamEvent({
+                        creatorAddress: user3.context.creatorAddress,
+                        salt: genIdBlob(),
+                        prevMiniblockHash: undefined,
+                        payload: { case: undefined, value: undefined },
+                        createdAtEpochMs: BigInt(Date.now()),
+                        tags: undefined,
+                    }),
+                ),
+                eventNum: 0n,
+                miniblockNum: 0n,
+                confirmedEventNum: 0n,
+            }),
+            decryptedContent: {
+                kind: 'channelMessage',
+                content: new ChannelMessage({
+                    payload: {
+                        case: 'post',
+                        value: {
+                            threadId: 'thread1',
+                            content: {
+                                case: 'text',
+                                value: {
+                                    body: 'hello world',
+                                    mentions: [],
+                                    attachments: [],
+                                },
+                            },
+                        },
+                    },
+                }),
+            },
+        })
+        mockStreamView.timeline.push(mockStreamView.events.get('event1')!)
+
+        mockStreamView.events.set('event2', {
+            ...makeRemoteTimelineEvent({
+                parsedEvent: makeParsedEvent(
+                    new StreamEvent({
+                        creatorAddress: user4.context.creatorAddress,
+                        salt: genIdBlob(),
+                        prevMiniblockHash: undefined,
+                        payload: { case: undefined, value: undefined },
+                        createdAtEpochMs: BigInt(Date.now()),
+                        tags: undefined,
+                    }),
+                ),
+                eventNum: 0n,
+                miniblockNum: 0n,
+                confirmedEventNum: 0n,
+            }),
+            decryptedContent: {
+                kind: 'channelMessage',
+                content: new ChannelMessage({
+                    payload: {
+                        case: 'post',
+                        value: {
+                            threadId: 'thread1',
+                            content: {
+                                case: 'text',
+                                value: {
+                                    body: 'hello world',
+                                    mentions: [],
+                                    attachments: [],
+                                },
+                            },
+                        },
+                    },
+                }),
+            },
+        })
+        mockStreamView.timeline.push(mockStreamView.events.get('event2')!)
+
+        const tags = makeTags(replyMessage, mockStreamView)
+
+        expect(tags.messageInteractionType).toBe(MessageInteractionType.REPLY)
+        expect(tags.groupMentionType).toBe(GroupMentionType.AT_CHANNEL)
+        expect(tags.mentionedUserAddresses).toEqual([user1.address])
+        expect(tags.participatingUserIds).toEqual([user2.address, user3.address, user4.address])
+    })
+})

--- a/packages/sdk/src/tags.ts
+++ b/packages/sdk/src/tags.ts
@@ -11,7 +11,7 @@ export function makeTags(
         messageInteractionType: getMessageInteractionType(message),
         groupMentionTypes: getGroupMentionTypes(message),
         mentionedUserAddresses: getMentionedUserIds(message),
-        participatingUserIds: getParticipatingUserIds(message, streamView),
+        participatingUserAddresses: getParticipatingUserAddresses(message, streamView),
     } satisfies PlainMessage<Tags>
 }
 
@@ -55,7 +55,7 @@ function getMentionedUserIds(message: PlainMessage<ChannelMessage>): Uint8Array[
     return []
 }
 
-function getParticipatingUserIds(
+function getParticipatingUserAddresses(
     message: PlainMessage<ChannelMessage>,
     streamView: IStreamStateView,
 ): Uint8Array[] {

--- a/packages/sdk/src/tags.ts
+++ b/packages/sdk/src/tags.ts
@@ -1,0 +1,100 @@
+import { PlainMessage } from '@bufbuild/protobuf'
+import { ChannelMessage, GroupMentionType, MessageInteractionType, Tags } from '@river-build/proto'
+import { IStreamStateView } from './streamStateView'
+import { addressFromUserId } from './id'
+
+export function makeTags(
+    message: PlainMessage<ChannelMessage>,
+    streamView: IStreamStateView,
+): PlainMessage<Tags> {
+    return {
+        messageInteractionType: getMessageInteractionType(message),
+        groupMentionType: getGroupMentionType(message),
+        mentionedUserAddresses: getMentionedUserIds(message),
+        participatingUserIds: getParticipatingUserIds(message, streamView),
+    } satisfies PlainMessage<Tags>
+}
+
+function getMessageInteractionType(message: PlainMessage<ChannelMessage>): MessageInteractionType {
+    switch (message.payload.case) {
+        case 'reaction':
+            return MessageInteractionType.REACTION
+        case 'post':
+            if (message.payload.value.threadId) {
+                return MessageInteractionType.REPLY
+            } else if (message.payload.value.replyId) {
+                return MessageInteractionType.REPLY
+            } else {
+                return MessageInteractionType.UNSPECIFIED
+            }
+        default:
+            return MessageInteractionType.UNSPECIFIED
+    }
+}
+
+function getGroupMentionType(message: PlainMessage<ChannelMessage>): GroupMentionType {
+    if (
+        message.payload.case === 'post' &&
+        message.payload.value.content.case === 'text' &&
+        message.payload.value.content.value.mentions.find(
+            (m) => m.mentionBehavior.case === 'atChannel',
+        )
+    ) {
+        return GroupMentionType.AT_CHANNEL
+    }
+    return GroupMentionType.UNSPECIFIED
+}
+
+function getMentionedUserIds(message: PlainMessage<ChannelMessage>): Uint8Array[] {
+    if (message.payload.case === 'post' && message.payload.value.content.case === 'text') {
+        return message.payload.value.content.value.mentions
+            .filter((m) => m.mentionBehavior.case === undefined && m.userId.length > 0)
+            .map((m) => addressFromUserId(m.userId))
+    }
+    return []
+}
+
+function getParticipatingUserIds(
+    message: PlainMessage<ChannelMessage>,
+    streamView: IStreamStateView,
+): Uint8Array[] {
+    switch (message.payload.case) {
+        case 'reaction': {
+            const event = streamView.events.get(message.payload.value.refEventId)
+            if (event && event.remoteEvent?.event.creatorAddress) {
+                return [event.remoteEvent.event.creatorAddress]
+            }
+            return []
+        }
+        case 'post': {
+            const participating = new Set<Uint8Array>()
+            const parentId = message.payload.value.threadId || message.payload.value.replyId
+            if (parentId) {
+                const parentEvent = streamView.events.get(parentId)
+                if (parentEvent && parentEvent.remoteEvent?.event.creatorAddress) {
+                    participating.add(parentEvent.remoteEvent.event.creatorAddress)
+                }
+                streamView.timeline.forEach((event) => {
+                    if (
+                        event.decryptedContent?.kind === 'channelMessage' &&
+                        event.decryptedContent.content.payload.case === 'post' &&
+                        event.decryptedContent.content.payload.value.threadId === parentId &&
+                        event.remoteEvent?.event.creatorAddress
+                    ) {
+                        participating.add(event.remoteEvent.event.creatorAddress)
+                    } else if (
+                        event.decryptedContent?.kind === 'channelMessage' &&
+                        event.decryptedContent.content.payload.case === 'reaction' &&
+                        event.decryptedContent.content.payload.value.refEventId === parentId &&
+                        event.remoteEvent?.event.creatorAddress
+                    ) {
+                        participating.add(event.remoteEvent.event.creatorAddress)
+                    }
+                })
+            }
+            return Array.from(participating)
+        }
+        default:
+            return []
+    }
+}

--- a/packages/sdk/src/tags.ts
+++ b/packages/sdk/src/tags.ts
@@ -9,7 +9,7 @@ export function makeTags(
 ): PlainMessage<Tags> {
     return {
         messageInteractionType: getMessageInteractionType(message),
-        groupMentionType: getGroupMentionType(message),
+        groupMentionTypes: getGroupMentionTypes(message),
         mentionedUserAddresses: getMentionedUserIds(message),
         participatingUserIds: getParticipatingUserIds(message, streamView),
     } satisfies PlainMessage<Tags>
@@ -32,7 +32,8 @@ function getMessageInteractionType(message: PlainMessage<ChannelMessage>): Messa
     }
 }
 
-function getGroupMentionType(message: PlainMessage<ChannelMessage>): GroupMentionType {
+function getGroupMentionTypes(message: PlainMessage<ChannelMessage>): GroupMentionType[] {
+    const types: GroupMentionType[] = []
     if (
         message.payload.case === 'post' &&
         message.payload.value.content.case === 'text' &&
@@ -40,9 +41,9 @@ function getGroupMentionType(message: PlainMessage<ChannelMessage>): GroupMentio
             (m) => m.mentionBehavior.case === 'atChannel',
         )
     ) {
-        return GroupMentionType.AT_CHANNEL
+        types.push(GroupMentionType.AT_CHANNEL)
     }
-    return GroupMentionType.UNSPECIFIED
+    return types
 }
 
 function getMentionedUserIds(message: PlainMessage<ChannelMessage>): Uint8Array[] {

--- a/protocol/protocol.proto
+++ b/protocol/protocol.proto
@@ -662,7 +662,7 @@ message Tags {
     MessageInteractionType message_interaction_type = 1;
     repeated GroupMentionType group_mention_types = 2;
     repeated bytes mentioned_user_addresses = 3;
-    repeated bytes participating_user_ids = 4;
+    repeated bytes participating_user_addresses = 4;
 }
 
 // GetStreamExResponse is a stream of raw data that represents the current state of the requested stream.

--- a/protocol/protocol.proto
+++ b/protocol/protocol.proto
@@ -85,6 +85,9 @@ message StreamEvent {
     /** DelegateExpiry is the time when the delegate signature expires. */
     int64 delegate_expiry_epoch_ms = 6;
 
+    /** Tags are optional, used for external systems to deliver notifications. */
+    Tags tags = 7;
+
     /** Variable-type payload. 
       * Payloads should obey the following rules:
       * - payloads should have their own unique type
@@ -137,9 +140,6 @@ message MiniblockHeader {
 
     // pointer to block with previous snapshot
     int64 prev_snapshot_miniblock_num = 7;
-
-    // optional metadata tags for external systems
-    Tags tags = 8;
 
     // stream payloads are required to have a content field
     oneof content {
@@ -659,7 +659,10 @@ message Minipool {
 }
 
 message Tags {
-    map<string, string> tags = 1;
+    MessageInteractionType message_interaction_type = 1;
+    GroupMentionType group_mention_type = 2;
+    repeated bytes mentioned_user_addresses = 3;
+    repeated bytes participating_user_ids = 4;
 }
 
 // GetStreamExResponse is a stream of raw data that represents the current state of the requested stream.
@@ -874,6 +877,18 @@ enum ChannelOp {
     CO_DELETED = 2;
     CO_UPDATED = 4;
 }
+
+enum MessageInteractionType {
+    MESSAGE_INTERACTION_TYPE_UNSPECIFIED = 0;
+    MESSAGE_INTERACTION_TYPE_REPLY = 1;
+    MESSAGE_INTERACTION_TYPE_REACTION = 2;
+}
+
+enum GroupMentionType {
+    GROUP_MENTION_TYPE_UNSPECIFIED = 0;
+    GROUP_MENTION_TYPE_AT_CHANNEL = 1;
+}
+
 
 // Codes from 1 to 16 match gRPC/Connect codes.
 enum Err {

--- a/protocol/protocol.proto
+++ b/protocol/protocol.proto
@@ -660,7 +660,7 @@ message Minipool {
 
 message Tags {
     MessageInteractionType message_interaction_type = 1;
-    GroupMentionType group_mention_type = 2;
+    repeated GroupMentionType group_mention_types = 2;
     repeated bytes mentioned_user_addresses = 3;
     repeated bytes participating_user_ids = 4;
 }


### PR DESCRIPTION
i added a react/reply indicator
a group mention type, which at the moment is just @channel but could support @everyone or @here or @role later
a mentions array for users mentioned
a participating array that grabs people who have replied to a thread or emoji'd the original message

work i expect the notification service to do
- figure out who gets notified for @channel
- figure out if this is a dm or gdm and notify accordingly

things i just skipped
- there's all this weird code about attachment notifications, i.e. "attachmentUsersTagged" that seems like it should just never happen, so i've ignored all that. 
- attachment mime types... seems like you should just decrypt things to figure that out.