### PR TITLE
Optimize stream metadata service by skipping validation

### DIFF
--- a/packages/encryption/src/decryptionExtensions.ts
+++ b/packages/encryption/src/decryptionExtensions.ts
@@ -691,7 +691,7 @@ export abstract class BaseDecryptionExtensions {
 
         const { isValid, reason } = this.isValidEvent(streamId, item.solicitation.srcEventId)
         if (!isValid) {
-            this.log.debug('processing key solicitation: invalid event id', {
+            this.log.error('processing key solicitation: invalid event id', {
                 streamId,
                 eventId: item.solicitation.srcEventId,
                 reason,

--- a/packages/encryption/src/decryptionExtensions.ts
+++ b/packages/encryption/src/decryptionExtensions.ts
@@ -691,7 +691,7 @@ export abstract class BaseDecryptionExtensions {
 
         const { isValid, reason } = this.isValidEvent(streamId, item.solicitation.srcEventId)
         if (!isValid) {
-            this.log.error('processing key solicitation: invalid event id', {
+            this.log.debug('processing key solicitation: invalid event id', {
                 streamId,
                 eventId: item.solicitation.srcEventId,
                 reason,

--- a/packages/stream-metadata/src/riverStreamRpcClient.ts
+++ b/packages/stream-metadata/src/riverStreamRpcClient.ts
@@ -17,6 +17,11 @@ import { FastifyBaseLogger } from 'fastify'
 import { MediaContent, StreamIdHex } from './types'
 import { getNodeForStream } from './streamRegistry'
 
+const STREAM_METADATA_SERVICE_DEFAULT_UNPACK_OPTS: UnpackEnvelopeOpts = {
+	disableHashValidation: true,
+	disableSignatureValidation: true,
+}
+
 const clients = new Map<string, StreamRpcClient>()
 
 export type StreamRpcClient = PromiseClient<typeof StreamService> & { url?: string }
@@ -180,7 +185,10 @@ export async function getStream(
 			'getStream finished',
 		)
 
-		const unpackedResponse = await unpackStream(response.stream, opts)
+		const unpackedResponse = await unpackStream(
+			response.stream,
+			opts ?? STREAM_METADATA_SERVICE_DEFAULT_UNPACK_OPTS,
+		)
 		return streamViewFromUnpackedResponse(streamId, unpackedResponse)
 	} catch (e) {
 		logger.error(

--- a/packages/stream-metadata/src/riverStreamRpcClient.ts
+++ b/packages/stream-metadata/src/riverStreamRpcClient.ts
@@ -158,7 +158,7 @@ function stripHexPrefix(hexString: string): string {
 export async function getStream(
 	logger: FastifyBaseLogger,
 	streamId: string,
-	opts?: UnpackEnvelopeOpts,
+	opts: UnpackEnvelopeOpts = STREAM_METADATA_SERVICE_DEFAULT_UNPACK_OPTS,
 ): Promise<StreamStateView> {
 	const { client, lastMiniblockNum } = await getStreamClient(logger, `0x${streamId}`)
 	logger.info(
@@ -185,10 +185,7 @@ export async function getStream(
 			'getStream finished',
 		)
 
-		const unpackedResponse = await unpackStream(
-			response.stream,
-			opts ?? STREAM_METADATA_SERVICE_DEFAULT_UNPACK_OPTS,
-		)
+		const unpackedResponse = await unpackStream(response.stream, opts)
 		return streamViewFromUnpackedResponse(streamId, unpackedResponse)
 	} catch (e) {
 		logger.error(


### PR DESCRIPTION
long term we should figure out a way to turn this back on