### PR TITLE
test(contract): refactor `EntitlementCheckRequested` event extraction…

### DIFF
--- a/contracts/test/crosschain/EntitlementGated.t.sol
+++ b/contracts/test/crosschain/EntitlementGated.t.sol
@@ -1,12 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-// utils
-
 //interfaces
-import {IEntitlementChecker} from "contracts/src/base/registry/facets/checker/IEntitlementChecker.sol";
 import {IEntitlementCheckerBase} from "contracts/src/base/registry/facets/checker/IEntitlementChecker.sol";
-import {IEntitlementGated} from "contracts/src/spaces/facets/gated/IEntitlementGated.sol";
 import {IEntitlementGatedBase} from "contracts/src/spaces/facets/gated/IEntitlementGated.sol";
 import {IRuleEntitlement} from "contracts/src/spaces/entitlements/rule/IRuleEntitlement.sol";
 
@@ -14,12 +10,12 @@ import {IRuleEntitlement} from "contracts/src/spaces/entitlements/rule/IRuleEnti
 import {RuleEntitlementUtil} from "./RuleEntitlementUtil.sol";
 
 //contracts
-import {EntitlementChecker} from "contracts/src/base/registry/facets/checker/EntitlementChecker.sol";
 import {MockEntitlementGated} from "contracts/test/mocks/MockEntitlementGated.sol";
-
+import {EntitlementTestUtils} from "contracts/test/utils/EntitlementTestUtils.sol";
 import {BaseSetup} from "contracts/test/spaces/BaseSetup.sol";
 
 contract EntitlementGatedTest is
+  EntitlementTestUtils,
   BaseSetup,
   IEntitlementGatedBase,
   IEntitlementCheckerBase
@@ -168,15 +164,20 @@ contract EntitlementGatedTest is
   }
 
   function test_postEntitlementCheckResult_multipleRoleIds() external {
-    address[] memory nodes = entitlementChecker.getRandomNodes(5);
-
     uint256[] memory roleIds = new uint256[](2);
     roleIds[0] = 0;
     roleIds[1] = 1;
 
+    vm.recordLogs();
+
     bytes32 requestId = gated.requestEntitlementCheckV2(
       roleIds,
       RuleEntitlementUtil.getMockERC721RuleData()
+    );
+
+    // get the nodes that were selected
+    (, , , address[] memory nodes) = _getRequestedEntitlementData(
+      vm.getRecordedLogs()
     );
 
     // first roleId is not entitled

--- a/contracts/test/mocks/MockEntitlementGated.sol
+++ b/contracts/test/mocks/MockEntitlementGated.sol
@@ -48,7 +48,7 @@ contract MockEntitlementGated is EntitlementGated {
   }
 
   function requestEntitlementCheckV2(
-    uint256[] memory roleIds,
+    uint256[] calldata roleIds,
     IRuleEntitlement.RuleDataV2 calldata ruleData
   ) external returns (bytes32) {
     for (uint256 i = 0; i < roleIds.length; i++) {

--- a/contracts/test/utils/EntitlementTestUtils.sol
+++ b/contracts/test/utils/EntitlementTestUtils.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {Vm} from "forge-std/Vm.sol";
+
+abstract contract EntitlementTestUtils {
+  bytes32 internal constant CHECK_REQUESTED =
+    keccak256(
+      "EntitlementCheckRequested(address,address,bytes32,uint256,address[])"
+    );
+
+  /// @dev Capture the requested entitlement data from the logs emitted by the EntitlementChecker
+  function _getRequestedEntitlementData(
+    Vm.Log[] memory requestLogs
+  )
+    internal
+    pure
+    returns (
+      address contractAddress,
+      bytes32 transactionId,
+      uint256 roleId,
+      address[] memory selectedNodes
+    )
+  {
+    for (uint256 i; i < requestLogs.length; ++i) {
+      if (
+        requestLogs[i].topics.length > 0 &&
+        requestLogs[i].topics[0] == CHECK_REQUESTED
+      ) {
+        (, contractAddress, transactionId, roleId, selectedNodes) = abi.decode(
+          requestLogs[i].data,
+          (address, address, bytes32, uint256, address[])
+        );
+        return (contractAddress, transactionId, roleId, selectedNodes);
+      }
+    }
+    revert("Entitlement check request not found");
+  }
+}


### PR DESCRIPTION
… to `EntitlementTestUtils` and fix test

Moved `EntitlementCheckRequested` event decoding to a common utility to improve code reuse and maintainability. Updated affected test contracts to utilize the new utility.

Currently `forge test --mt test_postEntitlementCheckResult_multipleRoleIds --isolate` fails.