### PR TITLE
[TOWNS-12637] Encode no op rule datas as empty bytes

### DIFF
--- a/packages/sdk/src/updateRole.test.ts
+++ b/packages/sdk/src/updateRole.test.ts
@@ -1,0 +1,32 @@
+/**
+ * @group with-v2-entitlements
+ */
+
+import { createTownWithRequirements, updateRole } from './util.test'
+import { NoopRuleData, UpdateRoleParams, Permission, EVERYONE_ADDRESS } from '@river-build/web3'
+
+describe('updateRole', () => {
+    test('user-gated space created with no-op ruleData allows updates on minter role', async () => {
+        const { bobSpaceDapp, bobProvider, spaceId } = await createTownWithRequirements({
+            everyone: false,
+            users: ['alice'],
+            ruleData: NoopRuleData,
+        })
+
+        // Update role to be ungated
+        const { error } = await updateRole(
+            bobSpaceDapp,
+            bobProvider,
+            {
+                spaceNetworkId: spaceId,
+                roleId: 1, // Minter role id
+                roleName: 'Updated minter role',
+                permissions: [Permission.JoinSpace],
+                users: [EVERYONE_ADDRESS],
+                ruleData: NoopRuleData,
+            } as UpdateRoleParams,
+            bobProvider.signer,
+        )
+        expect(error).toBeUndefined()
+    })
+})

--- a/packages/web3/src/entitlement.ts
+++ b/packages/web3/src/entitlement.ts
@@ -289,6 +289,11 @@ export function decodeRuleData(entitlementData: Hex): IRuleEntitlementBase.RuleD
 }
 
 export function encodeRuleDataV2(ruleData: IRuleEntitlementV2Base.RuleDataV2Struct): Hex {
+    // If we encounter a no-op rule data, just encode as empty bytes.
+    if (ruleData.operations.length === 0) {
+        return '0x'
+    }
+
     const getRuleDataV2Abi: ExtractAbiFunction<typeof IRuleEntitlementV2Abi, 'getRuleDataV2'> =
         getAbiItem({
             abi: IRuleEntitlementV2Abi,


### PR DESCRIPTION
https://linear.app/hnt-labs/issue/TOWNS-12637/%5Balpha%5D%5Buser-feedback%5D-unable-to-update-membership-of-a-town-gated-by was caused by towns with empty rule datas being initialized with an encode no-op rule data instead of empty bytes. This is an issue because the RuleEntitlementV2 contract will ignore NoOpRuleDatas when set on the contract, but the architect considers the rule data to be a valid entitlement if it is a non-empty byte array.

The most surgical change here is to encode `NoopRuleData`s as empty byte arrays. This allows us to continue using NoopRuleData as a placeholder for the empty RuleDataV2 which is consistent with what CreateRole expects on the spaceDapp, as well as the API/logic we exposed to create legacy spaces.

Follow up PR to revert when setEntitlement sets an empty entitlement for RuleEntitlementV2 to also catch this on the contracts side.
