### PR TITLE
Bump version of persistence store to fix decryption

### DIFF
--- a/packages/sdk/src/persistenceStore.ts
+++ b/packages/sdk/src/persistenceStore.ts
@@ -105,6 +105,16 @@ export class PersistenceStore extends Dexie implements IPersistenceStore {
             miniblocks: '[streamId+miniblockNum]',
         })
 
+        // Version 2: added a signature to the saved event, drop all saved miniblocks
+        this.version(2).upgrade((tx) => {
+            return tx.table('miniblocks').toCollection().delete()
+        })
+
+        // Version 3: added a signature to the saved event, drop all saved synced streams
+        this.version(3).upgrade((tx) => {
+            return tx.table('syncedStreams').toCollection().delete()
+        })
+
         this.requestPersistentStorage()
         this.logPersistenceStats()
     }


### PR DESCRIPTION
Any key solicitation loaded from a previous version of the db will fail to validate. I didn’t think this would cause much of an issue but it turns out to mess up decryption a lot.