### PR TITLE
SpaceDapp: add senderAddress param to getSpaceAddress

### DIFF
--- a/packages/sdk/src/legacySpace.test.ts
+++ b/packages/sdk/src/legacySpace.test.ts
@@ -21,7 +21,7 @@ describe('Legacy Space Detection', () => {
         )
         const receipt = await transaction.wait()
         expect(receipt.status).toEqual(1)
-        const spaceAddress = aliceSpaceDapp.getSpaceAddress(receipt)
+        const spaceAddress = aliceSpaceDapp.getSpaceAddress(receipt, aliceProvider.wallet.address)
         expect(spaceAddress).toBeDefined()
 
         await expect(aliceSpaceDapp.isLegacySpace(spaceAddress!)).resolves.toBeTruthy()
@@ -53,7 +53,7 @@ describe('Legacy Space Detection', () => {
         )
         const receipt = await transaction.wait()
         expect(receipt.status).toEqual(1)
-        const spaceAddress = aliceSpaceDapp.getSpaceAddress(receipt)
+        const spaceAddress = aliceSpaceDapp.getSpaceAddress(receipt, aliceProvider.wallet.address)
         expect(spaceAddress).toBeDefined()
 
         await expect(aliceSpaceDapp.isLegacySpace(spaceAddress!)).resolves.toBeFalsy()

--- a/packages/sdk/src/mediaWithEntitlements.test.ts
+++ b/packages/sdk/src/mediaWithEntitlements.test.ts
@@ -99,7 +99,7 @@ describe('mediaWithEntitlements', () => {
 
         const receipt = await transaction.wait()
         log('transaction receipt', receipt)
-        const spaceAddress = spaceDapp.getSpaceAddress(receipt)
+        const spaceAddress = spaceDapp.getSpaceAddress(receipt, provider.wallet.address)
         expect(spaceAddress).toBeDefined()
         const spaceStreamId = makeSpaceStreamId(spaceAddress!)
         const channelId = makeDefaultChannelStreamId(spaceAddress!)
@@ -123,7 +123,7 @@ describe('mediaWithEntitlements', () => {
         )
         const receipt2 = await transaction2.wait()
         log('transaction2 receipt', receipt2)
-        const space2Address = spaceDapp.getSpaceAddress(receipt)
+        const space2Address = spaceDapp.getSpaceAddress(receipt, provider.wallet.address)
         expect(space2Address).toBeDefined()
         const space2Id = makeSpaceStreamId(space2Address!)
         await spaceDapp.joinSpace(space2Id, aliceClient.userId, provider.wallet)
@@ -198,7 +198,7 @@ describe('mediaWithEntitlements', () => {
 
         const receipt = await transaction.wait()
         log('transaction receipt', receipt)
-        const spaceAddress = spaceDapp.getSpaceAddress(receipt)
+        const spaceAddress = spaceDapp.getSpaceAddress(receipt, provider.wallet.address)
         expect(spaceAddress).toBeDefined()
         const spaceStreamId = makeSpaceStreamId(spaceAddress!)
         await bobClient.initializeUser({ spaceId: spaceStreamId })

--- a/packages/sdk/src/membershipManagement.test.ts
+++ b/packages/sdk/src/membershipManagement.test.ts
@@ -82,7 +82,7 @@ describe('membershipManagement', () => {
         const receipt = await transaction.wait()
         log('transaction receipt')
         expect(receipt.status).toEqual(1)
-        const spaceAddress = spaceDapp.getSpaceAddress(receipt)
+        const spaceAddress = spaceDapp.getSpaceAddress(receipt, bobProvider.wallet.address)
         expect(spaceAddress).toBeDefined()
         const spaceId = makeSpaceStreamId(spaceAddress!)
         expect(isValidStreamId(spaceId)).toBe(true)

--- a/packages/sdk/src/spaceDapp.test.ts
+++ b/packages/sdk/src/spaceDapp.test.ts
@@ -32,7 +32,7 @@ describe('spaceDappTests', () => {
             baseProvider.signer,
         )
         const receipt = await tx.wait()
-        const spaceAddress = spaceDapp.getSpaceAddress(receipt)
+        const spaceAddress = spaceDapp.getSpaceAddress(receipt, baseProvider.wallet.address)
         if (!spaceAddress) {
             throw new Error('Space address not found')
         }

--- a/packages/sdk/src/sync-agent/spaces/spaces.ts
+++ b/packages/sdk/src/sync-agent/spaces/spaces.ts
@@ -100,7 +100,7 @@ export class Spaces extends PersistedObservable<SpacesModel> {
         )
         const receipt = await transaction.wait()
         logger.log('transaction receipt', receipt)
-        const spaceAddress = this.spaceDapp.getSpaceAddress(receipt)
+        const spaceAddress = this.spaceDapp.getSpaceAddress(receipt, await signer.getAddress())
         if (!spaceAddress) {
             throw new Error('Space address not found')
         }

--- a/packages/sdk/src/util.test.ts
+++ b/packages/sdk/src/util.test.ts
@@ -446,7 +446,7 @@ export async function createSpaceAndDefaultChannel(
     )
     const receipt = await transaction.wait()
     expect(receipt.status).toEqual(1)
-    const spaceAddress = spaceDapp.getSpaceAddress(receipt)
+    const spaceAddress = spaceDapp.getSpaceAddress(receipt, wallet.address)
     expect(spaceAddress).toBeDefined()
 
     const spaceId = makeSpaceStreamId(spaceAddress!)
@@ -600,7 +600,7 @@ export async function createUserStreamAndSyncClient(
     const transaction = await createVersionedSpace(spaceDapp, createSpaceParams, wallet)
     const receipt = await transaction.wait()
     expect(receipt.status).toEqual(1)
-    const spaceAddress = spaceDapp.getSpaceAddress(receipt)
+    const spaceAddress = spaceDapp.getSpaceAddress(receipt, wallet.address)
     expect(spaceAddress).toBeDefined()
 
     const spaceId = makeSpaceStreamId(spaceAddress!)

--- a/packages/sdk/src/withEntitlements.test.ts
+++ b/packages/sdk/src/withEntitlements.test.ts
@@ -90,7 +90,7 @@ describe('withEntitlements', () => {
         const receipt = await transaction.wait()
         log('transaction receipt', receipt)
         expect(receipt.status).toEqual(1)
-        const spaceAddress = spaceDapp.getSpaceAddress(receipt)
+        const spaceAddress = spaceDapp.getSpaceAddress(receipt, bobProvider.wallet.address)
         expect(spaceAddress).toBeDefined()
         const spaceId = makeSpaceStreamId(spaceAddress!)
         expect(isValidStreamId(spaceId)).toBe(true)

--- a/packages/stream-metadata/tests/integration/spaceMemberMetadata.test.ts
+++ b/packages/stream-metadata/tests/integration/spaceMemberMetadata.test.ts
@@ -49,7 +49,7 @@ describe('integration/space/:spaceAddress/token/:tokenId', () => {
 		const receipt = await tx.wait()
 		expect(receipt.status).toBe(1)
 
-		const spaceAddress = spaceDapp.getSpaceAddress(receipt)
+		const spaceAddress = spaceDapp.getSpaceAddress(receipt, provider.wallet.address)
 		expect(spaceAddress).toBeDefined()
 		const spaceStreamId = await bobsClient.createSpace(spaceAddress!)
 		expect(spaceStreamId).toBeDefined()

--- a/packages/stream-metadata/tests/integration/spaceMetadata.test.ts
+++ b/packages/stream-metadata/tests/integration/spaceMetadata.test.ts
@@ -60,7 +60,7 @@ describe('integration/space/:spaceAddress', () => {
 		const receipt = await tx.wait()
 		expect(receipt.status).toBe(1)
 
-		const spaceAddress = spaceDapp.getSpaceAddress(receipt)
+		const spaceAddress = spaceDapp.getSpaceAddress(receipt, provider.wallet.address)
 		expect(spaceAddress).toBeDefined()
 		if (!spaceAddress) {
 			throw new Error('spaceAddress is undefined')
@@ -114,7 +114,7 @@ describe('integration/space/:spaceAddress', () => {
 		const receipt = await tx.wait()
 		expect(receipt.status).toBe(1)
 
-		const spaceAddress = spaceDapp.getSpaceAddress(receipt)
+		const spaceAddress = spaceDapp.getSpaceAddress(receipt, provider.wallet.address)
 		expect(spaceAddress).toBeDefined()
 		if (!spaceAddress) {
 			throw new Error('spaceAddress is undefined')

--- a/packages/web3/src/ISpaceDapp.ts
+++ b/packages/web3/src/ISpaceDapp.ts
@@ -307,7 +307,7 @@ export interface ISpaceDapp {
     getMembershipSupply: (spaceId: string) => Promise<TotalSupplyInfo>
     getMembershipInfo: (spaceId: string) => Promise<MembershipInfo>
     getWalletLink: () => WalletLinkV3
-    getSpaceAddress: (receipt: ContractReceipt) => string | undefined
+    getSpaceAddress: (receipt: ContractReceipt, senderAddress: string) => string | undefined
     listPricingModules: () => Promise<PricingModuleStruct[]>
     setMembershipPrice: (
         spaceId: string,

--- a/packages/web3/src/v3/ISpaceArchitectShim.ts
+++ b/packages/web3/src/v3/ISpaceArchitectShim.ts
@@ -7,9 +7,48 @@ import LocalhostAbi from '@river-build/generated/dev/abis/Architect.abi.json' as
 
 import { ethers } from 'ethers'
 import { BaseContractShim } from './BaseContractShim'
+import { LogDescription } from 'ethers/lib/utils'
+import { dlogger } from '@river-build/dlog'
+const logger = dlogger('csb:SpaceDapp:debug')
 
 export class ISpaceArchitectShim extends BaseContractShim<LocalhostContract, LocalhostInterface> {
     constructor(address: string, provider: ethers.providers.Provider | undefined) {
         super(address, provider, LocalhostAbi)
+    }
+
+    public getSpaceAddressFromLog(log: ethers.providers.Log, userId: string) {
+        let spaceAddress: string | undefined
+
+        try {
+            const parsedLog = this.parseLog(log)
+            if (
+                isSpaceCreatedLog(parsedLog) &&
+                parsedLog.args.owner.toLowerCase() === userId.toLowerCase()
+            ) {
+                logger.log(`Event ${parsedLog.name} found: `, parsedLog.args)
+                spaceAddress = parsedLog.args.space
+            }
+        } catch (error) {
+            // This log wasn't from the contract we're interested in
+        }
+        return spaceAddress
+    }
+}
+
+function isSpaceCreatedLog(log: ethers.utils.LogDescription): log is SpaceCreatedLog {
+    const { name, args } = log
+    return name === 'SpaceCreated' && 'owner' in args && 'space' in args && 'tokenId' in args
+}
+
+class SpaceCreatedLog extends LogDescription {
+    readonly args: [] & {
+        owner: string
+        space: string
+        tokenId: string
+    }
+    constructor(log: LogDescription) {
+        super(log)
+        this.args = [] as any
+        Object.assign(this.args, ...log.args)
     }
 }

--- a/packages/web3/src/v3/SpaceDapp.ts
+++ b/packages/web3/src/v3/SpaceDapp.ts
@@ -1589,23 +1589,23 @@ export class SpaceDapp implements ISpaceDapp {
         )
     }
 
-    public getSpaceAddress(receipt: ContractReceipt): string | undefined {
-        const eventName = 'SpaceCreated'
+    /**
+     * Get the space address from the receipt and sender address
+     * @param receipt - The receipt from the transaction
+     * @param senderAddress - The address of the sender. Required for the case of a receipt containing multiple events of the same type.
+     * @returns The space address or undefined if the receipt is not successful
+     */
+    public getSpaceAddress(receipt: ContractReceipt, senderAddress: string): string | undefined {
         if (receipt.status !== 1) {
             return undefined
         }
         for (const receiptLog of receipt.logs) {
-            try {
-                // Parse the log with the contract interface
-                const parsedLog = this.spaceRegistrar.SpaceArchitect.interface.parseLog(receiptLog)
-                if (parsedLog.name === eventName) {
-                    // If the log matches the event we're looking for, do something with it
-                    // parsedLog.args contains the event arguments as an object
-                    logger.log(`Event ${eventName} found: `, parsedLog.args)
-                    return parsedLog.args.space as string
-                }
-            } catch (error) {
-                // This log wasn't from the contract we're interested in
+            const spaceAddress = this.spaceRegistrar.SpaceArchitect.getSpaceAddressFromLog(
+                receiptLog,
+                senderAddress,
+            )
+            if (spaceAddress) {
+                return spaceAddress
             }
         }
         return undefined


### PR DESCRIPTION
There could be multiple SpaceCreated events in a single tx if you are using 4337, passing the sender to correctly match.