### PR TITLE
Add default timeout to our connect rpc handlers

### DIFF
--- a/packages/sdk/src/bob.test_util.ts
+++ b/packages/sdk/src/bob.test_util.ts
@@ -149,9 +149,12 @@ export const bobTalksToHimself = async (
     log('Bob starts sync with sync cookie=', channel.stream?.nextSyncCookie)
 
     let syncCookie = channel.stream!.nextSyncCookie!
-    const bobSyncStreamIterable: AsyncIterable<SyncStreamsResponse> = bob.syncStreams({
-        syncPos: [syncCookie],
-    })
+    const bobSyncStreamIterable: AsyncIterable<SyncStreamsResponse> = bob.syncStreams(
+        {
+            syncPos: [syncCookie],
+        },
+        { timeoutMs: -1 },
+    )
     await expect(
         waitForSyncStreams(
             bobSyncStreamIterable,

--- a/packages/sdk/src/makeStreamRpcClient.ts
+++ b/packages/sdk/src/makeStreamRpcClient.ts
@@ -26,6 +26,7 @@ export function makeStreamRpcClient(
             retryInterceptor({ ...retryParams, refreshNodeUrl }),
             loggingInterceptor(transportId),
         ],
+        defaultTimeoutMs: 30000, // this is a massive timeout, but we have very long requests that can take > 10 seconds to create a stream for example
     }
     if (getEnvVar('RIVER_DEBUG_TRANSPORT') !== 'true') {
         options.useBinaryFormat = true

--- a/packages/sdk/src/streamRpcClient.test.ts
+++ b/packages/sdk/src/streamRpcClient.test.ts
@@ -129,9 +129,12 @@ describe('streamRpcClient using v2 sync', () => {
         let syncId: string | undefined = undefined
         const syncCookie = alicesStream.stream!.nextSyncCookie!
 
-        const aliceStreamIterable: AsyncIterable<SyncStreamsResponse> = alice.syncStreams({
-            syncPos: [syncCookie],
-        })
+        const aliceStreamIterable: AsyncIterable<SyncStreamsResponse> = alice.syncStreams(
+            {
+                syncPos: [syncCookie],
+            },
+            { timeoutMs: -1 },
+        )
         await expect(
             waitForSyncStreams(aliceStreamIterable, async (res) => {
                 syncId = res.syncId
@@ -225,9 +228,12 @@ describe('streamRpcClient using v2 sync', () => {
 
         /** Act */
         // bob calls syncStreams, and waits for the syncId in the response stream
-        const bobSyncStreams: AsyncIterable<SyncStreamsResponse> = bob.syncStreams({
-            syncPos: [],
-        })
+        const bobSyncStreams: AsyncIterable<SyncStreamsResponse> = bob.syncStreams(
+            {
+                syncPos: [],
+            },
+            { timeoutMs: -1 },
+        )
         // bob reads the syncId from the response stream
         let syncId: string | undefined = undefined
         for await (const resp of bobSyncStreams) {
@@ -251,7 +257,7 @@ describe('streamRpcClient using v2 sync', () => {
             event,
         })
         // bob adds alice's channel to his syncStreams
-        const bobsChannelStream = await bob.getStream({ streamId: channelId })
+        const bobsChannelStream = await bob.getStream({ streamId: channelId }, { timeoutMs: -1 })
         await bob.addStreamToSync({
             syncId: syncId!,
             syncPos: bobsChannelStream.stream!.nextSyncCookie!,
@@ -534,9 +540,12 @@ describe('streamRpcClient', () => {
         })
         if (!userAlice.stream) throw new Error('userAlice stream not found')
         let aliceSyncCookie = userAlice.stream.nextSyncCookie
-        const aliceSyncStreams = alice.syncStreams({
-            syncPos: aliceSyncCookie ? [aliceSyncCookie] : [],
-        })
+        const aliceSyncStreams = alice.syncStreams(
+            {
+                syncPos: aliceSyncCookie ? [aliceSyncCookie] : [],
+            },
+            { timeoutMs: -1 },
+        )
 
         let syncId
 

--- a/packages/sdk/src/syncWithBlocks.test.ts
+++ b/packages/sdk/src/syncWithBlocks.test.ts
@@ -145,9 +145,12 @@ describe('syncWithBlocks', () => {
         log('addEvent response', { resp })
 
         // Bob starts sync on the channel
-        const syncStream = bob.syncStreams({
-            syncPos: [channel.stream!.nextSyncCookie!],
-        })
+        const syncStream = bob.syncStreams(
+            {
+                syncPos: [channel.stream!.nextSyncCookie!],
+            },
+            { timeoutMs: -1 },
+        )
 
         // If there is a message, next expect a miniblock header, and vise versa.
         let expectMessage = true

--- a/packages/sdk/src/syncedStreamsLoop.ts
+++ b/packages/sdk/src/syncedStreamsLoop.ts
@@ -317,9 +317,12 @@ export class SyncedStreamsLoop {
                             // syncId needs to be reset before starting a new syncStreams
                             // syncStreams() should return a new syncId
                             this.syncId = undefined
-                            const streams = this.rpcClient.syncStreams({
-                                syncPos: syncCookies,
-                            })
+                            const streams = this.rpcClient.syncStreams(
+                                {
+                                    syncPos: syncCookies,
+                                },
+                                { timeoutMs: -1 },
+                            )
 
                             const iterator = streams[Symbol.asyncIterator]()
 

--- a/packages/stream-metadata/src/riverStreamRpcClient.ts
+++ b/packages/stream-metadata/src/riverStreamRpcClient.ts
@@ -33,6 +33,7 @@ export function makeStreamRpcClient(url: string): StreamRpcClient {
 		interceptors: [
 			retryInterceptor({ maxAttempts: 3, initialRetryDelay: 2000, maxRetryDelay: 6000 }),
 		],
+		defaultTimeoutMs: 30000,
 	}
 
 	const transport = createConnectTransport(options)

--- a/packages/stress/src/utils/rpc-http2.ts
+++ b/packages/stress/src/utils/rpc-http2.ts
@@ -26,6 +26,7 @@ export function makeHttp2StreamRpcClient(
             loggingInterceptor(transportId),
             retryInterceptor({ ...retryParams, refreshNodeUrl }),
         ],
+        defaultTimeoutMs: 30000,
     }
     if (!process.env.RIVER_DEBUG_TRANSPORT) {
         options.useBinaryFormat = true


### PR DESCRIPTION
default to 30 seconds
we're seeing cases where get or create stream will hang forever
i want to be very generous with the timeout to allow long running requests to finish
I updated all syncStream requests to have -1 timeout which resets the value to undefined if i'm reading this code correctly https://github.com/connectrpc/connect-es/blob/f154e67629c4553a232c15c45f5f7bf5c7a1b02d/packages/connect-web/src/connect-transport.ts#L330