### PR TITLE
adding more request details to the stream metadata logger

### DIFF
--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -3,7 +3,7 @@ import './tracer' // must come before importing any instrumented module.
 import { Server as HTTPServer, IncomingMessage, ServerResponse } from 'http'
 import { Server as HTTPSServer } from 'https'
 
-import Fastify, { FastifyInstance } from 'fastify'
+import Fastify, { FastifyInstance, FastifyRequest } from 'fastify'
 import cors from '@fastify/cors'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -60,8 +60,15 @@ const server = Fastify({
 })
 
 server.addHook('onRequest', (request, reply, done) => {
-	const reqId = request.id // Use Fastify's generated reqId, which is now a UUID
-	request.log = request.log.child({ reqId })
+	request.log = request.log.child({
+		request: {
+			id: request.id,
+			url: request.url,
+			query: request.query,
+			params: request.params,
+			routerPath: request.routerPath,
+		},
+	})
 	done()
 })
 

--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -3,7 +3,7 @@ import './tracer' // must come before importing any instrumented module.
 import { Server as HTTPServer, IncomingMessage, ServerResponse } from 'http'
 import { Server as HTTPSServer } from 'https'
 
-import Fastify, { FastifyInstance, FastifyRequest } from 'fastify'
+import Fastify, { FastifyInstance } from 'fastify'
 import cors from '@fastify/cors'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -118,6 +118,7 @@ export function getServerUrl(srv: Server) {
 
 process.on('SIGTERM', async () => {
 	try {
+		logger.warn('Received SIGTERM, shutting down server')
 		await server.close()
 		logger.info('Server closed gracefully')
 		process.exit(0)


### PR DESCRIPTION
This PR will allow us to run aggregate o11y queries based on request parameters. For example:

- What specific urls resulted in a specific error log
- What's the distribution of requests with respect to route, where an error was logged (and even narrow down based on a specific space id)
- What's the distribution of requests with respect to route, where a `Missing Cache-Control header` warning was logged? (so that we can detect them proactively)