### PR TITLE
chore(contract): use proper interface IDs in River contract

### DIFF
--- a/contracts/src/tokens/river/base/River.sol
+++ b/contracts/src/tokens/river/base/River.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.23;
 
 // interfaces
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
+import {IERC5267} from "@openzeppelin/contracts/interfaces/IERC5267.sol";
+import {IERC6372} from "@openzeppelin/contracts/interfaces/IERC6372.sol";
+import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {IOptimismMintableERC20, ILegacyMintableERC20} from "contracts/src/tokens/river/base/IOptimismMintableERC20.sol";
 import {ISemver} from "contracts/src/tokens/river/base/ISemver.sol";
-import {IERC5805} from "@openzeppelin/contracts/interfaces/IERC5805.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
-import {IERC5805} from "@openzeppelin/contracts/interfaces/IERC5805.sol";
-import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {ILock} from "contracts/src/tokens/lock/ILock.sol";
 
 // libraries
@@ -81,7 +81,9 @@ contract River is
     _addInterface(type(IERC20).interfaceId);
     _addInterface(type(IERC20Metadata).interfaceId);
     _addInterface(type(IERC20Permit).interfaceId);
-    _addInterface(type(IERC5805).interfaceId);
+    _addInterface(type(IERC5267).interfaceId);
+    _addInterface(type(IERC6372).interfaceId);
+    _addInterface(type(IVotes).interfaceId);
     _addInterface(type(IOptimismMintableERC20).interfaceId);
     _addInterface(type(ILegacyMintableERC20).interfaceId);
     _addInterface(type(ISemver).interfaceId);

--- a/contracts/test/river/token/base/RiverBase.t.sol
+++ b/contracts/test/river/token/base/RiverBase.t.sol
@@ -3,11 +3,14 @@ pragma solidity ^0.8.23;
 
 //interfaces
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC5267} from "@openzeppelin/contracts/interfaces/IERC5267.sol";
+import {IERC6372} from "@openzeppelin/contracts/interfaces/IERC6372.sol";
+import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {ILockBase} from "contracts/src/tokens/lock/ILock.sol";
 import {IOwnableBase} from "contracts/src/diamond/facets/ownable/IERC173.sol";
-import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 
 //libraries
 
@@ -35,8 +38,12 @@ contract RiverBaseTest is BaseSetup, ILockBase, IOwnableBase {
     assertEq(riverFacet.symbol(), "RVR");
     assertEq(riverFacet.decimals(), 18);
     assertTrue(riverFacet.supportsInterface(type(IERC20).interfaceId));
-    assertTrue(riverFacet.supportsInterface(type(IERC20Permit).interfaceId));
     assertTrue(riverFacet.supportsInterface(type(IERC20Metadata).interfaceId));
+    assertTrue(riverFacet.supportsInterface(type(IERC20Permit).interfaceId));
+    assertTrue(riverFacet.supportsInterface(type(IERC165).interfaceId));
+    assertTrue(riverFacet.supportsInterface(type(IERC5267).interfaceId));
+    assertTrue(riverFacet.supportsInterface(type(IERC6372).interfaceId));
+    assertTrue(riverFacet.supportsInterface(type(IVotes).interfaceId));
   }
 
   modifier givenCallerHasBridgedTokens(address caller, uint256 amount) {


### PR DESCRIPTION
Rearranged imports for better readability and added missing interfaces to the River contract. Updated test file to include checks for the new interfaces supported by the River contract.

Interface ID does not include inherited functions. Therefore `type(IERC5805).interfaceId` is 0.