### PR TITLE
Fix for flaky test: Update check in onStreamInitialized

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1300,7 +1300,9 @@ export class Client
     private onStreamInitialized = (streamId: string): void => {
         const scrollbackUntilContentFound = async () => {
             const stream = this.streams.get(streamId)
-            check(isDefined(stream), 'stream not found')
+            if (!stream) {
+                return
+            }
             while (stream.view.getContent().needsScrollback()) {
                 const scrollback = await this.scrollback(streamId)
                 if (scrollback.terminus) {


### PR DESCRIPTION
During ci this occasionally gets hit. I’m assuming that we stop the client and clear the streams but an async task finishes and broadcasts on stream initialize.

Callstack:

```
 stream not found

      15 |
      16 | export function throwWithCode(message?: string, code?: Err, data?: any): never {
    > 17 |     const e = new CodeException(message ?? 'Unknown', code ?? Err.ERR_UNSPECIFIED, data)
         |               ^
      18 |     log('throwWithCode', e)
      19 |     throw e
      20 | }

      at throwWithCode (../../../river/packages/dlog/src/check.ts:17:15)
      at check (../../../river/packages/dlog/src/check.ts:31:9)
      at scrollbackUntilContentFound (../../../river/packages/sdk/src/client.ts:1303:13)
      at Client.onStreamInitialized (../../../river/packages/sdk/src/client.ts:1311:14)
      at Client.<anonymous> (../../../river/packages/sdk/src/client.ts:307:55)
      at Client.emit (../../../river/packages/sdk/src/client.ts:1326:22)
      at SyncedStream.emit (../../../river/packages/sdk/src/stream.ts:115:28)
      at StreamStateView.initialize (../../../river/packages/sdk/src/streamStateView.ts:626:18)
      at SyncedStream.initialize (../../../river/packages/sdk/src/stream.ts:60:20)
      at SyncedStream.initialize (../../../river/packages/sdk/src/syncedStream.ts:93:15)
      at SyncedStream.initializeFromResponse (../../../river/packages/sdk/src/syncedStream.ts:117:20)
      at Client.createStreamAndSync (../../../river/packages/sdk/src/client.ts:517:13)
      at TownsClient.createChannelRoom (src/client/TownsClient.ts:565:30)
      at TownsClient.waitForCreateChannelTransaction (src/client/TownsClient.ts:693:21)
      at src/hooks/use-towns-client.ts:439:39
      at src/hooks/use-create-channel-transaction.ts:66:41
      at tests/integration/createSpaceChannelHooks.test.tsx:93:21
```