### PR TITLE
changing stream metadata service start message

### DIFF
--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -41,7 +41,7 @@ logger.info(
 		cloudfront: config.cloudfront,
 		openSea: config.openSea ? { ...config.openSea, apiKey: '***' } : undefined,
 	},
-	'config',
+	'starting server',
 )
 
 /*


### PR DESCRIPTION
the dashboard refers to the "config" message to determine when the server started. but it appears we have other logs that contain the word "config", which makes it look like the same server is booting multiple times. this PR will allow us to precisely see when a server started