### PR TITLE
stream-metadata: add logs when stream view is not space content

### DIFF
--- a/packages/sdk/src/streamStateView_Space.ts
+++ b/packages/sdk/src/streamStateView_Space.ts
@@ -157,9 +157,7 @@ export class StreamStateView_Space extends StreamStateView_AbstractContent {
         return this.spaceImage
     }
 
-    private async decryptSpaceImage(
-        encryptedData: EncryptedData,
-    ): Promise<ChunkedMedia | undefined> {
+    private async decryptSpaceImage(encryptedData: EncryptedData): Promise<ChunkedMedia> {
         try {
             const spaceAddress = contractAddressFromSpaceId(this.streamId)
             const context = spaceAddress.toLowerCase()

--- a/packages/stream-metadata/src/routes/spaceImage.ts
+++ b/packages/stream-metadata/src/routes/spaceImage.ts
@@ -1,4 +1,4 @@
-import { FastifyReply, FastifyRequest } from 'fastify'
+import { FastifyReply, FastifyRequest, type FastifyBaseLogger } from 'fastify'
 import { ChunkedMedia } from '@river-build/proto'
 import { StreamPrefix, StreamStateView, makeStreamId } from '@river-build/sdk'
 import { z } from 'zod'
@@ -59,7 +59,7 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 	}
 
 	// get the image metatdata from the stream
-	const spaceImage = await getSpaceImage(stream)
+	const spaceImage = await getSpaceImage(logger, stream)
 	if (!spaceImage) {
 		logger.error({ spaceAddress, streamId: stream.streamId }, 'spaceImage not found')
 		return reply
@@ -107,9 +107,11 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 }
 
 export async function getSpaceImage(
+	logger: FastifyBaseLogger,
 	streamView: StreamStateView,
 ): Promise<ChunkedMedia | undefined> {
 	if (streamView.contentKind !== 'spaceContent') {
+		logger.error({ streamView }, 'stream view is not a space content')
 		return undefined
 	}
 	return streamView.spaceContent.getSpaceImage()


### PR DESCRIPTION
We're seeing a lot of spaceImage failures, adding this to add more context to help investigation