### PR TITLE
cli tool for fetching stream metadata from river registry

### DIFF
--- a/core/cmd/get_stream.go
+++ b/core/cmd/get_stream.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/river-build/river/core/config"
+	"github.com/river-build/river/core/node/crypto"
+	"github.com/river-build/river/core/node/registries"
+	"github.com/river-build/river/core/node/shared"
+)
+
+func listRegisteredStream(ctx context.Context, cfg config.Config, streamId shared.StreamId) error {
+	riverChain, err := crypto.NewBlockchain(ctx, &cfg.RiverChain, nil, nil, nil)
+	if err != nil {
+		return fmt.Errorf("error initialzing river blockchain: %w", err)
+	}
+
+	riverRegistryContract, err := registries.NewRiverRegistryContract(ctx, riverChain, &cfg.RegistryContract)
+	if err != nil {
+		return fmt.Errorf("unable to instanstiate river registry contract: %w", err)
+	}
+
+	streamResult, err := riverRegistryContract.GetStream(ctx, streamId)
+	if err != nil {
+		return fmt.Errorf("error fetching stream with genesis: %w", err)
+	}
+
+	var d []byte
+	if d, err = yaml.Marshal(streamResult); err != nil {
+		return fmt.Errorf("unable to marshal stream result: %w", err)
+	}
+	fmt.Printf("River chain stream result for stream id (%v): \n%s\n\n", streamId, string(d))
+
+	return nil
+}
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "get_registered_stream <streamId>",
+		Short: "List stream contents for a stream",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			streamId, err := shared.StreamIdFromString(args[0])
+			if err != nil {
+				return fmt.Errorf("could not parse stream id from arguments: %w", err)
+			}
+			return listRegisteredStream(cmd.Context(), *cmdConfig, streamId)
+		},
+	}
+
+	rootCmd.AddCommand(cmd)
+}


### PR DESCRIPTION
```

./env/omega/run.sh get_registered_stream 103399d29c8d0dec2f271422db2a44e40567555ccc0000000000000000000000
Error: error fetching stream with genesis: GetStream: (5:NOT_FOUND) Contract Returned Error | Call failed base_error: execution reverted: NOT_FOUND
    revert_reason = NOT_FOUND
exit status 1


❯ ./env/omega/run.sh get_registered_stream 20c87bb04477151743070b45a3426938128896ac5d1f3e3670036e5d987fd615
River chain stream result for stream id (20c87bb04477151743070b45a3426938128896ac5d1f3e3670036e5d987fd615): 
streamid:
    - 32
    - 200
    - 123
    - 176
    - 68
    - 119
    - 21
    - 23
    - 67
    - 7
    - 11
    - 69
    - 163
    - 66
    - 105
    - 56
    - 18
    - 136
    - 150
    - 172
    - 93
    - 31
    - 62
    - 54
    - 112
    - 3
    - 110
    - 93
    - 152
    - 127
    - 214
    - 21
nodes:
    - 0x122ba69b3fdce8b6cb18c0ed163744b17400c2cb
lastminiblockhash: 0x01dcadc39bea599166277c02bd0a1160a753e3b7c19bd4e004b74b086d2c1a74
lastminiblocknum: 2355
issealed: false
```