### PR TITLE
Reduce overhead of cache of spaces in SpaceRegistrar

### DIFF
--- a/packages/encryption/src/groupEncryption.ts
+++ b/packages/encryption/src/groupEncryption.ts
@@ -42,6 +42,15 @@ export class GroupEncryption extends EncryptionAlgorithm {
 
             if (opts?.awaitInitialShareSession === true) {
                 await promise
+            } else {
+                // await the promise but timeout after 15 seconds
+                const waitTimeBeforeMovingOn = 30000
+                await Promise.race([
+                    promise,
+                    new Promise<void>((resolve, _) =>
+                        setTimeout(() => resolve(), waitTimeBeforeMovingOn),
+                    ),
+                ])
             }
         }
     }


### PR DESCRIPTION
we don't really need to cache spaces, but they instantiate a lot of objects for the contracts and it's worth not wasting memory if we need to access the same space multiple times this code is also used on the server so we don't want to cache spaces for too long