### PR TITLE
custom logging logic for stream metadata service

### DIFF
--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -47,21 +47,16 @@ logger.info(
 /*
  * Server setup
  */
-export type Server = FastifyInstance<
-	HTTPServer | HTTPSServer,
-	IncomingMessage,
-	ServerResponse,
-	typeof logger
->
+export type Server = FastifyInstance<HTTPServer | HTTPSServer, IncomingMessage, ServerResponse>
 
 const server = Fastify({
-	logger,
+	logger: false,
 	genReqId: () => uuidv4(),
 })
 
 server.addHook('onRequest', (request, reply, done) => {
-	request.log = request.log.child({
-		request: {
+	request.log = logger.child({
+		req: {
 			id: request.id,
 			url: request.url,
 			query: request.query,
@@ -69,6 +64,23 @@ server.addHook('onRequest', (request, reply, done) => {
 			routerPath: request.routerPath,
 		},
 	})
+
+	request.log.info('incoming request')
+
+	done()
+})
+
+server.addHook('onResponse', (request, reply, done) => {
+	request.log.info(
+		{
+			res: {
+				statusCode: reply.statusCode,
+				elapsedTime: reply.elapsedTime,
+			},
+		},
+		'request completed',
+	)
+
 	done()
 })
 

--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -62,6 +62,7 @@ server.addHook('onRequest', (request, reply, done) => {
 			query: request.query,
 			params: request.params,
 			routerPath: request.routerPath,
+			method: request.method,
 		},
 	})
 


### PR DESCRIPTION
fastify's default logging reports status codes of responses, without showing anything about the original request. this PR removes the default logger and replaces it with one that standardizes everything