### PR TITLE
perf(contract): refactor `permit` call to use inline assembly

### DIFF
--- a/contracts/src/base/registry/facets/distribution/v2/IRewardsDistribution.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/IRewardsDistribution.sol
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
-// interfaces
-
-// libraries
 import {StakingRewards} from "./StakingRewards.sol";
-
-// contracts
 
 interface IRewardsDistributionBase {
   /// @notice The state of the staking rewards contract


### PR DESCRIPTION
Replace the try-catch block with inline assembly for the permit call to reduce gas costs and improve efficiency. The new approach directly uses the selector and memory allocation, removing unnecessary overhead.