### PR TITLE
stream-metadata: add support for `/refreshStatus/:invalidationId`

### DIFF
--- a/packages/stream-metadata/src/constants.ts
+++ b/packages/stream-metadata/src/constants.ts
@@ -1,0 +1,1 @@
+export const HEADER_INVALIDATION_ID = 'X-StreamMetadata-Invalidation-Id'

--- a/packages/stream-metadata/src/environment.ts
+++ b/packages/stream-metadata/src/environment.ts
@@ -79,9 +79,6 @@ function makeConfig() {
 		healthCheck: {
 			timeout: 5000, // 5 seconds
 		},
-		headers: {
-			invalidationId: 'X-StreamMetadata-Invalidation-Id',
-		},
 	}
 }
 

--- a/packages/stream-metadata/src/environment.ts
+++ b/packages/stream-metadata/src/environment.ts
@@ -79,6 +79,9 @@ function makeConfig() {
 		healthCheck: {
 			timeout: 5000, // 5 seconds
 		},
+		headers: {
+			invalidationId: 'X-StreamMetadata-Invalidation-Id',
+		},
 	}
 }
 

--- a/packages/stream-metadata/src/node.ts
+++ b/packages/stream-metadata/src/node.ts
@@ -16,9 +16,10 @@ import { fetchUserProfileImage } from './routes/profileImage'
 import { fetchUserBio } from './routes/userBio'
 import { fetchMedia } from './routes/media'
 import { spaceRefresh, spaceRefreshOnResponse } from './routes/spaceRefresh'
-import { userRefresh, userRefreshOnResponse } from './routes/userRefresh'
+import { userRefresh } from './routes/userRefresh'
 import { addCacheControlCheck } from './check-cache-control'
 import { fetchSpaceMemberMetadata } from './routes/spaceMemberMetadata'
+import { fetchRefreshStatus } from './routes/refreshStatus'
 
 // Set the process title to 'stream-metadata' so it can be easily identified
 // or killed with `pkill stream-metadata`
@@ -116,10 +117,11 @@ export function setupRoutes(srv: Server) {
 
 	// not cached
 	srv.get('/health', checkHealth)
+	srv.get('/refreshStatus/:invalidationId', fetchRefreshStatus)
 
 	// should be rate-limited, but not yet
 	srv.get('/space/:spaceAddress/refresh', { onResponse: spaceRefreshOnResponse }, spaceRefresh)
-	srv.get('/user/:userId/refresh', { onResponse: userRefreshOnResponse }, userRefresh)
+	srv.get('/user/:userId/refresh', userRefresh)
 
 	// Fastify will return 404 for any unmatched routes
 }
@@ -152,7 +154,7 @@ async function main() {
 		await registerPlugins(server)
 		setupRoutes(server)
 		addCacheControlCheck(server, {
-			skippedRoutes: ['/refresh', '/health'],
+			skippedRoutes: ['/refresh', '/health', '/refreshStatus'],
 		})
 		await server.listen({
 			port: config.port,

--- a/packages/stream-metadata/src/routes/refreshStatus.ts
+++ b/packages/stream-metadata/src/routes/refreshStatus.ts
@@ -1,0 +1,40 @@
+import { FastifyReply, FastifyRequest } from 'fastify'
+import { z } from 'zod'
+
+import { CloudfrontManager } from '../aws'
+
+const paramsSchema = z.object({
+	invalidationId: z.string().min(1, 'invalidationId parameter is required'),
+})
+
+export async function fetchRefreshStatus(request: FastifyRequest, reply: FastifyReply) {
+	const logger = request.log.child({ name: fetchRefreshStatus.name })
+	const parseResult = paramsSchema.safeParse(request.params)
+
+	if (!parseResult.success) {
+		const errorMessage = parseResult.error.errors[0]?.message || 'Invalid parameters'
+		logger.info(errorMessage)
+		return reply.code(400).send({ error: 'Bad Request', message: errorMessage })
+	}
+	const { invalidationId } = parseResult.data
+	logger.info({ invalidationId }, 'Fetching invalidation status')
+
+	try {
+		const invalidation = await CloudfrontManager.getInvalidation({ logger, invalidationId })
+		const status = invalidation
+			? invalidation.Invalidation?.Status === 'Completed'
+				? 'completed'
+				: 'pending'
+			: 'unset'
+		return reply.code(200).send({ status })
+	} catch (error) {
+		logger.error(
+			{
+				err: error,
+				invalidationId,
+			},
+			'Failed to get invalidation status',
+		)
+		return reply.code(200).send({ status: 'error' })
+	}
+}

--- a/packages/stream-metadata/src/routes/spaceRefresh.ts
+++ b/packages/stream-metadata/src/routes/spaceRefresh.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import { isValidEthereumAddress } from '../validators'
 import { CloudfrontManager } from '../aws'
 import { refreshOpenSea } from '../opensea'
-import { config } from '../environment'
+import { HEADER_INVALIDATION_ID } from '../constants'
 
 const paramsSchema = z.object({
 	spaceAddress: z
@@ -36,7 +36,7 @@ export async function spaceRefresh(request: FastifyRequest, reply: FastifyReply)
 
 		return reply
 			.code(200)
-			.header(config.headers.invalidationId, invalidationId)
+			.header(HEADER_INVALIDATION_ID, invalidationId)
 			.send({ ok: true, invalidationId })
 	} catch (error) {
 		logger.error({ err: error }, 'Failed to create CloudFront invalidation')
@@ -53,7 +53,7 @@ export async function spaceRefreshOnResponse(
 	const logger = request.log.child({ name: spaceRefreshOnResponse.name })
 	const { spaceAddress } = paramsSchema.parse(request.params)
 	try {
-		const invalidationId = z.string().parse(reply.getHeader(config.headers.invalidationId))
+		const invalidationId = z.string().parse(reply.getHeader(HEADER_INVALIDATION_ID))
 		await CloudfrontManager.waitForInvalidation({ invalidationId, logger })
 		await refreshOpenSea({ spaceAddress, logger })
 	} catch (error) {

--- a/packages/stream-metadata/src/routes/userRefresh.ts
+++ b/packages/stream-metadata/src/routes/userRefresh.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 
 import { isValidEthereumAddress } from '../validators'
 import { CloudfrontManager } from '../aws'
+import { config } from '../environment'
 
 const paramsSchema = z.object({
 	userId: z.string().min(1, 'userId parameter is required').refine(isValidEthereumAddress, {
@@ -14,12 +15,11 @@ const querySchema = z.object({
 	target: z.enum(['bio', 'image', 'all']).default('all'),
 })
 
-// This route handler validates the refresh request and quickly returns a 200 response.
+// This route handler validates the refresh request, initiates the CloudFront invalidation, and returns a 200 response.
 export async function userRefresh(request: FastifyRequest, reply: FastifyReply) {
 	const logger = request.log.child({ name: userRefresh.name })
 
 	const paramsParseResult = paramsSchema.safeParse(request.params)
-
 	if (!paramsParseResult.success) {
 		const errorMessage = paramsParseResult.error.errors[0]?.message || 'Invalid parameters'
 		logger.info(errorMessage)
@@ -33,19 +33,8 @@ export async function userRefresh(request: FastifyRequest, reply: FastifyReply) 
 		return reply.code(400).send({ error: 'Bad Request', message: errorMessage })
 	}
 
-	return reply.code(200).send({ ok: true })
-}
-
-// This onResponse hook does the actual heavy lifting of invalidating the CloudFront cache.
-export async function userRefreshOnResponse(
-	request: FastifyRequest,
-	reply: FastifyReply,
-	done: () => void,
-) {
-	const logger = request.log.child({ name: userRefreshOnResponse.name })
-
-	const { userId } = paramsSchema.parse(request.params)
-	const { target } = querySchema.parse(request.query)
+	const { userId } = paramsParseResult.data
+	const { target } = queryParamResult.data
 
 	logger.info({ userId, target }, 'Refreshing user')
 
@@ -57,7 +46,12 @@ export async function userRefreshOnResponse(
 			: [`/user/${userId}/*`]
 
 	try {
-		await CloudfrontManager.createCloudfrontInvalidation({ paths, logger })
+		const invalidation = await CloudfrontManager.createCloudfrontInvalidation({ paths, logger })
+		const invalidationId = invalidation?.Invalidation?.Id
+		return reply
+			.code(200)
+			.header(config.headers.invalidationId, invalidationId)
+			.send({ ok: true, invalidationId })
 	} catch (error) {
 		logger.error(
 			{
@@ -68,7 +62,6 @@ export async function userRefreshOnResponse(
 			},
 			'Failed to refresh user',
 		)
+		return reply.code(500).send({ ok: false })
 	}
-
-	done()
 }

--- a/packages/stream-metadata/src/routes/userRefresh.ts
+++ b/packages/stream-metadata/src/routes/userRefresh.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 
 import { isValidEthereumAddress } from '../validators'
 import { CloudfrontManager } from '../aws'
-import { config } from '../environment'
+import { HEADER_INVALIDATION_ID } from '../constants'
 
 const paramsSchema = z.object({
 	userId: z.string().min(1, 'userId parameter is required').refine(isValidEthereumAddress, {
@@ -50,7 +50,7 @@ export async function userRefresh(request: FastifyRequest, reply: FastifyReply) 
 		const invalidationId = invalidation?.Invalidation?.Id
 		return reply
 			.code(200)
-			.header(config.headers.invalidationId, invalidationId)
+			.header(HEADER_INVALIDATION_ID, invalidationId)
 			.send({ ok: true, invalidationId })
 	} catch (error) {
 		logger.error(


### PR DESCRIPTION
We need to wait for refresh to finish before emitting `refreshMetadata` for space members nft.
Previously we tried polling both space and space member metadata and waiting eventId of the image to be equal
The previous attempt didn’t worked and also increased the load on the service. 

This PR solves it, adding a `/refreshStatus/:invalidationId` route. 
Now after a refresh we get the invalidationId, which we can use to poll `/refreshStatus/:invalidationId` on the client until the refresh is completed.

We dont need `/event` in the space image route anymore. I'll create a PR later
