### PR TITLE
wait for cache invalidation to complete

### DIFF
--- a/packages/stream-metadata/src/routes/userRefresh.ts
+++ b/packages/stream-metadata/src/routes/userRefresh.ts
@@ -39,7 +39,11 @@ export async function userRefreshOnResponse(
 
 	try {
 		const path = `/user/${userId}/image`
-		await CloudfrontManager.createCloudfrontInvalidation({ path, logger })
+		await CloudfrontManager.createCloudfrontInvalidation({
+			path,
+			logger,
+			waitUntilFinished: true,
+		})
 	} catch (error) {
 		logger.error(
 			{


### PR DESCRIPTION
Would this have any negative side effects? It's currently tricky to invalidate local cache and reload images since we have no idea whether the invalidation has completed on Cloudfront's end.