### PR TITLE
fix(contract): add owner address to `RewardsDistribution` events

### DIFF
--- a/contracts/src/base/registry/facets/distribution/v2/IRewardsDistribution.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/IRewardsDistribution.sol
@@ -70,14 +70,16 @@ interface IRewardsDistributionBase {
   event RewardNotifierSet(address indexed notifier, bool enabled);
 
   /// @notice Emitted when a deposit is staked
-  /// @param depositId The ID of the deposit
+  /// @param owner The address of the depositor
   /// @param delegatee The address of the delegatee
   /// @param beneficiary The address of the beneficiary
+  /// @param depositId The ID of the deposit
   /// @param amount The amount of stakeToken that is staked
   event Stake(
-    uint256 indexed depositId,
+    address indexed owner,
     address indexed delegatee,
     address indexed beneficiary,
+    uint256 depositId,
     uint96 amount
   );
 
@@ -100,9 +102,14 @@ interface IRewardsDistributionBase {
   );
 
   /// @notice Emitted when the withdrawal of a deposit is initiated
+  /// @param owner The address of the depositor
   /// @param depositId The ID of the deposit
   /// @param amount The amount of stakeToken that will be withdrawn
-  event InitiateWithdraw(uint256 indexed depositId, uint96 amount);
+  event InitiateWithdraw(
+    address indexed owner,
+    uint256 indexed depositId,
+    uint96 amount
+  );
 
   /// @notice Emitted when the stakeToken is withdrawn from a deposit
   /// @param depositId The ID of the deposit

--- a/contracts/src/base/registry/facets/distribution/v2/RewardsDistribution.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/RewardsDistribution.sol
@@ -272,7 +272,7 @@ contract RewardsDistribution is
 
     _sweepSpaceRewardsIfNecessary(delegatee);
 
-    emit InitiateWithdraw(depositId, amount);
+    emit InitiateWithdraw(owner, depositId, amount);
   }
 
   /// @inheritdoc IRewardsDistribution

--- a/contracts/src/base/registry/facets/distribution/v2/RewardsDistributionBase.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/RewardsDistributionBase.sol
@@ -56,7 +56,7 @@ abstract contract RewardsDistributionBase is IRewardsDistributionBase {
       ds.staking.stakeToken.safeTransferFrom(msg.sender, proxy, amount);
     }
 
-    emit Stake(depositId, delegatee, beneficiary, amount);
+    emit Stake(owner, delegatee, beneficiary, depositId, amount);
   }
 
   /// @dev Deploys a beacon proxy for the delegation


### PR DESCRIPTION
Updated events in `IRewardsDistribution` to include the owner address, ensuring more detailed event logging. Modified corresponding implementations and tests to reflect this change, improving traceability in contract interactions.