### PR TITLE
dApp: Enable empty metadata when updating channel status only

### DIFF
--- a/packages/web3/src/ContractTypes.ts
+++ b/packages/web3/src/ContractTypes.ts
@@ -12,7 +12,12 @@ import { IPricingModulesBase } from './v3/IPricingShim'
 import { RuleEntitlementV2Shim } from './v3/RuleEntitlementV2Shim'
 import { NoopRuleData } from './entitlement'
 
-import { CreateSpaceParams, CreateLegacySpaceParams } from './ISpaceDapp'
+import {
+    CreateSpaceParams,
+    CreateLegacySpaceParams,
+    UpdateChannelParams,
+    UpdateChannelStatusParams,
+} from './ISpaceDapp'
 
 export const Permission = {
     Undefined: 'Undefined', // No permission required
@@ -175,6 +180,15 @@ export function isRuleEntitlementV2(
     entitlement: EntitlementModule,
 ): entitlement is RuleEntitlementV2Shim {
     return entitlement.moduleType === EntitlementModuleType.RuleEntitlementV2
+}
+
+export const isUpdateChannelStatusParams = (
+    params: UpdateChannelParams,
+): params is UpdateChannelStatusParams => {
+    return (
+        'disabled' in params &&
+        !('roleIds' in params || 'channelName' in params || 'channelDescription' in params)
+    )
 }
 
 export function isStringArray(

--- a/packages/web3/src/ISpaceDapp.ts
+++ b/packages/web3/src/ISpaceDapp.ts
@@ -47,7 +47,7 @@ export interface CreateSpaceParams {
     prepaySupply?: number
 }
 
-export interface UpdateChannelParams {
+export interface UpdateChannelMetadataParams {
     spaceId: string
     channelId: string
     channelName: string
@@ -55,6 +55,14 @@ export interface UpdateChannelParams {
     roleIds: number[]
     disabled?: boolean
 }
+
+export interface UpdateChannelStatusParams {
+    spaceId: string
+    channelId: string
+    disabled: boolean
+}
+
+export type UpdateChannelParams = UpdateChannelMetadataParams | UpdateChannelStatusParams
 
 export interface RemoveChannelParams {
     spaceId: string
@@ -234,7 +242,7 @@ export interface ISpaceDapp {
         logs: ethers.providers.Log[],
     ) => Promise<(ethers.utils.LogDescription | undefined)[]>
     updateChannel: (
-        params: UpdateChannelParams,
+        params: UpdateChannelMetadataParams,
         signer: SignerType,
         txnOpts?: TransactionOpts,
     ) => Promise<TransactionType>


### PR DESCRIPTION
When disabling channels, passing names and roles is not required. To ensure the contract accepts this exception, the metadata param should be encoded to 0 bytes.