### PR TITLE
[TOWNS-12637] Update RuleEntitlementV2 to revert when zero length rule data is passed in

### DIFF
--- a/contracts/src/spaces/entitlements/rule/RuleEntitlementV2.sol
+++ b/contracts/src/spaces/entitlements/rule/RuleEntitlementV2.sol
@@ -117,7 +117,11 @@ contract RuleEntitlementV2 is
   ) external onlySpace {
     _removeRuleDataV1(roleId);
 
-    if (entitlementData.length == 0) return;
+    // We should never allow the setting of empty rule datas because it can cause the xchain
+    // architecture to be invoked when by default a user is not entitled.
+    if (entitlementData.length == 0) {
+      revert Entitlement__InvalidValue();
+    }
 
     // equivalent: abi.decode(entitlementData, (RuleDataV2))
     RuleDataV2 calldata data;
@@ -127,7 +131,11 @@ contract RuleEntitlementV2 is
       data := add(entitlementData.offset, calldataload(entitlementData.offset))
     }
 
-    if (data.operations.length == 0) return;
+    // We should never allow the setting of empty rule datas because it can cause the xchain
+    // architecture to be invoked when by default a user is not entitled.
+    if (data.operations.length == 0) {
+      revert Entitlement__InvalidValue();
+    }
 
     // Cache lengths of operations arrays to reduce state access cost
     uint256 operationsLength = data.operations.length;

--- a/contracts/test/crosschain/RuleEntitlementV2.t.sol
+++ b/contracts/test/crosschain/RuleEntitlementV2.t.sol
@@ -88,12 +88,11 @@ contract RuleEntitlementV2Test is RuleEntitlementTest {
   function test_setRuleEntitlement_revertOnZeroLengthRuleData() public {
     test_upgradeToRuleV2();
 
-    RuleDataV2 memory ruleDataV2;
-
     vm.expectRevert(abi.encodeWithSelector(Entitlement__InvalidValue.selector));
 
     vm.prank(space);
 
+    RuleDataV2 memory ruleDataV2;
     ruleEntitlementV2.setEntitlement(roleId, abi.encode(ruleDataV2));
   }
 

--- a/contracts/test/crosschain/RuleEntitlementV2.t.sol
+++ b/contracts/test/crosschain/RuleEntitlementV2.t.sol
@@ -78,7 +78,7 @@ contract RuleEntitlementV2Test is RuleEntitlementTest {
   function test_setRuleEntitlement_revertOnEmptyRuleData() public {
     test_upgradeToRuleV2();
 
-    vm.expectRevert(abi.encodeWithSelector(Entitlement__InvalidValue.selector));
+    vm.expectRevert(Entitlement__InvalidValue.selector);
 
     vm.prank(space);
 
@@ -88,7 +88,7 @@ contract RuleEntitlementV2Test is RuleEntitlementTest {
   function test_setRuleEntitlement_revertOnZeroLengthRuleData() public {
     test_upgradeToRuleV2();
 
-    vm.expectRevert(abi.encodeWithSelector(Entitlement__InvalidValue.selector));
+    vm.expectRevert(Entitlement__InvalidValue.selector);
 
     vm.prank(space);
 

--- a/contracts/test/crosschain/RuleEntitlementV2.t.sol
+++ b/contracts/test/crosschain/RuleEntitlementV2.t.sol
@@ -75,6 +75,19 @@ contract RuleEntitlementV2Test is RuleEntitlementTest {
     assertEq(vm.getMappingLength(entitlement, bytes32(ENTITLEMENTS_SLOT)), 0);
   }
 
+  function test_setRuleEntitlement_revertOnEmptyRuleData() public {
+    test_upgradeToRuleV2();
+
+    RuleDataV2 memory ruleDataV2 = ruleEntitlementV2.getRuleDataV2(roleId);
+    assertTrue(ruleDataV2.operations.length == 0);
+
+    vm.expectRevert(abi.encodeWithSelector(Entitlement__InvalidValue.selector));
+
+    vm.prank(space);
+
+    ruleEntitlementV2.setEntitlement(roleId, "");
+  }
+
   function test_removeRuleEntitlement() external override {
     test_setRuleEntitlement();
 

--- a/contracts/test/crosschain/RuleEntitlementV2.t.sol
+++ b/contracts/test/crosschain/RuleEntitlementV2.t.sol
@@ -89,7 +89,6 @@ contract RuleEntitlementV2Test is RuleEntitlementTest {
     test_upgradeToRuleV2();
 
     RuleDataV2 memory ruleDataV2;
-    assertTrue(ruleDataV2.operations.length == 0);
 
     vm.expectRevert(abi.encodeWithSelector(Entitlement__InvalidValue.selector));
 

--- a/contracts/test/crosschain/RuleEntitlementV2.t.sol
+++ b/contracts/test/crosschain/RuleEntitlementV2.t.sol
@@ -78,14 +78,24 @@ contract RuleEntitlementV2Test is RuleEntitlementTest {
   function test_setRuleEntitlement_revertOnEmptyRuleData() public {
     test_upgradeToRuleV2();
 
-    RuleDataV2 memory ruleDataV2 = ruleEntitlementV2.getRuleDataV2(roleId);
+    vm.expectRevert(abi.encodeWithSelector(Entitlement__InvalidValue.selector));
+
+    vm.prank(space);
+
+    ruleEntitlementV2.setEntitlement(roleId, "");
+  }
+
+  function test_setRuleEntitlement_revertOnZeroLengthRuleData() public {
+    test_upgradeToRuleV2();
+
+    RuleDataV2 memory ruleDataV2;
     assertTrue(ruleDataV2.operations.length == 0);
 
     vm.expectRevert(abi.encodeWithSelector(Entitlement__InvalidValue.selector));
 
     vm.prank(space);
 
-    ruleEntitlementV2.setEntitlement(roleId, "");
+    ruleEntitlementV2.setEntitlement(roleId, abi.encode(ruleDataV2));
   }
 
   function test_removeRuleEntitlement() external override {

--- a/packages/sdk/src/updateRole.test.ts
+++ b/packages/sdk/src/updateRole.test.ts
@@ -1,0 +1,32 @@
+/**
+ * @group with-v2-entitlements
+ */
+
+import { createTownWithRequirements, updateRole } from './util.test'
+import { NoopRuleData, UpdateRoleParams, Permission, EVERYONE_ADDRESS } from '@river-build/web3'
+
+describe('updateRole', () => {
+    test('user-gated space created with no-op ruleData allows updates on minter role', async () => {
+        const { bobSpaceDapp, bobProvider, spaceId } = await createTownWithRequirements({
+            everyone: false,
+            users: ['alice'],
+            ruleData: NoopRuleData,
+        })
+
+        // Update role to be ungated
+        const { error } = await updateRole(
+            bobSpaceDapp,
+            bobProvider,
+            {
+                spaceNetworkId: spaceId,
+                roleId: 1, // Minter role id
+                roleName: 'Updated minter role',
+                permissions: [Permission.JoinSpace],
+                users: [EVERYONE_ADDRESS],
+                ruleData: NoopRuleData,
+            } as UpdateRoleParams,
+            bobProvider.signer,
+        )
+        expect(error).toBeUndefined()
+    })
+})

--- a/packages/web3/src/entitlement.ts
+++ b/packages/web3/src/entitlement.ts
@@ -289,6 +289,11 @@ export function decodeRuleData(entitlementData: Hex): IRuleEntitlementBase.RuleD
 }
 
 export function encodeRuleDataV2(ruleData: IRuleEntitlementV2Base.RuleDataV2Struct): Hex {
+    // If we encounter a no-op rule data, just encode as empty bytes.
+    if (ruleData.operations.length === 0) {
+        return '0x'
+    }
+
     const getRuleDataV2Abi: ExtractAbiFunction<typeof IRuleEntitlementV2Abi, 'getRuleDataV2'> =
         getAbiItem({
             abi: IRuleEntitlementV2Abi,


### PR DESCRIPTION
Previously setEntitlement RuleEntitlementV2 ignored empty rule datas, but this created a bit of confusion with createSpace when the architect assumed a rule data was set when creating the minter role.

Here we update the contract to just always revert when setEntitlement doesn't actually set an entitlement as an extra guard to avoid creating spaces with an invalid view of entitlements on the minter role.