### PR TITLE
Add configuration for transaction isolation levels

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -202,10 +202,10 @@ type DatabaseConfig struct {
 	// If set to 0, then default value is used. To disable the delay set to 1ms or less.
 	StartupDelay time.Duration
 
-	// IsolationLevel is the transaction isolation level to use for the database oprations.
+	// IsolationLevel is the transaction isolation level to use for the database operations.
 	// Allowed values: "serializable", "repeatable read", "read committed".
 	// If not set or value can't be parsed, defaults to "serializable".
-	// Interntion is to migrate to "read committed" for performance reasons after testing is complete.
+	// Intention is to migrate to "read committed" for performance reasons after testing is complete.
 	IsolationLevel string
 }
 

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -201,6 +201,12 @@ type DatabaseConfig struct {
 	// If StandByOnStart is true, it's recommended to set it to the double of Config.ShutdownTimeout.
 	// If set to 0, then default value is used. To disable the delay set to 1ms or less.
 	StartupDelay time.Duration
+
+	// IsolationLevel is the transaction isolation level to use for the database oprations.
+	// Allowed values: "serializable", "repeatable read", "read committed".
+	// If not set or value can't be parsed, defaults to "serializable".
+	// Interntion is to migrate to "read committed" for performance reasons after testing is complete.
+	IsolationLevel string
 }
 
 func (c DatabaseConfig) GetUrl() string {

--- a/core/config/testdata/databaseconfig_json.txt
+++ b/core/config/testdata/databaseconfig_json.txt
@@ -1,1 +1,1 @@
-{"time":"[TIMESTAMP]","level":"INFO","msg":"test message","databaseConfig":{"Host":"localhost","Port":5432,"User":"user","Database":"testdb","Extra":"extra","StreamingConnectionsRatio":0,"StartupDelay":0}}
+{"time":"[TIMESTAMP]","level":"INFO","msg":"test message","databaseConfig":{"Host":"localhost","Port":5432,"User":"user","Database":"testdb","Extra":"extra","StreamingConnectionsRatio":0,"StartupDelay":0,"IsolationLevel":""}}

--- a/core/env/local/common/common.yaml
+++ b/core/env/local/common/common.yaml
@@ -2,6 +2,7 @@
 
 database:
     url: postgres://postgres:postgres@localhost:5433/river?sslmode=disable&pool_max_conns=1000
+    isolationLevel: 'read committed'
 
 # Certificates for TLS
 TLSConfig:

--- a/core/node/storage/pg_storage.go
+++ b/core/node/storage/pg_storage.go
@@ -44,6 +44,8 @@ type PostgresEventStore struct {
 
 	txCounter  *infra.StatusCounterVec
 	txDuration *prometheus.HistogramVec
+
+	isolationLevel pgx.TxIsoLevel
 }
 
 // var _ StreamStorage = (*PostgresEventStore)(nil)
@@ -131,7 +133,7 @@ func (s *PostgresEventStore) txRunnerInner(
 	}
 	defer release()
 
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable, AccessMode: accessMode})
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: s.isolationLevel, AccessMode: accessMode})
 	if err != nil {
 		return err
 	}
@@ -573,6 +575,21 @@ func (s *PostgresEventStore) init(
 		infra.DefaultDurationBucketsSeconds,
 		"name",
 	)
+
+	switch strings.ToLower(poolInfo.Config.IsolationLevel) {
+	case "serializable":
+		s.isolationLevel = pgx.Serializable
+	case "repeatable read", "repeatable_read", "repeatableread":
+		s.isolationLevel = pgx.RepeatableRead
+	case "read committed", "read_committed", "readcommitted":
+		s.isolationLevel = pgx.ReadCommitted
+	default:
+		s.isolationLevel = pgx.Serializable
+	}
+
+	if s.isolationLevel != pgx.Serializable {
+		log.Info("PostgresEventStore: using isolation level", "level", s.isolationLevel)
+	}
 
 	err := s.InitStorage(ctx)
 	if err != nil {


### PR DESCRIPTION
Can be set with "RIVER_DATABASE_ISOLATIONLEVEL" env var.

Allowed values: "serializable", "repeatable read", "read committed".
If not set or value can't be parsed, defaults to "serializable".
Intention is to migrate to "read committed" for performance reasons after testing is complete.