### PR TITLE
revert: /space prefix to space owner default tokenURI #1183

### DIFF
--- a/contracts/src/spaces/facets/owner/SpaceOwnerUriBase.sol
+++ b/contracts/src/spaces/facets/owner/SpaceOwnerUriBase.sol
@@ -25,7 +25,7 @@ abstract contract SpaceOwnerUriBase is ISpaceOwnerBase {
     return SpaceOwnerStorage.layout().defaultUri;
   }
 
-  /// @dev Returns `${space.uri}` or `${defaultUri}/space/${spaceAddress}`
+  /// @dev Returns `${space.uri}` or `${defaultUri}/${spaceAddress}`
   function _render(
     uint256 tokenId
   ) internal view virtual returns (string memory) {
@@ -48,18 +48,9 @@ abstract contract SpaceOwnerUriBase is ISpaceOwnerBase {
       // the ASCII code for "/" is 0x2f
       if (bytes(defaultUri)[length - 1] != 0x2f) {
         return
-          string.concat(
-            defaultUri,
-            "/space/",
-            spaceAddress.toHexStringChecksummed()
-          );
+          string.concat(defaultUri, "/", spaceAddress.toHexStringChecksummed());
       } else {
-        return
-          string.concat(
-            defaultUri,
-            "space/",
-            spaceAddress.toHexStringChecksummed()
-          );
+        return string.concat(defaultUri, spaceAddress.toHexStringChecksummed());
       }
     }
   }

--- a/contracts/test/spaces/owner/SpaceOwner.t.sol
+++ b/contracts/test/spaces/owner/SpaceOwner.t.sol
@@ -265,7 +265,7 @@ contract SpaceOwnerTest is ISpaceOwnerBase, IOwnableBase, BaseSetup {
     string memory tokenUri = spaceOwnerToken.tokenURI(tokenId);
     string memory expectedUri = string.concat(
       defaultUri,
-      "/space/",
+      "/",
       Strings.toHexString(spaceAddress)
     );
     assertEq(LibString.toCase(tokenUri, false), expectedUri);
@@ -283,7 +283,6 @@ contract SpaceOwnerTest is ISpaceOwnerBase, IOwnableBase, BaseSetup {
     string memory tokenUri = spaceOwnerToken.tokenURI(tokenId);
     string memory expectedUri = string.concat(
       uriWithSlash,
-      "space/",
       Strings.toHexString(spaceAddress)
     );
     assertEq(LibString.toCase(tokenUri, false), expectedUri);

--- a/packages/sdk/src/spaceDapp.test.ts
+++ b/packages/sdk/src/spaceDapp.test.ts
@@ -43,11 +43,9 @@ describe('spaceDappTests', () => {
         }
 
         const uri = await spaceDapp.tokenURI(spaceId)
-        expect(uri).toBe(`http://localhost:3002/space/${spaceAddress}`) // hardcoded in InteractSetDefaultUriLocalhost.s.sol
+        expect(uri).toBe(`http://localhost:3002/${spaceAddress}`) // hardcoded in InteractSetDefaultUriLocalhost.s.sol
 
         const memberURI = await spaceDapp.memberTokenURI(spaceId, membership2.tokenId)
-        expect(memberURI).toBe(
-            `http://localhost:3002/space/${spaceAddress}/token/${membership2.tokenId}`,
-        ) // hardcoded in InteractSetDefaultUriLocalhost.s.sol
+        expect(memberURI).toBe(`http://localhost:3002/${spaceAddress}/token/${membership2.tokenId}`) // hardcoded in InteractSetDefaultUriLocalhost.s.sol
     })
 })


### PR DESCRIPTION
This reverts commit 45cd228b0c6333219465cf2c22b6118a42fad5df.

Caused `/space/space/` as a side effect.





