### PR TITLE
feat(contract): add convenience methods to `EIP712Facet`

### DIFF
--- a/contracts/scripts/deployments/facets/DeployEIP712Facet.s.sol
+++ b/contracts/scripts/deployments/facets/DeployEIP712Facet.s.sol
@@ -12,6 +12,8 @@ import {EIP712Facet} from "contracts/src/diamond/utils/cryptography/signature/EI
 
 contract DeployEIP712Facet is FacetHelper, Deployer {
   constructor() {
+    addSelector(EIP712Facet.DOMAIN_SEPARATOR.selector);
+    addSelector(EIP712Facet.nonces.selector);
     addSelector(EIP712Facet.eip712Domain.selector);
   }
 

--- a/contracts/src/diamond/utils/cryptography/signature/EIP712Facet.sol
+++ b/contracts/src/diamond/utils/cryptography/signature/EIP712Facet.sol
@@ -20,6 +20,14 @@ contract EIP712Facet is IERC5267, EIP712Base, Nonces, Facet {
     __EIP712_init_unchained(name, version);
   }
 
+  function DOMAIN_SEPARATOR() external view virtual returns (bytes32) {
+    return _domainSeparatorV4();
+  }
+
+  function nonces(address owner) external view returns (uint256) {
+    return _latestNonce(owner);
+  }
+
   /// @inheritdoc IERC5267
   function eip712Domain()
     public


### PR DESCRIPTION
Added external view functions `DOMAIN_SEPARATOR` and `nonces` to `EIP712Facet` for easier access. Updated deployment script to include new selectors in constructor.

Required for #878.