### PR TITLE
Add miniblock headers to view when initializing streams

### DIFF
--- a/packages/proto/internal.proto
+++ b/packages/proto/internal.proto
@@ -16,6 +16,7 @@ message PersistedMiniblock {
     bytes hash = 1;
     MiniblockHeader header = 2;
     repeated PersistedEvent events = 3;
+    PersistedEvent header_event = 4;
 }
 
 message PersistedSyncedStream {

--- a/packages/sdk/src/sign.ts
+++ b/packages/sdk/src/sign.ts
@@ -174,6 +174,7 @@ export const unpackMiniblock = async (
     return {
         hash: miniblock.header.hash,
         header: header.event.payload.value,
+        headerEvent: header,
         events: [...events, header],
     }
 }

--- a/packages/sdk/src/streamUtils.ts
+++ b/packages/sdk/src/streamUtils.ts
@@ -26,12 +26,17 @@ export function persistedEventToParsedEvent(event: PersistedEvent): ParsedEvent 
 export function persistedMiniblockToParsedMiniblock(
     miniblock: PersistedMiniblock,
 ): ParsedMiniblock | undefined {
-    if (!miniblock.header) {
+    if (!miniblock.header || !miniblock.headerEvent) {
+        return undefined
+    }
+    const headerEvent = persistedEventToParsedEvent(miniblock.headerEvent)
+    if (!headerEvent) {
         return undefined
     }
     return {
         hash: miniblock.hash,
         header: miniblock.header,
+        headerEvent,
         events: miniblock.events.map(persistedEventToParsedEvent).filter(isDefined),
     }
 }
@@ -40,6 +45,7 @@ export function parsedMiniblockToPersistedMiniblock(miniblock: ParsedMiniblock) 
     return new PersistedMiniblock({
         hash: miniblock.hash,
         header: miniblock.header,
+        headerEvent: parsedEventToPersistedEvent(miniblock.headerEvent),
         events: miniblock.events.map(parsedEventToPersistedEvent),
     })
 }

--- a/packages/sdk/src/syncedStream.ts
+++ b/packages/sdk/src/syncedStream.ts
@@ -177,6 +177,7 @@ export class SyncedStream extends Stream implements ISyncedStream {
         const miniblock: ParsedMiniblock = {
             hash: hash,
             header: miniblockHeader,
+            headerEvent: miniblockEvent,
             events: [...events, miniblockEvent],
         }
         await this.persistenceStore.saveMiniblock(this.streamId, miniblock)

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -138,6 +138,7 @@ export function makeRemoteTimelineEvent(params: {
 export interface ParsedMiniblock {
     hash: Uint8Array
     header: MiniblockHeader
+    headerEvent: ParsedEvent
     events: ParsedEvent[]
 }
 


### PR DESCRIPTION
1) in cases where event signature validation is turned off, i want to be able to validate events later, so i need to keep the miniblock header event around so that i can check the signature
2) we have bookkeeping on miniblock numbers that we need to keep up to date
3) i think this is causing issues with membership confirmation