### PR TITLE
Attempt to fix flaky wait for membership tests

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1771,8 +1771,8 @@ export class Client
 
         if (opts?.skipWaitForUserStreamUpdate !== true) {
             if (!userStream.view.userContent.isJoined(streamIdStr)) {
-                await userStream.waitFor('userStreamMembershipChanged', (streamId) =>
-                    userStream.view.userContent.isJoined(streamId),
+                await userStream.waitFor('userStreamMembershipChanged', () =>
+                    userStream.view.userContent.isJoined(streamIdStr),
                 )
             }
         }


### PR DESCRIPTION
we have this nasty flaky test that happens very regularly now https://github.com/river-build/river/actions/runs/11509558048/job/32039872496?pr=1350

[Error: waitFor timeout waiting for streamMembershipUpdated]

It always seems to affect the spaceWithV2Entitlements, but i’ve seen it elsewhere, its actually been around since i first wrote these tests.

I have two theories:

1. the stream is getting initialized and updated before we add a listener to streamMembership updated
2. the stream is getting re-initialized while we are listening to a membership changed event, and the new state has the membership already set, so it doesn’t fire a new event

This Fix:

1. in waitFor, always pass a condition, check the condition before adding any listeners
2. in waitFor, also listen to the streamInitialized event, re-run the check after stream initialized

:fingers_crossed: