### PR TITLE
Kerem/stream metadata worker prep

### DIFF
--- a/.github/workflows/Stream_metadata_docker.yml
+++ b/.github/workflows/Stream_metadata_docker.yml
@@ -8,6 +8,12 @@ on:
             - 'packages/stream-metadata/**'
             - 'packages/**'
     workflow_dispatch:
+        inputs:
+            is_latest: # This is a boolean input
+                description: 'Add docker:latest tag'
+                required: true
+                default: false
+                type: boolean
 
 env:
     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CD_WORKFLOW_WEBHOOK_URL }}
@@ -45,6 +51,7 @@ jobs:
                   #This can be custom alias once requested to aws and approved for public repo
                   REGISTRY_ALIAS: h5v6m2x1
                   ECR_REPOSITORY: river-stream-metadata
+                  IS_LATEST_OR_PUSH: ${{ github.event_name == 'push' || github.event.inputs.is_latest }}
               run: |
                   docker build \
                     --build-arg GIT_SHA=${{ github.sha }} \
@@ -53,7 +60,13 @@ jobs:
                     -t $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:${{ github.sha }} \
                     .
 
-                  docker push $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+                  if [ $IS_LATEST_OR_PUSH == true ]; then
+                      echo "Pushing docker image with latest tag"
+                      docker push $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+                  else
+                      echo "Not pushing docker image with latest tag"
+                  fi
+
                   docker push $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:${{ github.sha }}
 
             # If action failed, we send a slack notification

--- a/packages/stream-metadata/src/environment.ts
+++ b/packages/stream-metadata/src/environment.ts
@@ -15,7 +15,7 @@ const BoolFromStringSchema = BoolStringSchema.transform((str) => str === 'true')
 
 const envMainSchema = z.object({
 	RIVER_ENV: z.string(),
-	ENVIRONMENT: z.string().optional(),
+	ENVIRONMENT: z.string(),
 	RIVER_CHAIN_RPC_URL: z.string().url(),
 	BASE_CHAIN_RPC_URL: z.string().url(),
 	RIVER_STREAM_METADATA_BASE_URL: z.string().url(),
@@ -74,7 +74,7 @@ function makeConfig() {
 		apm: {
 			tracingEnabled: envMain.TRACING_ENABLED,
 			profilingEnabled: envMain.PROFILING_ENABLED,
-			environment: envMain.ENVIRONMENT ?? envMain.RIVER_ENV,
+			environment: envMain.ENVIRONMENT,
 		},
 		healthCheck: {
 			timeout: 5000, // 5 seconds

--- a/packages/stream-metadata/src/environment.ts
+++ b/packages/stream-metadata/src/environment.ts
@@ -15,6 +15,7 @@ const BoolFromStringSchema = BoolStringSchema.transform((str) => str === 'true')
 
 const envMainSchema = z.object({
 	RIVER_ENV: z.string(),
+	ENVIRONMENT: z.string().optional(),
 	RIVER_CHAIN_RPC_URL: z.string().url(),
 	BASE_CHAIN_RPC_URL: z.string().url(),
 	RIVER_STREAM_METADATA_BASE_URL: z.string().url(),
@@ -73,6 +74,7 @@ function makeConfig() {
 		apm: {
 			tracingEnabled: envMain.TRACING_ENABLED,
 			profilingEnabled: envMain.PROFILING_ENABLED,
+			environment: envMain.ENVIRONMENT ?? envMain.RIVER_ENV,
 		},
 		healthCheck: {
 			timeout: 5000, // 5 seconds

--- a/packages/stream-metadata/src/tracer.ts
+++ b/packages/stream-metadata/src/tracer.ts
@@ -7,7 +7,7 @@ import { config } from './environment'
 if (config.apm.tracingEnabled) {
 	tracer.init({
 		service: 'stream-metadata',
-		env: config.riverEnv,
+		env: config.apm.environment,
 		profiling: config.apm.profilingEnabled,
 		logInjection: true,
 		version: config.version,


### PR DESCRIPTION
this pr allows us to deploy different instances of the stream metadata worker, against the same river environment, and report metrics under different names. this is ideal for testing new things, such as the incoming worker threads fix. we'll be able to test the new image against omega, under a new environment name, without impacting the omega clients.

additionally, i'm adding the ability to publish docker images without marking them as latest. this will allow us to test docker images without having them eventually picked up by the cd flows of other environments.