### PR TITLE
use pino default err key

### DIFF
--- a/packages/stream-metadata/src/opensea.ts
+++ b/packages/stream-metadata/src/opensea.ts
@@ -83,7 +83,7 @@ export const refreshOpenSea = async ({
 			.catch((error: unknown) => {
 				logger.error(
 					{
-						error,
+						err: error,
 						spaceAddress,
 					},
 					'Failed to refresh OpenSea',

--- a/packages/stream-metadata/src/riverStreamRpcClient.ts
+++ b/packages/stream-metadata/src/riverStreamRpcClient.ts
@@ -189,7 +189,7 @@ export async function getStream(
 		return streamViewFromUnpackedResponse(streamId, unpackedResponse)
 	} catch (e) {
 		logger.error(
-			{ url: client.url, streamId, error: e },
+			{ url: client.url, streamId, err: e },
 			'getStream failed, removing client from cache',
 		)
 		removeClient(logger, client)

--- a/packages/stream-metadata/src/routes/media.ts
+++ b/packages/stream-metadata/src/routes/media.ts
@@ -80,7 +80,7 @@ export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 			.header('Cache-Control', CACHE_CONTROL[200])
 			.send(Buffer.from(data))
 	} catch (error) {
-		logger.error({ mediaStreamId, error }, 'Failed to fetch media stream content')
+		logger.error({ mediaStreamId, err: error }, 'Failed to fetch media stream content')
 
 		return reply
 			.code(404)

--- a/packages/stream-metadata/src/routes/profileImage.ts
+++ b/packages/stream-metadata/src/routes/profileImage.ts
@@ -46,7 +46,7 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 	} catch (error) {
 		logger.error(
 			{
-				error,
+				err: error,
 				userId,
 			},
 			'Failed to get stream',
@@ -95,7 +95,7 @@ export async function fetchUserProfileImage(request: FastifyRequest, reply: Fast
 	} catch (error) {
 		logger.error(
 			{
-				error,
+				err: error,
 				userId,
 				mediaStreamId: profileImage.streamId,
 			},

--- a/packages/stream-metadata/src/routes/spaceImage.ts
+++ b/packages/stream-metadata/src/routes/spaceImage.ts
@@ -51,7 +51,7 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 	} catch (error) {
 		logger.error(
 			{
-				error,
+				err: error,
 				spaceAddress,
 			},
 			'Failed to get stream',
@@ -94,7 +94,7 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 	} catch (error) {
 		logger.error(
 			{
-				error,
+				err: error,
 				spaceAddress,
 				mediaStreamId: spaceImage.streamId,
 			},

--- a/packages/stream-metadata/src/routes/spaceMemberMetadata.ts
+++ b/packages/stream-metadata/src/routes/spaceMemberMetadata.ts
@@ -54,7 +54,7 @@ export async function fetchSpaceMemberMetadata(request: FastifyRequest, reply: F
 			.header('Cache-Control', CACHE_CONTROL[200])
 			.send(metadata)
 	} catch (error) {
-		logger.error({ spaceAddress, tokenId, error }, 'Failed to fetch space contract info')
+		logger.error({ spaceAddress, tokenId, err: error }, 'Failed to fetch space contract info')
 		return reply
 			.code(404)
 			.header('Cache-Control', CACHE_CONTROL['4xx'])

--- a/packages/stream-metadata/src/routes/spaceMetadata.ts
+++ b/packages/stream-metadata/src/routes/spaceMetadata.ts
@@ -54,7 +54,7 @@ export async function fetchSpaceMetadata(request: FastifyRequest, reply: Fastify
 	try {
 		spaceInfo = await spaceDapp.getSpaceInfo(spaceAddress)
 	} catch (error) {
-		logger.error({ spaceAddress, error }, 'Failed to fetch space contract info')
+		logger.error({ spaceAddress, err: error }, 'Failed to fetch space contract info')
 		return reply
 			.code(404)
 			.header('Cache-Control', CACHE_CONTROL['4xx'])

--- a/packages/stream-metadata/src/routes/spaceRefresh.ts
+++ b/packages/stream-metadata/src/routes/spaceRefresh.ts
@@ -51,7 +51,7 @@ export async function spaceRefreshOnResponse(
 	} catch (error) {
 		logger.error(
 			{
-				error,
+				err: error,
 				spaceAddress,
 			},
 			'Failed to refresh space',

--- a/packages/stream-metadata/src/routes/userBio.ts
+++ b/packages/stream-metadata/src/routes/userBio.ts
@@ -41,7 +41,7 @@ export async function fetchUserBio(request: FastifyRequest, reply: FastifyReply)
 	} catch (error) {
 		logger.error(
 			{
-				error,
+				err: error,
 				userId,
 			},
 			'Failed to get stream',

--- a/packages/stream-metadata/src/routes/userRefresh.ts
+++ b/packages/stream-metadata/src/routes/userRefresh.ts
@@ -59,7 +59,7 @@ export async function userRefreshOnResponse(
 	} catch (error) {
 		logger.error(
 			{
-				error,
+				err: error,
 				userId,
 				target,
 				paths,

--- a/packages/stress/src/mode/chat/root_chat.ts
+++ b/packages/stress/src/mode/chat/root_chat.ts
@@ -146,7 +146,7 @@ export async function startStressChat(opts: {
                         return { streamId, randomClients }
                     })
                     .catch((e) => {
-                        logStep(client, 'CREATE_GDM', false, { reason: e })
+                        logStep(client, 'CREATE_GDM', false, { err: e })
                         throw e
                     })
             }),
@@ -175,7 +175,7 @@ export async function startStressChat(opts: {
                     })
                     .catch((e) => {
                         errors.push(e)
-                        logStep(client, 'GDM_CHAT', false, { reason: e })
+                        logStep(client, 'GDM_CHAT', false, { err: e })
                         throw e
                     }),
             )


### PR DESCRIPTION
https://getpino.io/#/docs/api?id=logging-method-parameters

Pino by default only serializes errors that: is the only param, like `logger.error(error)` or is in a err key like `logger.error({ err: new Error('oops') })`