### PR TITLE
DApp: nit UpdateChannel types

### DIFF
--- a/packages/web3/src/ContractTypes.ts
+++ b/packages/web3/src/ContractTypes.ts
@@ -16,7 +16,7 @@ import {
     CreateSpaceParams,
     CreateLegacySpaceParams,
     UpdateChannelParams,
-    UpdateChannelStatusParams,
+    UpdateChannelAccessParams,
 } from './ISpaceDapp'
 
 export const Permission = {
@@ -184,7 +184,7 @@ export function isRuleEntitlementV2(
 
 export const isUpdateChannelStatusParams = (
     params: UpdateChannelParams,
-): params is UpdateChannelStatusParams => {
+): params is UpdateChannelAccessParams => {
     return (
         'disabled' in params &&
         !('roleIds' in params || 'channelName' in params || 'channelDescription' in params)

--- a/packages/web3/src/ISpaceDapp.ts
+++ b/packages/web3/src/ISpaceDapp.ts
@@ -56,13 +56,13 @@ export interface UpdateChannelMetadataParams {
     disabled?: boolean
 }
 
-export interface UpdateChannelStatusParams {
+export interface UpdateChannelAccessParams {
     spaceId: string
     channelId: string
     disabled: boolean
 }
 
-export type UpdateChannelParams = UpdateChannelMetadataParams | UpdateChannelStatusParams
+export type UpdateChannelParams = UpdateChannelMetadataParams | UpdateChannelAccessParams
 
 export interface RemoveChannelParams {
     spaceId: string
@@ -242,7 +242,7 @@ export interface ISpaceDapp {
         logs: ethers.providers.Log[],
     ) => Promise<(ethers.utils.LogDescription | undefined)[]>
     updateChannel: (
-        params: UpdateChannelMetadataParams,
+        params: UpdateChannelParams,
         signer: SignerType,
         txnOpts?: TransactionOpts,
     ) => Promise<TransactionType>


### PR DESCRIPTION
- enable passing `UpdateChannelAccessParams` to `updateChannel` transaction (i.e. omitting roleIds)
- rename Status -> Access