### PR TITLE
fix(contract): remove token delegation threshold and fix lock

### DIFF
--- a/contracts/src/diamond/facets/governance/votes/enumerable/VotesEnumerable.sol
+++ b/contracts/src/diamond/facets/governance/votes/enumerable/VotesEnumerable.sol
@@ -36,12 +36,18 @@ abstract contract VotesEnumerable is IVotesEnumerable {
   ) internal virtual {
     VotesEnumerableStorage.Layout storage ds = VotesEnumerableStorage.layout();
 
-    ds.delegators.remove(account);
-    ds.delegatorsByDelegatee[currentDelegatee].remove(account);
-
-    // if the delegatee is not address(0) then add the account and is not already a delegator then add it
-    if (newDelegatee != address(0)) {
+    // if the current delegatee is address(0) then add the account
+    if (currentDelegatee == address(0)) {
       ds.delegators.add(account);
+    } else {
+      ds.delegatorsByDelegatee[currentDelegatee].remove(account);
+    }
+
+    if (newDelegatee == address(0)) {
+      ds.delegators.remove(account);
+      ds.delegationTimeForDelegator[account] = 0;
+    } else {
+      // if the new delegatee is not address(0) then add the account
       ds.delegatorsByDelegatee[newDelegatee].add(account);
       ds.delegationTimeForDelegator[account] = block.timestamp;
     }

--- a/contracts/src/tokens/lock/ILock.sol
+++ b/contracts/src/tokens/lock/ILock.sol
@@ -8,8 +8,6 @@ pragma solidity ^0.8.23;
 // contracts
 
 interface ILockBase {
-  error LockAlreadyEnabled();
-  error LockAlreadyDisabled();
   error LockNotAuthorized();
 
   event LockUpdated(

--- a/contracts/src/tokens/lock/ILock.sol
+++ b/contracts/src/tokens/lock/ILock.sol
@@ -15,8 +15,7 @@ interface ILockBase {
   event LockUpdated(
     address indexed caller,
     bool indexed enabled,
-    uint256 cooldown,
-    uint256 timestamp
+    uint256 cooldown
   );
 }
 

--- a/contracts/src/tokens/lock/ILock.sol
+++ b/contracts/src/tokens/lock/ILock.sol
@@ -8,6 +8,8 @@ pragma solidity ^0.8.23;
 // contracts
 
 interface ILockBase {
+  error LockAlreadyEnabled();
+  error LockAlreadyDisabled();
   error LockNotAuthorized();
 
   event LockUpdated(

--- a/contracts/src/tokens/lock/LockBase.sol
+++ b/contracts/src/tokens/lock/LockBase.sol
@@ -24,10 +24,6 @@ abstract contract LockBase is ILockBase {
   function _enableLock(address caller) internal {
     LockStorage.Layout storage ds = LockStorage.layout();
 
-    if (ds.enabledByAddress[caller]) {
-      revert LockAlreadyEnabled();
-    }
-
     ds.enabledByAddress[caller] = true;
 
     emit LockUpdated(caller, true, 0, block.timestamp);
@@ -35,10 +31,6 @@ abstract contract LockBase is ILockBase {
 
   function _disableLock(address caller) internal {
     LockStorage.Layout storage ds = LockStorage.layout();
-
-    if (ds.enabledByAddress[caller] == false) {
-      revert LockAlreadyDisabled();
-    }
 
     ds.enabledByAddress[caller] = false;
     ds.cooldownByAddress[caller] = block.timestamp + ds.defaultCooldown;

--- a/contracts/src/tokens/lock/LockBase.sol
+++ b/contracts/src/tokens/lock/LockBase.sol
@@ -30,7 +30,7 @@ abstract contract LockBase is ILockBase {
 
     ds.enabledByAddress[caller] = true;
 
-    emit LockUpdated(caller, true, 0, block.timestamp);
+    emit LockUpdated(caller, true, 0);
   }
 
   function _disableLock(address caller) internal {
@@ -43,7 +43,7 @@ abstract contract LockBase is ILockBase {
     ds.enabledByAddress[caller] = false;
     ds.cooldownByAddress[caller] = cooldown;
 
-    emit LockUpdated(caller, false, cooldown, block.timestamp);
+    emit LockUpdated(caller, false, cooldown);
   }
 
   function _lockCooldown(address caller) internal view returns (uint256) {

--- a/contracts/src/tokens/river/base/River.sol
+++ b/contracts/src/tokens/river/base/River.sol
@@ -208,7 +208,7 @@ contract River is
     if (delegatee == address(0)) {
       _disableLock(account);
     } else {
-      if (!_lockEnabled(account)) _enableLock(account);
+      _enableLock(account);
     }
 
     super._delegate(account, delegatee);

--- a/contracts/src/tokens/river/base/River.sol
+++ b/contracts/src/tokens/river/base/River.sol
@@ -199,8 +199,10 @@ contract River is
   }
 
   function _delegate(address account, address delegatee) internal override {
+    address currentDelegatee = delegates(account);
+
     // revert if the delegatee is the same as the current delegatee
-    if (delegates(account) == delegatee) revert River__DelegateeSameAsCurrent();
+    if (currentDelegatee == delegatee) revert River__DelegateeSameAsCurrent();
 
     // if the delegatee is the zero address, initialize disable lock
     if (delegatee == address(0)) {
@@ -209,7 +211,6 @@ contract River is
       if (!_lockEnabled(account)) _enableLock(account);
     }
 
-    address currentDelegatee = delegates(account);
     super._delegate(account, delegatee);
 
     _setDelegators(account, delegatee, currentDelegatee);

--- a/contracts/src/tokens/river/base/River.sol
+++ b/contracts/src/tokens/river/base/River.sol
@@ -42,7 +42,6 @@ contract River is
   // =============================================================
   error River__TransferLockEnabled();
   error River__DelegateeSameAsCurrent();
-  error River__InvalidTokenAmount();
 
   // =============================================================
   //                           Events
@@ -61,11 +60,6 @@ contract River is
 
   /// @notice Address of the StandardBridge on this network.
   address public immutable BRIDGE;
-
-  // =============================================================
-  //                           Variables
-  // =============================================================
-  uint256 public MIN_TOKEN_THRESHOLD = 10 ether;
 
   // =============================================================
   //                           Modifiers
@@ -203,15 +197,6 @@ contract River is
   }
 
   // =============================================================
-  //                           Token
-  // =============================================================
-  function setTokenThreshold(uint256 threshold) external onlyOwner {
-    if (threshold > totalSupply()) revert River__InvalidTokenAmount();
-    MIN_TOKEN_THRESHOLD = threshold;
-    emit TokenThresholdSet(threshold);
-  }
-
-  // =============================================================
   //                           Hooks
   // =============================================================
   function _update(
@@ -244,10 +229,6 @@ contract River is
   ) internal virtual override {
     // revert if the delegatee is the same as the current delegatee
     if (delegates(account) == delegatee) revert River__DelegateeSameAsCurrent();
-
-    // revert if the balance is below the threshold
-    if (balanceOf(account) < MIN_TOKEN_THRESHOLD)
-      revert River__InvalidTokenAmount();
 
     // if the delegatee is the zero address, initialize disable lock
     if (delegatee == address(0)) {

--- a/contracts/src/tokens/river/mainnet/River.sol
+++ b/contracts/src/tokens/river/mainnet/River.sol
@@ -130,7 +130,7 @@ contract River is
     uint256 value
   ) internal virtual override(ERC20, ERC20Votes) {
     if (from != address(0) && _lockEnabled(from)) {
-      // allow transfering at minting time
+      // allow transferring at minting time
       revert River__TransferLockEnabled();
     }
     super._update(from, to, value);
@@ -170,7 +170,7 @@ contract River is
   /// @dev Do not allow disabling lock without delegating
   function disableLock(address account) external override onlyAllowed {}
 
-  /// @notice Clock used for flagging checkpoints, overriden to implement timestamp based
+  /// @notice Clock used for flagging checkpoints, overridden to implement timestamp based
   /// checkpoints (and voting).
   function clock() public view override returns (uint48) {
     return uint48(block.timestamp);

--- a/contracts/test/river/token/base/RiverBase.t.sol
+++ b/contracts/test/river/token/base/RiverBase.t.sol
@@ -22,12 +22,10 @@ contract RiverBaseTest is BaseSetup, ILockBase, IOwnableBase {
     0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
 
   River riverFacet;
-  uint256 stakeRequirement;
 
   function setUp() public override {
     super.setUp();
     riverFacet = River(riverToken);
-    stakeRequirement = riverFacet.MIN_TOKEN_THRESHOLD();
   }
 
   function test_init() external view {
@@ -41,7 +39,7 @@ contract RiverBaseTest is BaseSetup, ILockBase, IOwnableBase {
 
   modifier givenCallerHasBridgedTokens(address caller, uint256 amount) {
     vm.assume(caller != address(0));
-    amount = bound(amount, stakeRequirement, type(uint208).max);
+    amount = bound(amount, 0, type(uint208).max);
 
     vm.prank(bridge);
     riverFacet.mint(caller, amount);
@@ -215,8 +213,8 @@ contract RiverBaseTest is BaseSetup, ILockBase, IOwnableBase {
     vm.assume(alice != address(0));
     vm.assume(bob != address(0));
 
-    amountA = bound(amountA, 1, type(uint208).max - stakeRequirement);
-    amountB = bound(amountB, stakeRequirement, type(uint208).max - amountA);
+    amountA = bound(amountA, 1, type(uint208).max - 1);
+    amountB = bound(amountB, 1, type(uint208).max - amountA);
 
     vm.prank(bridge);
     riverFacet.mint(alice, amountA);


### PR DESCRIPTION
Eliminated the token threshold mechanism from the `River` contract, including the removal of the `MIN_TOKEN_THRESHOLD` variable and the `setTokenThreshold` function. Updated related tests to reflect these changes, ensuring consistent functionality throughout the contract.

Replaced `IntrospectionBase` and `LockBase` with `IntrospectionFacet` and `LockFacet` for better modularization. Removed redundant lock methods and corrected minor typos in comments for improved code clarity and maintainability.

Update logic in `_setDelegators` to handle edge cases for delegate assignment more efficiently. Simplify `River._delegate` by reusing the current delegate storage.

Fix delegation lock and add tests.