### PR TITLE
Key solicitation correctness fix - key local and dispatched solicitations in sync

### DIFF
--- a/packages/sdk/src/streamStateView_Members_Solicitations.ts
+++ b/packages/sdk/src/streamStateView_Members_Solicitations.ts
@@ -32,19 +32,19 @@ export class StreamStateView_Members_Solicitations {
         user.solicitations = user.solicitations.filter(
             (x) => x.deviceKey !== solicitation.deviceKey,
         )
-        user.solicitations.push({
+        const newSolicitation = {
             deviceKey: solicitation.deviceKey,
             fallbackKey: solicitation.fallbackKey,
             isNewDevice: solicitation.isNewDevice,
-            sessionIds: [...solicitation.sessionIds.sort()],
-        })
-
+            sessionIds: solicitation.sessionIds.toSorted(),
+        }
+        user.solicitations.push(newSolicitation)
         encryptionEmitter?.emit(
             'newKeySolicitation',
             this.streamId,
             user.userId,
             user.userAddress,
-            solicitation,
+            newSolicitation,
         )
     }
 
@@ -62,7 +62,7 @@ export class StreamStateView_Members_Solicitations {
             deviceKey: prev.deviceKey,
             fallbackKey: prev.fallbackKey,
             isNewDevice: false,
-            sessionIds: [...removeCommon(prev.sessionIds, fulfillment.sessionIds.sort())],
+            sessionIds: [...removeCommon(prev.sessionIds, fulfillment.sessionIds.toSorted())],
         }
         user.solicitations[index] = newEvent
         encryptionEmitter?.emit(


### PR DESCRIPTION
I don’t know if this caused any actual issues, but I’m going to be modifying this structure and it seems weird that we didn’t preserve the sort here.