### PR TITLE
Update options to disable expensive validation during envelope parsing

### DIFF
--- a/packages/sdk/src/bob.test_util.ts
+++ b/packages/sdk/src/bob.test_util.ts
@@ -120,7 +120,7 @@ export const bobTalksToHimself = async (
     // Now there must be "channel created" event in the space stream.
     const spaceResponse = await bob.getStream({ streamId: spacedStreamId })
     const channelCreatePayload = lastEventFiltered(
-        await unpackStreamEnvelopes(spaceResponse.stream!),
+        await unpackStreamEnvelopes(spaceResponse.stream!, undefined),
         getChannelUpdatePayload,
     )
     expect(channelCreatePayload).toBeDefined()

--- a/packages/sdk/src/restart.test.ts
+++ b/packages/sdk/src/restart.test.ts
@@ -173,7 +173,7 @@ const createNewChannelAndPostHello = async (
     // Now there must be "channel created" event in the space stream.
     const spaceResponse = await bob.getStream({ streamId: spacedStreamId })
     const channelCreatePayload = lastEventFiltered(
-        await unpackStreamEnvelopes(spaceResponse.stream!),
+        await unpackStreamEnvelopes(spaceResponse.stream!, undefined),
         getChannelUpdatePayload,
     )
     expect(channelCreatePayload).toBeDefined()
@@ -225,7 +225,7 @@ const getStreamAndExpectHello = async (bob: StreamRpcClient, channelId: Uint8Arr
     expect(channel2.stream?.nextSyncCookie?.streamId).toEqual(channelId)
 
     const hello = lastEventFiltered(
-        await unpackStreamEnvelopes(channel2.stream!),
+        await unpackStreamEnvelopes(channel2.stream!, undefined),
         getMessagePayload,
     )
     expect(hello).toBeDefined()
@@ -237,7 +237,7 @@ const countStreamBlocksAndSnapshots = async (bob: StreamRpcClient, streamId: Uin
     expect(response).toBeDefined()
     expect(response.stream).toBeDefined()
     expect(response.stream?.nextSyncCookie?.streamId).toEqual(streamId)
-    const stream = await unpackStream(response.stream)
+    const stream = await unpackStream(response.stream, undefined)
     const minipoolEventNum = stream.streamAndCookie.events.length
     let totalEvents = minipoolEventNum
     const miniblocks = stream.streamAndCookie.miniblocks.length

--- a/packages/sdk/src/sign.test.ts
+++ b/packages/sdk/src/sign.test.ts
@@ -231,34 +231,34 @@ describe('sign', () => {
                 },
             }
             const event = await makeEvent(context, payload, hash)
-            expect(await unpackEnvelope(event)).toBeDefined()
+            expect(await unpackEnvelope(event, undefined)).toBeDefined()
 
             // Event with same payload from different wallet doesn't match
             const event2 = await makeEvent(context2, payload, hash)
-            expect(await unpackEnvelope(event2)).toBeDefined()
+            expect(await unpackEnvelope(event2, undefined)).toBeDefined()
             expect(event2).not.toEqual(event)
 
             await expect(async () => {
                 const e = _.cloneDeep(event)
                 e.hash = event2.hash
-                await unpackEnvelope(e)
+                await unpackEnvelope(e, undefined)
             }).rejects.toThrow()
 
             await expect(async () => {
                 const e = _.cloneDeep(event)
                 e.signature = event2.signature
-                await unpackEnvelope(e)
+                await unpackEnvelope(e, undefined)
             }).rejects.toThrow()
 
             await expect(async () => {
                 const e = _.cloneDeep(event)
                 e.event = event2.event
-                await unpackEnvelope(e)
+                await unpackEnvelope(e, undefined)
             }).rejects.toThrow()
 
             // Event with same payload from the same wallet doesn't match
             const event3 = await makeEvent(context, payload, hash)
-            expect(await unpackEnvelope(event3)).toBeDefined()
+            expect(await unpackEnvelope(event3, undefined)).toBeDefined()
             expect(event3.hash).not.toEqual(event.hash)
             expect(event3).not.toEqual(event)
         },

--- a/packages/sdk/src/sign.ts
+++ b/packages/sdk/src/sign.ts
@@ -18,6 +18,19 @@ import { ParsedEvent, ParsedMiniblock, ParsedStreamAndCookie, ParsedStreamRespon
 import { SignerContext, checkDelegateSig } from './signerContext'
 import { keccak256 } from 'ethereum-cryptography/keccak'
 
+export interface UnpackEnvelopeOpts {
+    // the client recreates the hash from the event bytes in the envelope
+    // and compares it to the hash in the envelope.
+    // if this is true, we skip the hash check
+    // this operation is cheap, but it can be useful to skip if you can trust the source of the envelope
+    disableHashValidation?: boolean
+    // the client derives the creator address from the signature in the envelope
+    // and compares it to the creator address on the event.
+    // if this is true, we skip the signature check
+    // this operation is relatively expensive, and can be evaluated later
+    disableSignatureValidation?: boolean
+}
+
 export const _impl_makeEvent_impl_ = async (
     context: SignerContext,
     payload: PlainMessage<StreamEvent>['payload'],
@@ -82,9 +95,12 @@ export const makeEvents = async (
     return events
 }
 
-export const unpackStream = async (stream?: StreamAndCookie): Promise<ParsedStreamResponse> => {
+export const unpackStream = async (
+    stream: StreamAndCookie | undefined,
+    opts: UnpackEnvelopeOpts | undefined,
+): Promise<ParsedStreamResponse> => {
     assert(stream !== undefined, 'bad stream')
-    const streamAndCookie = await unpackStreamAndCookie(stream)
+    const streamAndCookie = await unpackStreamAndCookie(stream, opts)
     assert(
         stream.miniblocks.length > 0,
         `bad stream: no blocks ${streamIdAsString(streamAndCookie.nextSyncCookie.streamId)}`,
@@ -113,7 +129,10 @@ export const unpackStream = async (stream?: StreamAndCookie): Promise<ParsedStre
     }
 }
 
-export const unpackStreamEx = async (miniblocks: Miniblock[]): Promise<ParsedStreamResponse> => {
+export const unpackStreamEx = async (
+    miniblocks: Miniblock[],
+    opts: UnpackEnvelopeOpts | undefined,
+): Promise<ParsedStreamResponse> => {
     const streamAndCookie: StreamAndCookie = new StreamAndCookie()
     streamAndCookie.events = []
     streamAndCookie.miniblocks = miniblocks
@@ -122,15 +141,16 @@ export const unpackStreamEx = async (miniblocks: Miniblock[]): Promise<ParsedStr
     // need to be non-null to avoid runtime errors when unpacking the stream into a StreamStateView,
     // which parses content by type.
     streamAndCookie.nextSyncCookie = new SyncCookie()
-    return unpackStream(streamAndCookie)
+    return unpackStream(streamAndCookie, opts)
 }
 
 export const unpackStreamAndCookie = async (
     streamAndCookie: StreamAndCookie,
+    opts: UnpackEnvelopeOpts | undefined,
 ): Promise<ParsedStreamAndCookie> => {
     assert(streamAndCookie.nextSyncCookie !== undefined, 'bad stream: no cookie')
     const miniblocks = await Promise.all(
-        streamAndCookie.miniblocks.map(async (mb) => await unpackMiniblock(mb)),
+        streamAndCookie.miniblocks.map(async (mb) => await unpackMiniblock(mb, opts)),
     )
     return {
         events: await unpackEnvelopes(streamAndCookie.events),
@@ -142,7 +162,7 @@ export const unpackStreamAndCookie = async (
 // returns all events + the header event and pointer to header content
 export const unpackMiniblock = async (
     miniblock: Miniblock,
-    opts?: { disableChecks: boolean },
+    opts: UnpackEnvelopeOpts | undefined,
 ): Promise<ParsedMiniblock> => {
     check(isDefined(miniblock.header), 'Miniblock header is not set')
     const header = await unpackEnvelope(miniblock.header, opts)
@@ -160,19 +180,23 @@ export const unpackMiniblock = async (
 
 export const unpackEnvelope = async (
     envelope: Envelope,
-    opts?: { disableChecks: boolean },
+    opts: UnpackEnvelopeOpts | undefined,
 ): Promise<ParsedEvent> => {
     check(hasElements(envelope.event), 'Event base is not set', Err.BAD_EVENT)
     check(hasElements(envelope.hash), 'Event hash is not set', Err.BAD_EVENT)
     check(hasElements(envelope.signature), 'Event signature is not set', Err.BAD_EVENT)
 
     const event = StreamEvent.fromBinary(envelope.event)
+    let hash = envelope.hash
 
-    const runChecks = opts?.disableChecks !== true
-    if (runChecks) {
-        const hash = riverHash(envelope.event)
+    const checkEventHash = opts?.disableHashValidation !== true
+    if (checkEventHash) {
+        hash = riverHash(envelope.event)
         check(bin_equal(hash, envelope.hash), 'Event id is not valid', Err.BAD_EVENT_ID)
+    }
 
+    const checkEventSignature = opts?.disableSignatureValidation !== true
+    if (checkEventSignature) {
         const recoveredPubKey = riverRecoverPubKey(hash, envelope.signature)
 
         if (!hasElements(event.delegateSig)) {
@@ -189,15 +213,6 @@ export const unpackEnvelope = async (
                 delegateSig: event.delegateSig,
                 expiryEpochMs: event.delegateExpiryEpochMs,
             })
-        }
-
-        if (event.prevMiniblockHash) {
-            // TODO replace with a proper check
-            // check(
-            //     bin_equal(e.prevEvents[0], prevEventHash),
-            //     'prevEvents[0] is not valid',
-            //     Err.BAD_PREV_EVENTS,
-            // )
         }
     }
 
@@ -219,7 +234,7 @@ export function makeParsedEvent(event: StreamEvent, hash?: Uint8Array) {
 
 export const unpackEnvelopes = async (
     event: Envelope[],
-    opts?: { disableChecks: boolean },
+    opts?: UnpackEnvelopeOpts,
 ): Promise<ParsedEvent[]> => {
     const ret: ParsedEvent[] = []
     //let prevEventHash: Uint8Array | undefined = undefined
@@ -233,15 +248,18 @@ export const unpackEnvelopes = async (
 }
 
 // First unpacks miniblocks, including header events, then unpacks events from the minipool
-export const unpackStreamEnvelopes = async (stream: StreamAndCookie): Promise<ParsedEvent[]> => {
+export const unpackStreamEnvelopes = async (
+    stream: StreamAndCookie,
+    opts: UnpackEnvelopeOpts | undefined,
+): Promise<ParsedEvent[]> => {
     const ret: ParsedEvent[] = []
 
     for (const mb of stream.miniblocks) {
-        ret.push(...(await unpackEnvelopes(mb.events)))
-        ret.push(await unpackEnvelope(mb.header!))
+        ret.push(...(await unpackEnvelopes(mb.events, opts)))
+        ret.push(await unpackEnvelope(mb.header!, opts))
     }
 
-    ret.push(...(await unpackEnvelopes(stream.events)))
+    ret.push(...(await unpackEnvelopes(stream.events, opts)))
     return ret
 }
 

--- a/packages/sdk/src/streamRpcClient.test.ts
+++ b/packages/sdk/src/streamRpcClient.test.ts
@@ -636,7 +636,7 @@ describe('streamRpcClient', () => {
         const channel = await alice.getStream({ streamId: channelId })
         let messageCount = 0
         if (!channel.stream) throw new Error('channel stream not found')
-        const envelopes = await unpackStreamEnvelopes(channel.stream)
+        const envelopes = await unpackStreamEnvelopes(channel.stream, undefined)
         envelopes.forEach((e) => {
             const p = e.event.payload
             if (p?.case === 'channelPayload' && p.value.content.case === 'message') {
@@ -1035,7 +1035,7 @@ const waitForEvent = async (
             stream?.nextSyncCookie?.streamId &&
             bin_equal(stream.nextSyncCookie.streamId, streamIdToBytes(streamId))
         ) {
-            const events = await unpackStreamEnvelopes(stream)
+            const events = await unpackStreamEnvelopes(stream, undefined)
             for (const e of events) {
                 if (matcher(e)) {
                     return stream.nextSyncCookie

--- a/packages/sdk/src/syncWithBlocks.test.ts
+++ b/packages/sdk/src/syncWithBlocks.test.ts
@@ -115,9 +115,9 @@ describe('syncWithBlocks', () => {
         expect(channel.stream?.nextSyncCookie?.streamId).toEqual(channelId)
 
         // Last event must be a genesis miniblock header.
-        const events = (await unpackStream(channel.stream)).streamAndCookie.miniblocks.flatMap(
-            (mb) => mb.events,
-        )
+        const events = (
+            await unpackStream(channel.stream, undefined)
+        ).streamAndCookie.miniblocks.flatMap((mb) => mb.events)
         const lastEvent = events.at(-1)
         const miniblockHeader = getMiniblockHeader(lastEvent)
         expect(miniblockHeader).toBeDefined()
@@ -164,7 +164,7 @@ describe('syncWithBlocks', () => {
             }
             const stream: StreamAndCookie | undefined = res.stream
             expect(stream).toBeDefined()
-            const parsed = await unpackStreamEnvelopes(res.stream)
+            const parsed = await unpackStreamEnvelopes(res.stream, undefined)
             log('===================sunk===================', { parsed })
             for (const p of parsed) {
                 if (knownHashes.has(p.hashStr)) {

--- a/packages/sdk/src/syncedStreams.test.ts
+++ b/packages/sdk/src/syncedStreams.test.ts
@@ -66,7 +66,7 @@ describe('syncStreams', () => {
                 events,
                 streamId,
             })
-            const response = await unpackStream(streamResponse.stream)
+            const response = await unpackStream(streamResponse.stream, undefined)
             return response
         }
 

--- a/packages/sdk/src/syncedStreamsLoop.ts
+++ b/packages/sdk/src/syncedStreamsLoop.ts
@@ -675,11 +675,11 @@ export class SyncedStreamsLoop {
                         this.log('sync got stream', streamId, 'NOT FOUND')
                     } else if (syncStream.syncReset) {
                         this.log('initStream from sync reset', streamId, 'RESET')
-                        const response = await unpackStream(syncStream)
+                        const response = await unpackStream(syncStream, undefined)
                         streamRecord.syncCookie = response.streamAndCookie.nextSyncCookie
                         await streamRecord.stream.initializeFromResponse(response)
                     } else {
-                        const streamAndCookie = await unpackStreamAndCookie(syncStream)
+                        const streamAndCookie = await unpackStreamAndCookie(syncStream, undefined)
                         streamRecord.syncCookie = streamAndCookie.nextSyncCookie
                         await streamRecord.stream.appendEvents(
                             streamAndCookie.events,

--- a/packages/sdk/src/util.test.ts
+++ b/packages/sdk/src/util.test.ts
@@ -826,7 +826,7 @@ export async function waitForSyncStreamsMessage(
         if (res.syncOp === SyncOp.SYNC_UPDATE) {
             const stream = res.stream
             if (stream) {
-                const env = await unpackStreamEnvelopes(stream)
+                const env = await unpackStreamEnvelopes(stream, undefined)
                 for (const e of env) {
                     if (e.event.payload.case === 'channelPayload') {
                         const p = e.event.payload.value.content

--- a/packages/sdk/src/workflows.test.ts
+++ b/packages/sdk/src/workflows.test.ts
@@ -84,7 +84,7 @@ describe('workflows', () => {
         let userResponse = await bob.getStream({ streamId: bobsUserStreamId })
         expect(userResponse.stream).toBeDefined()
         let joinPayload = lastEventFiltered(
-            await unpackStreamEnvelopes(userResponse.stream!),
+            await unpackStreamEnvelopes(userResponse.stream!, undefined),
             getUserPayload_Membership,
         )
         expect(joinPayload).toBeDefined()
@@ -119,7 +119,7 @@ describe('workflows', () => {
         userResponse = await bob.getStream({ streamId: bobsUserStreamId })
         expect(userResponse.stream).toBeDefined()
         joinPayload = lastEventFiltered(
-            await unpackStreamEnvelopes(userResponse.stream!),
+            await unpackStreamEnvelopes(userResponse.stream!, undefined),
             getUserPayload_Membership,
         )
 
@@ -131,7 +131,7 @@ describe('workflows', () => {
         const spaceResponse = await bob.getStream({ streamId: spacedStreamId })
         expect(spaceResponse.stream).toBeDefined()
         const channelCreatePayload = lastEventFiltered(
-            await unpackStreamEnvelopes(spaceResponse.stream!),
+            await unpackStreamEnvelopes(spaceResponse.stream!, undefined),
             getChannelUpdatePayload,
         )
         expect(channelCreatePayload).toBeDefined()

--- a/packages/stream-metadata/src/riverStreamRpcClient.ts
+++ b/packages/stream-metadata/src/riverStreamRpcClient.ts
@@ -1,6 +1,7 @@
 import {
 	ParsedStreamResponse,
 	StreamStateView,
+	UnpackEnvelopeOpts,
 	decryptAESGCM,
 	retryInterceptor,
 	streamIdAsBytes,
@@ -152,6 +153,7 @@ function stripHexPrefix(hexString: string): string {
 export async function getStream(
 	logger: FastifyBaseLogger,
 	streamId: string,
+	opts?: UnpackEnvelopeOpts,
 ): Promise<StreamStateView> {
 	const { client, lastMiniblockNum } = await getStreamClient(logger, `0x${streamId}`)
 	logger.info(
@@ -178,7 +180,7 @@ export async function getStream(
 			'getStream finished',
 		)
 
-		const unpackedResponse = await unpackStream(response.stream)
+		const unpackedResponse = await unpackStream(response.stream, opts)
 		return streamViewFromUnpackedResponse(streamId, unpackedResponse)
 	} catch (e) {
 		logger.error(


### PR DESCRIPTION
This pr doesn’t change behavior, just provides more flexibility when parsing streams