### PR TITLE
adding cache-control headers to response logs in stream metadata

### DIFF
--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -77,6 +77,9 @@ server.addHook('onResponse', (request, reply, done) => {
 			res: {
 				statusCode: reply.statusCode,
 				elapsedTime: reply.elapsedTime,
+				headers: {
+					'cache-control': reply.getHeader('cache-control'),
+				},
 			},
 		},
 		'request completed',

--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -63,6 +63,8 @@ server.addHook('onRequest', (request, reply, done) => {
 			params: request.params,
 			routerPath: request.routerPath,
 			method: request.method,
+			ip: request.ip,
+			ips: request.ips,
 		},
 	})
 


### PR DESCRIPTION
we're seeing multiple requests hitting the same `/media` endpoint, which should never happen. and there are a few other routes that are supposed to be cached and should not make it to the server, but we're still seeing them. i'm adding cache-control headers to the logger just to see if there's a pattern