### PR TITLE
GetStream/InitStream improvements

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -56,7 +56,7 @@ import {
     makeSessionKeys,
     type EncryptionDeviceInitOpts,
 } from '@river-build/encryption'
-import { StreamRpcClient } from './makeStreamRpcClient'
+import { getMaxTimeoutMs, StreamRpcClient } from './makeStreamRpcClient'
 import { errorContains, getRpcErrorProperty } from './rpcInterceptors'
 import { assert, isDefined } from './check'
 import EventEmitter from 'events'
@@ -568,7 +568,7 @@ export class Client
                 await this.streams.addStreamToSync(stream.view.syncCookie)
             }
         } catch (err) {
-            this.logError('Failed to initialize stream', streamId)
+            this.logError('Failed to create stream', streamId)
             this.streams.delete(streamId)
             this.creatingStreamIds.delete(streamId)
             throw err
@@ -1121,7 +1121,7 @@ export class Client
         opts?: { timeoutMs?: number; logId?: string },
     ): Promise<Stream> {
         this.logCall('waitForStream', inStreamId)
-        const timeoutMs = opts?.timeoutMs ?? 15000
+        const timeoutMs = opts?.timeoutMs ?? getMaxTimeoutMs(this.rpcClient.opts)
         const streamId = streamIdAsString(inStreamId)
         let stream = this.stream(streamId)
         if (stream !== undefined && stream.view.isInitialized) {
@@ -1299,9 +1299,9 @@ export class Client
                     // We need to remove the stream from syncedStreams, since we added it above
                     this.streams.delete(streamId)
                     throw new Error(
-                        `Failed to initialize stream ${streamIdAsString(
+                        `Failed to initialize stream from persistence ${streamIdAsString(
                             streamId,
-                        )} from persistence`,
+                        )}`,
                     )
                 }
 
@@ -1316,8 +1316,9 @@ export class Client
                         await this.streams.addStreamToSync(stream.view.syncCookie)
                     }
                 } catch (err) {
-                    this.logError('Failed to initialize stream', streamId)
+                    this.logError('Failed to initialize stream', streamId, err)
                     this.streams.delete(streamId)
+                    throw err
                 }
                 return stream
             }

--- a/packages/sdk/src/makeStreamRpcClient.ts
+++ b/packages/sdk/src/makeStreamRpcClient.ts
@@ -3,12 +3,25 @@ import { ConnectTransportOptions, createConnectTransport } from '@connectrpc/con
 import { StreamService } from '@river-build/proto'
 import { dlog } from '@river-build/dlog'
 import { getEnvVar, randomUrlSelector } from './utils'
-import { loggingInterceptor, retryInterceptor, type RetryParams } from './rpcInterceptors'
+import {
+    getRetryDelayMs,
+    loggingInterceptor,
+    retryInterceptor,
+    type RetryParams,
+} from './rpcInterceptors'
 
 const logInfo = dlog('csb:rpc:info')
 let nextRpcClientNum = 0
 
-export type StreamRpcClient = PromiseClient<typeof StreamService> & { url?: string }
+export interface StreamRpcClientOptions {
+    retryParams: RetryParams
+    defaultTimeoutMs?: number
+}
+
+export type StreamRpcClient = PromiseClient<typeof StreamService> & {
+    url: string
+    opts: StreamRpcClientOptions
+}
 export type MakeRpcClientType = typeof makeStreamRpcClient
 
 export function makeStreamRpcClient(
@@ -45,5 +58,14 @@ export function makeStreamRpcClient(
 
     const client: StreamRpcClient = createPromiseClient(StreamService, transport) as StreamRpcClient
     client.url = url
+    client.opts = { retryParams, defaultTimeoutMs }
     return client
+}
+
+export function getMaxTimeoutMs(opts: StreamRpcClientOptions): number {
+    let maxTimeoutMs = 0
+    for (let i = 1; i <= opts.retryParams.maxAttempts; i++) {
+        maxTimeoutMs += opts.defaultTimeoutMs ?? 0 + getRetryDelayMs(i, opts.retryParams)
+    }
+    return maxTimeoutMs
 }

--- a/packages/sdk/src/rpcInterceptors.ts
+++ b/packages/sdk/src/rpcInterceptors.ts
@@ -337,6 +337,8 @@ function getRetryDelay(error: unknown, attempts: number, retryParams: RetryParam
             return retryDelay
         } else if (errorContains(error, Err.DB_OPERATION_FAILURE)) {
             return retryDelay
+        } else if (errorContains(error, Err.DEADLINE_EXCEEDED)) {
+            return retryDelay
         }
     }
 

--- a/packages/sdk/src/rpcInterceptors.ts
+++ b/packages/sdk/src/rpcInterceptors.ts
@@ -301,16 +301,21 @@ export function getRpcErrorProperty(err: unknown, prop: string): string | undefi
     return undefined
 }
 
+export function getRetryDelayMs(attempts: number, retryParams: RetryParams): number {
+    return Math.min(
+        retryParams.maxRetryDelay,
+        retryParams.initialRetryDelay * Math.pow(2, attempts),
+    )
+}
+
 function getRetryDelay(error: unknown, attempts: number, retryParams: RetryParams): number {
     check(attempts >= 1, 'attempts must be >= 1')
     // aellis wondering if we should retry forever if there's no internet connection
     if (attempts > retryParams.maxAttempts) {
         return -1 // no more attempts
     }
-    const retryDelay = Math.min(
-        retryParams.maxRetryDelay,
-        retryParams.initialRetryDelay * Math.pow(2, attempts),
-    )
+    const retryDelay = getRetryDelayMs(attempts, retryParams)
+
     // we don't get a lot of info off of these errors... retry the ones that we know we need to
     if (error !== null && typeof error === 'object') {
         if ('message' in error) {
@@ -334,5 +339,17 @@ function getRetryDelay(error: unknown, attempts: number, retryParams: RetryParam
             return retryDelay
         }
     }
+
+    if (isIConnectError(error)) {
+        if (
+            error.code === (Code.DeadlineExceeded as number) ||
+            error.code === (Code.Unavailable as number) ||
+            error.code === (Code.ResourceExhausted as number)
+        ) {
+            // handle deadline_exceeded errors
+            return retryDelay
+        }
+    }
+
     return -1
 }

--- a/packages/stress/src/utils/rpc-http2.ts
+++ b/packages/stress/src/utils/rpc-http2.ts
@@ -5,10 +5,14 @@ import {
     loggingInterceptor,
     randomUrlSelector,
     retryInterceptor,
+    StreamRpcClientOptions,
     type RetryParams,
 } from '@river-build/sdk'
 
-export type StreamRpcClient = PromiseClient<typeof StreamService> & { url?: string }
+export type StreamHttp2RpcClient = PromiseClient<typeof StreamService> & {
+    url: string
+    opts: StreamRpcClientOptions
+}
 
 let nextRpcClientNum = 0
 
@@ -16,7 +20,7 @@ export function makeHttp2StreamRpcClient(
     urls: string,
     retryParams: RetryParams = { maxAttempts: 3, initialRetryDelay: 2000, maxRetryDelay: 6000 },
     refreshNodeUrl?: () => Promise<string>,
-): StreamRpcClient {
+): StreamHttp2RpcClient {
     const transportId = nextRpcClientNum++
     const url = randomUrlSelector(urls)
     const options: ConnectTransportOptions = {
@@ -26,7 +30,7 @@ export function makeHttp2StreamRpcClient(
             loggingInterceptor(transportId),
             retryInterceptor({ ...retryParams, refreshNodeUrl }),
         ],
-        defaultTimeoutMs: 30000,
+        defaultTimeoutMs: 20000,
     }
     if (!process.env.RIVER_DEBUG_TRANSPORT) {
         options.useBinaryFormat = true
@@ -39,7 +43,11 @@ export function makeHttp2StreamRpcClient(
     }
     const transport = createConnectTransport(options)
 
-    const client: StreamRpcClient = createPromiseClient(StreamService, transport) as StreamRpcClient
+    const client: StreamHttp2RpcClient = createPromiseClient(
+        StreamService,
+        transport,
+    ) as StreamHttp2RpcClient
     client.url = url
+    client.opts = { retryParams, defaultTimeoutMs: options.defaultTimeoutMs }
     return client
 }

--- a/packages/stress/src/utils/rpc-http2.ts
+++ b/packages/stress/src/utils/rpc-http2.ts
@@ -1,18 +1,13 @@
-import { PromiseClient, createPromiseClient } from '@connectrpc/connect'
+import { createPromiseClient } from '@connectrpc/connect'
 import { ConnectTransportOptions, createConnectTransport } from '@connectrpc/connect-node'
 import { StreamService } from '@river-build/proto'
 import {
     loggingInterceptor,
     randomUrlSelector,
     retryInterceptor,
-    StreamRpcClientOptions,
+    StreamRpcClient,
     type RetryParams,
 } from '@river-build/sdk'
-
-export type StreamHttp2RpcClient = PromiseClient<typeof StreamService> & {
-    url: string
-    opts: StreamRpcClientOptions
-}
 
 let nextRpcClientNum = 0
 
@@ -20,7 +15,7 @@ export function makeHttp2StreamRpcClient(
     urls: string,
     retryParams: RetryParams = { maxAttempts: 3, initialRetryDelay: 2000, maxRetryDelay: 6000 },
     refreshNodeUrl?: () => Promise<string>,
-): StreamHttp2RpcClient {
+): StreamRpcClient {
     const transportId = nextRpcClientNum++
     const url = randomUrlSelector(urls)
     const options: ConnectTransportOptions = {
@@ -43,10 +38,7 @@ export function makeHttp2StreamRpcClient(
     }
     const transport = createConnectTransport(options)
 
-    const client: StreamHttp2RpcClient = createPromiseClient(
-        StreamService,
-        transport,
-    ) as StreamHttp2RpcClient
+    const client = createPromiseClient(StreamService, transport) as StreamRpcClient
     client.url = url
     client.opts = { retryParams, defaultTimeoutMs: options.defaultTimeoutMs }
     return client


### PR DESCRIPTION
1. fix up logs so they are easier to differentiate
2. Throw the error when a stream fails to fetch from the rpc client. Otherwise we are left in a very bad state where we returned a stream that is not registered in any way. This will cause serious issues (like trying to wait for an event that never comes)
3. Retry deadline_exceeded errors
4. use the rpc default timeout for the wait for timeouts

seeing tons of these in the stress tests now that we have timeouts on gamma
```
_ConnectError: [deadline_exceeded] the operation timed out
    at Timeout.listener (/monorepo/node_modules/@connectrpc/connect/dist/esm/protocol/signals.js:62:26)
    at listOnTimeout (node:internal/timers:581:17)
    at process.processTimers (node:internal/timers:519:7) {
  rawMessage: 'the operation timed out',
  code: 4,
  metadata: Headers {},
  details: [],
  cause: undefined
}
```