### PR TITLE
test(contract): fix initialization of `RuleDataV2` operations array

### DIFF
--- a/contracts/test/crosschain/RuleEntitlementUtil.sol
+++ b/contracts/test/crosschain/RuleEntitlementUtil.sol
@@ -29,17 +29,17 @@ library RuleEntitlementUtil {
     returns (IRuleEntitlementBase.RuleDataV2 memory data)
   {
     data = IRuleEntitlementBase.RuleDataV2({
-      operations: new IRuleEntitlementBase.Operation[](0),
+      operations: new IRuleEntitlementBase.Operation[](1),
       checkOperations: new IRuleEntitlementBase.CheckOperationV2[](0),
       logicalOperations: new IRuleEntitlementBase.LogicalOperation[](0)
     });
-    // IRuleEntitlementBase.Operation memory noop = IRuleEntitlementBase
-    //   .Operation({
-    //     opType: IRuleEntitlementBase.CombinedOperationType.NONE,
-    //     index: 0
-    //   });
+    IRuleEntitlementBase.Operation memory noop = IRuleEntitlementBase
+      .Operation({
+        opType: IRuleEntitlementBase.CombinedOperationType.NONE,
+        index: 0
+      });
 
-    // data.operations[0] = noop;
+    data.operations[0] = noop;
   }
 
   function getMockERC721RuleData()


### PR DESCRIPTION
Initialize the operations array with size 1 instead of 0. Add a no-op entry to the operations array to ensure it is correctly populated. This addresses potential issues with operations array being empty.