### PR TITLE
Add signature validation checks to decryption extensions

### DIFF
--- a/packages/encryption/src/tests/decryptionExtensions.test.ts
+++ b/packages/encryption/src/tests/decryptionExtensions.test.ts
@@ -61,6 +61,7 @@ describe('TestDecryptionExtensions', () => {
             fallbackKey: aliceDex.userDevice.fallbackKey,
             isNewDevice: true,
             sessionIds: [sessionId],
+            srcEventId: '',
         }
         const keySolicitation = aliceClient.sendKeySolicitation(keySolicitationData)
         // pretend bob receives a key solicitation request from alice, and starts processing it.
@@ -284,6 +285,11 @@ class MockDecryptionExtensions extends BaseDecryptionExtensions {
     public hasStream(streamId: string): boolean {
         log('canProcessStream', streamId, true)
         return this._upToDateStreams.has(streamId)
+    }
+
+    public isValidEvent(streamId: string, eventId: string): { isValid: boolean; reason?: string } {
+        log('isValidEvent', streamId, eventId)
+        return { isValid: true }
     }
 
     public decryptGroupEvent(

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -83,6 +83,7 @@ import {
     isUserId,
 } from './id'
 import {
+    checkEventSignature,
     makeEvent,
     UnpackEnvelopeOpts,
     unpackMiniblock,
@@ -192,6 +193,7 @@ export class Client
     private decryptionExtensions?: BaseDecryptionExtensions
     private syncedStreamsExtensions?: SyncedStreamsExtension
     private persistenceStore: IPersistenceStore
+    private validatedEvents: Record<string, { isValid: boolean; reason?: string }> = {}
 
     constructor(
         signerContext: SignerContext,
@@ -302,6 +304,45 @@ export class Client
         )
         this.streams.set(streamId, stream)
         return stream
+    }
+
+    isValidEvent(streamId: string, eventId: string): { isValid: boolean; reason?: string } {
+        // if we didn't disable signature validation, we can assume the event is valid
+        if (this.unpackEnvelopeOpts?.disableSignatureValidation !== true) {
+            return { isValid: true }
+        }
+        const stream = this.stream(streamId)
+        if (!stream) {
+            return { isValid: false, reason: 'stream not found' }
+        }
+        const event = stream.view.events.get(eventId)
+        if (!event) {
+            return { isValid: false, reason: 'event not found' }
+        }
+        if (!event.remoteEvent) {
+            return { isValid: false, reason: 'remote event not found' }
+        }
+        if (!event.remoteEvent.signature) {
+            return { isValid: false, reason: 'remote event signature not found' }
+        }
+        if (this.validatedEvents[eventId]) {
+            return this.validatedEvents[eventId]
+        }
+        try {
+            checkEventSignature(
+                event.remoteEvent.event,
+                event.remoteEvent.hash,
+                event.remoteEvent.signature,
+            )
+            const result = { isValid: true }
+            this.validatedEvents[eventId] = result
+            return result
+        } catch (err) {
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+            const result = { isValid: false, reason: `error: ${err}` }
+            this.validatedEvents[eventId] = result
+            return result
+        }
     }
 
     private async initUserJoinedStreams() {

--- a/packages/sdk/src/clientDecryptionExtensions.ts
+++ b/packages/sdk/src/clientDecryptionExtensions.ts
@@ -179,6 +179,10 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
         return true
     }
 
+    public isValidEvent(streamId: string, eventId: string): { isValid: boolean; reason?: string } {
+        return this.client.isValidEvent(streamId, eventId)
+    }
+
     public onDecryptionError(item: EncryptedContentItem, err: DecryptionSessionError): void {
         this.client.stream(item.streamId)?.updateDecryptedContentError(item.eventId, {
             missingSession: err.missingSession,

--- a/packages/sdk/src/sign.ts
+++ b/packages/sdk/src/sign.ts
@@ -189,34 +189,38 @@ export const unpackEnvelope = async (
     const event = StreamEvent.fromBinary(envelope.event)
     let hash = envelope.hash
 
-    const checkEventHash = opts?.disableHashValidation !== true
-    if (checkEventHash) {
+    const doCheckEventHash = opts?.disableHashValidation !== true
+    if (doCheckEventHash) {
         hash = riverHash(envelope.event)
         check(bin_equal(hash, envelope.hash), 'Event id is not valid', Err.BAD_EVENT_ID)
     }
 
-    const checkEventSignature = opts?.disableSignatureValidation !== true
-    if (checkEventSignature) {
-        const recoveredPubKey = riverRecoverPubKey(hash, envelope.signature)
-
-        if (!hasElements(event.delegateSig)) {
-            const address = publicKeyToAddress(recoveredPubKey)
-            check(
-                bin_equal(address, event.creatorAddress),
-                'Event signature is not valid',
-                Err.BAD_EVENT_SIGNATURE,
-            )
-        } else {
-            checkDelegateSig({
-                delegatePubKey: recoveredPubKey,
-                creatorAddress: event.creatorAddress,
-                delegateSig: event.delegateSig,
-                expiryEpochMs: event.delegateExpiryEpochMs,
-            })
-        }
+    const doCheckEventSignature = opts?.disableSignatureValidation !== true
+    if (doCheckEventSignature) {
+        checkEventSignature(event, hash, envelope.signature)
     }
 
     return makeParsedEvent(event, envelope.hash, envelope.signature)
+}
+
+export function checkEventSignature(event: StreamEvent, hash: Uint8Array, signature: Uint8Array) {
+    const recoveredPubKey = riverRecoverPubKey(hash, signature)
+
+    if (!hasElements(event.delegateSig)) {
+        const address = publicKeyToAddress(recoveredPubKey)
+        check(
+            bin_equal(address, event.creatorAddress),
+            'Event signature is not valid',
+            Err.BAD_EVENT_SIGNATURE,
+        )
+    } else {
+        checkDelegateSig({
+            delegatePubKey: recoveredPubKey,
+            creatorAddress: event.creatorAddress,
+            delegateSig: event.delegateSig,
+            expiryEpochMs: event.delegateExpiryEpochMs,
+        })
+    }
 }
 
 export function makeParsedEvent(

--- a/packages/sdk/src/streamStateView.ts
+++ b/packages/sdk/src/streamStateView.ts
@@ -293,7 +293,7 @@ export class StreamStateView implements IStreamStateView {
             default:
                 logNever(snapshot.content)
         }
-        this.membershipContent.applySnapshot(snapshot, cleartexts, encryptionEmitter)
+        this.membershipContent.applySnapshot(eventHash, snapshot, cleartexts, encryptionEmitter)
     }
 
     private appendStreamAndCookie(

--- a/packages/sdk/src/streamStateView_Members.ts
+++ b/packages/sdk/src/streamStateView_Members.ts
@@ -59,6 +59,7 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
 
     // initialization
     applySnapshot(
+        eventId: string,
         snapshot: Snapshot,
         cleartexts: Record<string, string> | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
@@ -80,6 +81,7 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
                             fallbackKey: s.fallbackKey,
                             isNewDevice: s.isNewDevice,
                             sessionIds: [...s.sessionIds],
+                            srcEventId: eventId,
                         } satisfies KeySolicitationContent),
                 ),
                 encryptedUsername: member.username,
@@ -208,6 +210,7 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
                     check(isDefined(stateMember), 'key solicitation from non-member')
                     this.solicitHelper.applySolicitation(
                         stateMember,
+                        event.hashStr,
                         payload.content.value,
                         encryptionEmitter,
                     )

--- a/packages/sdk/src/streamStateView_Members_Solicitations.ts
+++ b/packages/sdk/src/streamStateView_Members_Solicitations.ts
@@ -3,6 +3,7 @@ import { MemberPayload_KeyFulfillment, MemberPayload_KeySolicitation } from '@ri
 import { StreamEncryptionEvents } from './streamEvents'
 import { StreamMember } from './streamStateView_Members'
 import { removeCommon } from './utils'
+import { KeySolicitationContent } from '@river-build/encryption'
 
 export class StreamStateView_Members_Solicitations {
     constructor(readonly streamId: string) {}
@@ -26,6 +27,7 @@ export class StreamStateView_Members_Solicitations {
 
     applySolicitation(
         user: StreamMember,
+        eventId: string,
         solicitation: MemberPayload_KeySolicitation,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ): void {
@@ -37,7 +39,8 @@ export class StreamStateView_Members_Solicitations {
             fallbackKey: solicitation.fallbackKey,
             isNewDevice: solicitation.isNewDevice,
             sessionIds: solicitation.sessionIds.toSorted(),
-        }
+            srcEventId: eventId,
+        } satisfies KeySolicitationContent
         user.solicitations.push(newSolicitation)
         encryptionEmitter?.emit(
             'newKeySolicitation',
@@ -63,7 +66,8 @@ export class StreamStateView_Members_Solicitations {
             fallbackKey: prev.fallbackKey,
             isNewDevice: false,
             sessionIds: [...removeCommon(prev.sessionIds, fulfillment.sessionIds.toSorted())],
-        }
+            srcEventId: prev.srcEventId,
+        } satisfies KeySolicitationContent
         user.solicitations[index] = newEvent
         encryptionEmitter?.emit(
             'updatedKeySolicitation',

--- a/packages/sdk/src/sync-agent/river-connection/models/transactionalClient.ts
+++ b/packages/sdk/src/sync-agent/river-connection/models/transactionalClient.ts
@@ -3,6 +3,7 @@ import { Client, ClientEvents } from '../../../client'
 import { StreamRpcClient } from '../../../makeStreamRpcClient'
 import { SignerContext } from '../../../signerContext'
 import { Store } from '../../../store/store'
+import { UnpackEnvelopeOpts } from '../../../sign'
 
 export class TransactionalClient extends Client {
     store: Store
@@ -15,6 +16,7 @@ export class TransactionalClient extends Client {
         persistenceStoreName?: string,
         logNamespaceFilter?: string,
         highPriorityStreamIds?: string[],
+        unpackEnvelopeOpts?: UnpackEnvelopeOpts,
     ) {
         super(
             signerContext,
@@ -24,6 +26,7 @@ export class TransactionalClient extends Client {
             persistenceStoreName,
             logNamespaceFilter,
             highPriorityStreamIds,
+            unpackEnvelopeOpts,
         )
         this.store = store
     }

--- a/packages/sdk/src/sync-agent/river-connection/riverConnection.ts
+++ b/packages/sdk/src/sync-agent/river-connection/riverConnection.ts
@@ -19,6 +19,7 @@ import { AuthStatus } from './models/authStatus'
 import { RetryParams } from '../../rpcInterceptors'
 import { Stream } from '../../stream'
 import { isDefined } from '../../check'
+import { UnpackEnvelopeOpts } from '../../sign'
 
 const logger = dlogger('csb:riverConnection')
 
@@ -31,6 +32,7 @@ export interface ClientParams {
     highPriorityStreamIds?: string[]
     rpcRetryParams?: RetryParams
     encryptionDevice?: EncryptionDeviceInitOpts
+    unpackEnvelopeOpts?: UnpackEnvelopeOpts
 }
 
 export type OnStoppedFn = () => void
@@ -62,7 +64,7 @@ export class RiverConnection extends PersistedObservable<RiverConnectionModel> {
         public spaceDapp: SpaceDapp,
         public riverRegistryDapp: RiverRegistry,
         private makeRpcClient: MakeRpcClientType,
-        private clientParams: ClientParams,
+        public clientParams: ClientParams,
     ) {
         super({ id: '0', userExists: false }, store, LoadPriority.high)
         this.riverChain = new RiverChain(store, riverRegistryDapp, this.userId)
@@ -160,6 +162,7 @@ export class RiverConnection extends PersistedObservable<RiverConnectionModel> {
             this.clientParams.persistenceStoreName,
             this.clientParams.logNamespaceFilter,
             this.clientParams.highPriorityStreamIds,
+            this.clientParams.unpackEnvelopeOpts,
         )
         client.setMaxListeners(100)
         this.client = client

--- a/packages/sdk/src/sync-agent/spaces/models/channel.ts
+++ b/packages/sdk/src/sync-agent/spaces/models/channel.ts
@@ -67,6 +67,13 @@ export class Channel extends PersistedObservable<ChannelModel> {
         }
     }
 
+    async join() {
+        const channelId = this.data.id
+        await this.riverConnection.call(async (client) => {
+            await client.joinStream(channelId)
+        })
+    }
+
     async sendMessage(
         message: string,
         options?: {

--- a/packages/sdk/src/sync-agent/syncAgents.test.ts
+++ b/packages/sdk/src/sync-agent/syncAgents.test.ts
@@ -86,6 +86,41 @@ describe('syncAgents.test.ts', () => {
         )
     })
 
+    test('syncAgents send a message with disableSignatureValidation=true', async () => {
+        const prevBobOpts = bob.riverConnection.clientParams.unpackEnvelopeOpts
+        const prevAliceOpts = alice.riverConnection.clientParams.unpackEnvelopeOpts
+        bob.riverConnection.clientParams.unpackEnvelopeOpts = {
+            disableSignatureValidation: true,
+        }
+        alice.riverConnection.clientParams.unpackEnvelopeOpts = {
+            disableSignatureValidation: true,
+        }
+        await Promise.all([bob.start(), alice.start()])
+        await waitFor(() => bob.spaces.value.status === 'loaded')
+        const spaceId = bob.spaces.data.spaceIds[0]
+        const space = bob.spaces.getSpace(spaceId)
+        const channelId = await space.createChannel('random', bobUser.signer)
+        const channel = space.getChannel(channelId)
+        await channel.sendMessage('Hello, World again!')
+
+        // join the channel, find the message
+        const aliceChannel = alice.spaces.getSpace(spaceId).getChannel(channel.data.id)
+        await aliceChannel.join()
+        logger.log(aliceChannel.timeline.events.value)
+        await waitFor(
+            () =>
+                expect(
+                    aliceChannel.timeline.events.value.find(
+                        (e) => e.text === 'Hello, World again!',
+                    ),
+                ).toBeDefined(),
+            { timeoutMS: 10000 },
+        )
+        // reset the unpackEnvelopeOpts
+        bob.riverConnection.clientParams.unpackEnvelopeOpts = prevBobOpts
+        alice.riverConnection.clientParams.unpackEnvelopeOpts = prevAliceOpts
+    })
+
     test('syncAgents pin a message', async () => {
         await Promise.all([bob.start(), alice.start()])
         await waitFor(() => bob.spaces.value.status === 'loaded')


### PR DESCRIPTION
If we signature validation was disabled, run signature validation before sharing keys
I don't feel like we can safely turn off signature checks otherwise