### PR TITLE
If reconciliation worker pools size set to 0, disable reconciliation.

### DIFF
--- a/core/node/events/stream_cache.go
+++ b/core/node/events/stream_cache.go
@@ -108,11 +108,13 @@ func NewStreamCache(
 	}
 
 	// schedule sync tasks for all local streams in the background
-	go func() {
-		for _, stream := range localStreamResults {
-			s.syncTasks.Submit(ctx, stream, s)
-		}
-	}()
+	if params.Config.StreamReconciliation.WorkerPoolSize > 0 {
+		go func() {
+			for _, stream := range localStreamResults {
+				s.syncTasks.Submit(ctx, stream, s)
+			}
+		}()
+	}
 
 	// load local streams in-memory cache
 	for _, stream := range localStreamResults {

--- a/core/node/rpc/tester_test.go
+++ b/core/node/rpc/tester_test.go
@@ -215,6 +215,7 @@ func (st *serviceTester) getConfig(opts ...startOpts) *config.Config {
 		options = &opts[0]
 	}
 
+	// TODO: derive this config from the default config.
 	cfg := &config.Config{
 		DisableBaseChain: true,
 		DisableHttps:     true,
@@ -228,6 +229,9 @@ func (st *serviceTester) getConfig(opts ...startOpts) *config.Config {
 			NumRetries: 3,
 		},
 		ShutdownTimeout: 2 * time.Millisecond,
+		StreamReconciliation: config.StreamReconciliationConfig{
+			WorkerPoolSize: 8,
+		},
 	}
 
 	if options.configUpdater != nil {


### PR DESCRIPTION
Should help to start with overloaded DB.