### PR TITLE
react-sdk: runtime check streamId instead of union type

### DIFF
--- a/packages/playground/src/components/blocks/timeline.tsx
+++ b/packages/playground/src/components/blocks/timeline.tsx
@@ -2,17 +2,17 @@ import { getRoom, useMember, useSendMessage, useSyncAgent } from '@river-build/r
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
-import type { TimelineEvent } from '@river-build/sdk'
+import { type TimelineEvent, isChannelStreamId, spaceIdFromChannelId } from '@river-build/sdk'
 import { useMemo } from 'react'
-import { type RiverRoom } from '@river-build/react-sdk'
 import { cn } from '@/utils'
 import { Form, FormControl, FormField, FormItem, FormMessage } from '../ui/form'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { ScrollArea } from '../ui/scroll-area'
 
-type TimelineProps = RiverRoom & {
+type TimelineProps = {
     events: TimelineEvent[]
+    streamId: string
 }
 
 export const Timeline = (props: TimelineProps) => {
@@ -21,11 +21,11 @@ export const Timeline = (props: TimelineProps) => {
             <ScrollArea className="h-[calc(100dvh-172px)]">
                 <div className="flex flex-col gap-1.5">
                     {props.events.map((event) => (
-                        <Message key={event.eventId} {...props} event={event} />
+                        <Message key={event.eventId} streamId={props.streamId} event={event} />
                     ))}
                 </div>
             </ScrollArea>
-            <SendMessage {...props} />
+            <SendMessage streamId={props.streamId} />
         </div>
     )
 }
@@ -34,8 +34,8 @@ const formSchema = z.object({
     message: z.string(),
 })
 
-export const SendMessage = (props: RiverRoom) => {
-    const { sendMessage, isPending } = useSendMessage(props)
+export const SendMessage = ({ streamId }: { streamId: string }) => {
+    const { sendMessage, isPending } = useSendMessage(streamId)
     const form = useForm<z.infer<typeof formSchema>>({
         resolver: zodResolver(formSchema),
         defaultValues: { message: '' },
@@ -66,15 +66,17 @@ export const SendMessage = (props: RiverRoom) => {
     )
 }
 
-const Message = ({ event, ...props }: { event: TimelineEvent } & RiverRoom) => {
+const Message = ({ event, streamId }: { event: TimelineEvent; streamId: string }) => {
     const sync = useSyncAgent()
+    const preferSpaceMember = isChannelStreamId(streamId)
+        ? spaceIdFromChannelId(streamId)
+        : streamId
     const member = useMemo(
-        () => getRoom(sync, props).members.get(event.creatorUserId),
-        [props, sync, event.creatorUserId],
+        () => getRoom(sync, preferSpaceMember).members.get(event.creatorUserId),
+        [sync, preferSpaceMember, event.creatorUserId],
     )
     const { username, displayName } = useMember(member)
     const prettyDisplayName = displayName || username
-
     return (
         <div className="flex gap-1">
             {prettyDisplayName && (

--- a/packages/playground/src/routes/m/dm-timeline.tsx
+++ b/packages/playground/src/routes/m/dm-timeline.tsx
@@ -11,7 +11,7 @@ export const DmTimelineRoute = () => {
             <h2 className="text-2xl font-bold">
                 Direct Message Timeline {dm.metadata?.name ? `#${dm.metadata.name}` : ''}
             </h2>
-            <Timeline events={timeline} type="dm" streamId={dmStreamId!} />
+            <Timeline events={timeline} streamId={dmStreamId!} />
         </>
     )
 }

--- a/packages/playground/src/routes/m/gdm-timeline.tsx
+++ b/packages/playground/src/routes/m/gdm-timeline.tsx
@@ -11,7 +11,7 @@ export const GdmTimelineRoute = () => {
             <h2 className="text-2xl font-bold">
                 Group Chat Timeline {gdm.metadata?.name ? `#${gdm.metadata.name}` : ''}
             </h2>
-            <Timeline events={timeline} type="gdm" streamId={gdmStreamId!} />
+            <Timeline events={timeline} streamId={gdmStreamId!} />
         </>
     )
 }

--- a/packages/playground/src/routes/t/channel-timeline.tsx
+++ b/packages/playground/src/routes/t/channel-timeline.tsx
@@ -14,7 +14,7 @@ export const ChannelTimelineRoute = () => {
             <h2 className="text-2xl font-bold">
                 Channel Timeline {channel.metadata?.name ? `#${channel.metadata.name}` : ''}
             </h2>
-            <Timeline events={timeline} type="channel" spaceId={spaceId} channelId={channelId!} />
+            <Timeline events={timeline} streamId={channelId!} />
         </ChannelProvider>
     )
 }

--- a/packages/react-sdk/src/useSendMessage.ts
+++ b/packages/react-sdk/src/useSendMessage.ts
@@ -1,19 +1,20 @@
 'use client'
 
-import type { Channel, Gdm } from '@river-build/sdk'
+import { type Channel, Space, assert } from '@river-build/sdk'
 import { useMemo } from 'react'
 import { type ActionConfig, useAction } from './internals/useAction'
 import { useSyncAgent } from './useSyncAgent'
-import { type RiverRoom, getRoom } from './utils'
+import { getRoom } from './utils'
 
 export const useSendMessage = (
-    props: RiverRoom,
-    config?: (typeof props)['type'] extends 'gdm'
-        ? ActionConfig<Gdm['sendMessage']>
-        : ActionConfig<Channel['sendMessage']>,
+    streamId: string,
+    // TODO: now that we're using runtime check for room type, Gdm/Dm will have the same config as Channel.
+    // Its not a problem, both should be the same, but we need more abstractions around this on the SyncAgent
+    config?: ActionConfig<Channel['sendMessage']>,
 ) => {
     const sync = useSyncAgent()
-    const room = useMemo(() => getRoom(sync, props), [props, sync])
+    const room = useMemo(() => getRoom(sync, streamId), [streamId, sync])
+    assert(!(room instanceof Space), 'room cant be a space')
     const { action: sendMessage, ...rest } = useAction(room, 'sendMessage', config)
 
     return {

--- a/packages/react-sdk/src/utils.ts
+++ b/packages/react-sdk/src/utils.ts
@@ -1,4 +1,16 @@
-import type { Channel, Dm, Gdm, PersistedModel, SyncAgent } from '@river-build/sdk'
+import {
+    type Channel,
+    type Dm,
+    type Gdm,
+    type PersistedModel,
+    Space,
+    type SyncAgent,
+    isChannelStreamId,
+    isDMChannelStreamId,
+    isGDMChannelStreamId,
+    isSpaceStreamId,
+    spaceIdFromChannelId,
+} from '@river-build/sdk'
 
 export const isPersistedModel = <T>(value: T | PersistedModel<T>): value is PersistedModel<T> => {
     if (typeof value !== 'object') {
@@ -10,28 +22,18 @@ export const isPersistedModel = <T>(value: T | PersistedModel<T>): value is Pers
     return 'status' in value && 'data' in value
 }
 
-export type RiverRoom =
-    | {
-          type: 'gdm'
-          streamId: string
-      }
-    | {
-          type: 'channel'
-          spaceId: string
-          channelId: string
-      }
-    | {
-          type: 'dm'
-          streamId: string
-      }
-
-export const getRoom = (sync: SyncAgent, props: RiverRoom): Gdm | Channel | Dm => {
-    if (props.type === 'gdm') {
-        return sync.gdms.getGdm(props.streamId)
-    } else if (props.type === 'channel') {
-        return sync.spaces.getSpace(props.spaceId).getChannel(props.channelId)
-    } else if (props.type === 'dm') {
-        return sync.dms.getDm(props.streamId)
+export const getRoom = (sync: SyncAgent, streamId: string): Gdm | Channel | Dm | Space => {
+    if (isChannelStreamId(streamId)) {
+        return sync.spaces.getSpace(spaceIdFromChannelId(streamId)).getChannel(streamId)
+    }
+    if (isGDMChannelStreamId(streamId)) {
+        return sync.gdms.getGdm(streamId)
+    }
+    if (isDMChannelStreamId(streamId)) {
+        return sync.dms.getDm(streamId)
+    }
+    if (isSpaceStreamId(streamId)) {
+        return sync.spaces.getSpace(streamId)
     }
     throw new Error('Invalid room type')
 }


### PR DESCRIPTION
It was getting confusing and not ergonomic to work with union types on the UI everytime, every new change was touching this and just making it more complex.