### PR TITLE
Switch local deployments to use serializable isolation level and retry txns on deadlock

### DIFF
--- a/core/env/local/common/common.yaml
+++ b/core/env/local/common/common.yaml
@@ -2,7 +2,7 @@
 
 database:
     url: postgres://postgres:postgres@localhost:5433/river?sslmode=disable&pool_max_conns=50
-    isolationLevel: 'read committed'
+    isolationLevel: 'serializable'
 
 # Certificates for TLS
 TLSConfig:

--- a/core/node/storage/pg_storage.go
+++ b/core/node/storage/pg_storage.go
@@ -122,7 +122,7 @@ func (s *PostgresEventStore) txRunner(
 			pass := false
 
 			if pgErr, ok := err.(*pgconn.PgError); ok {
-				if pgErr.Code == pgerrcode.SerializationFailure {
+				if pgErr.Code == pgerrcode.SerializationFailure || pgErr.Code == pgerrcode.DeadlockDetected {
 					backoffErr := backoff.wait(ctx)
 					if backoffErr != nil {
 						return AsRiverError(backoffErr).Func(name).Message("Timed out waiting for backoff")


### PR DESCRIPTION
Deadlocks typically occur at read committed isolation level, at serializable they would manifest as serialization errors, which we already retry on. However we do plan to move back to read committed in the near future, and should retry on these anyway.

revert to serializable isolation level until we take row locks on es table for stream operations.

Note this PR only updates isolation level for local deployments, alpha / gamma / omega will need to be handled separately.