### PR TITLE
fix(contract): add reward sweeping in `SpaceDelegationFacet`

### DIFF
--- a/contracts/scripts/deployments/facets/DeploySpaceDelegation.s.sol
+++ b/contracts/scripts/deployments/facets/DeploySpaceDelegation.s.sol
@@ -17,6 +17,7 @@ contract DeploySpaceDelegation is Deployer, FacetHelper {
     addSelector(SpaceDelegationFacet.getSpaceDelegation.selector);
     addSelector(SpaceDelegationFacet.getSpaceDelegationsByOperator.selector);
     addSelector(SpaceDelegationFacet.setRiverToken.selector);
+    addSelector(SpaceDelegationFacet.riverToken.selector);
     addSelector(SpaceDelegationFacet.getTotalDelegation.selector);
     addSelector(SpaceDelegationFacet.setMainnetDelegation.selector);
     addSelector(SpaceDelegationFacet.setSpaceFactory.selector);

--- a/contracts/src/base/registry/facets/delegation/SpaceDelegationFacet.sol
+++ b/contracts/src/base/registry/facets/delegation/SpaceDelegationFacet.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-
 import {ISpaceDelegation} from "contracts/src/base/registry/facets/delegation/ISpaceDelegation.sol";
 import {IMainnetDelegation} from "contracts/src/tokens/river/base/delegation/IMainnetDelegation.sol";
 import {IERC173} from "contracts/src/diamond/facets/ownable/IERC173.sol";

--- a/contracts/src/base/registry/facets/delegation/SpaceDelegationFacet.sol
+++ b/contracts/src/base/registry/facets/delegation/SpaceDelegationFacet.sol
@@ -215,8 +215,6 @@ contract SpaceDelegationFacet is
     address space,
     address currentOperator
   ) internal {
-    if (currentOperator == address(0)) return;
-
     StakingRewards.Layout storage staking = RewardsDistributionStorage
       .layout()
       .staking;
@@ -229,10 +227,12 @@ contract SpaceDelegationFacet is
     uint256 reward = spaceTreasure.unclaimedRewardSnapshot;
     if (reward == 0) return;
 
-    StakingRewards.Treasure storage operatorTreasure = staking
-      .treasureByBeneficiary[currentOperator];
-
-    operatorTreasure.unclaimedRewardSnapshot += reward;
+    // forfeit the rewards if the space has undelegated
+    if (currentOperator != address(0)) {
+      StakingRewards.Treasure storage operatorTreasure = staking
+        .treasureByBeneficiary[currentOperator];
+      operatorTreasure.unclaimedRewardSnapshot += reward;
+    }
     spaceTreasure.unclaimedRewardSnapshot = 0;
 
     emit SpaceRewardsSwept(space, currentOperator, reward);

--- a/contracts/src/base/registry/facets/distribution/v2/RewardsDistribution.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/RewardsDistribution.sol
@@ -304,7 +304,6 @@ contract RewardsDistribution is
   }
 
   /// @inheritdoc IRewardsDistribution
-  // TODO: transfer rewards when a space redelegates
   function claimReward(
     address beneficiary,
     address recipient

--- a/contracts/src/base/registry/facets/distribution/v2/RewardsDistributionBase.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/RewardsDistributionBase.sol
@@ -112,7 +112,8 @@ abstract contract RewardsDistributionBase is IRewardsDistributionBase {
   /// @dev Sweeps the rewards in the space delegation to the operator if necessary
   /// @dev Must be called after `StakingRewards.updateGlobalReward`
   function _sweepSpaceRewardsIfNecessary(address space) internal {
-    if (!_isSpace(space)) return;
+    address operator = _getOperatorBySpace(space);
+    if (operator == address(0)) return;
 
     StakingRewards.Layout storage staking = RewardsDistributionStorage
       .layout()
@@ -124,7 +125,6 @@ abstract contract RewardsDistributionBase is IRewardsDistributionBase {
     uint256 scaledReward = spaceTreasure.unclaimedRewardSnapshot;
     if (scaledReward == 0) return;
 
-    address operator = _getOperatorBySpace(space);
     StakingRewards.Treasure storage operatorTreasure = staking
       .treasureByBeneficiary[operator];
 

--- a/contracts/test/base/registry/BaseRegistry.t.sol
+++ b/contracts/test/base/registry/BaseRegistry.t.sol
@@ -342,4 +342,31 @@ abstract contract BaseRegistryTest is BaseSetup, IRewardsDistributionBase {
       "expected reward"
     );
   }
+
+  function verifySweep(
+    address space,
+    address operator,
+    uint256 amount,
+    uint256 commissionRate,
+    uint256 timeLapse
+  ) internal view {
+    StakingState memory state = rewardsDistributionFacet.stakingState();
+    StakingRewards.Treasure memory spaceTreasure = rewardsDistributionFacet
+      .treasureByBeneficiary(space);
+
+    assertEq(spaceTreasure.earningPower, (amount * commissionRate) / 10000);
+    assertEq(
+      spaceTreasure.rewardPerTokenAccumulated,
+      state.rewardPerTokenAccumulated
+    );
+    assertEq(spaceTreasure.unclaimedRewardSnapshot, 0);
+
+    assertEq(
+      rewardsDistributionFacet
+        .treasureByBeneficiary(operator)
+        .unclaimedRewardSnapshot,
+      spaceTreasure.earningPower *
+        state.rewardRate.fullMulDiv(timeLapse, state.totalStaked)
+    );
+  }
 }

--- a/contracts/test/base/registry/BaseRegistry.t.sol
+++ b/contracts/test/base/registry/BaseRegistry.t.sol
@@ -125,18 +125,18 @@ abstract contract BaseRegistryTest is BaseSetup, IRewardsDistributionBase {
   /*                           SPACE                            */
   /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
-  function deploySpace() internal returns (address _space) {
+  function deploySpace(address _deployer) internal returns (address _space) {
     IArchitectBase.SpaceInfo memory spaceInfo = _createSpaceInfo(
       string(abi.encode(_randomUint256()))
     );
     spaceInfo.membership.settings.pricingModule = pricingModule;
-    vm.prank(deployer);
+    vm.prank(_deployer);
     _space = ICreateSpace(spaceFactory).createSpace(spaceInfo);
     space = _space;
   }
 
   modifier givenSpaceIsDeployed() {
-    deploySpace();
+    deploySpace(deployer);
     _;
   }
 

--- a/contracts/test/base/registry/RewardsDistributionV2.t.sol
+++ b/contracts/test/base/registry/RewardsDistributionV2.t.sol
@@ -1076,7 +1076,7 @@ contract RewardsDistributionV2Test is
     bridgeTokensForUser(address(this), 1 ether * uint256(count));
     river.approve(address(rewardsDistributionFacet), type(uint256).max);
     for (uint256 i; i < count; ++i) {
-      address _space = deploySpace();
+      address _space = deploySpace(deployer);
       pointSpaceToOperator(_space, OPERATOR);
       rewardsDistributionFacet.stake(1 ether, _space, address(this));
     }

--- a/contracts/test/base/registry/SpaceDelegation.t.sol
+++ b/contracts/test/base/registry/SpaceDelegation.t.sol
@@ -7,6 +7,8 @@ import {ISpaceDelegationBase} from "contracts/src/base/registry/facets/delegatio
 
 // libraries
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
+import {StakingRewards} from "contracts/src/base/registry/facets/distribution/v2/StakingRewards.sol";
 
 // contracts
 import {SpaceDelegationFacet} from "contracts/src/base/registry/facets/delegation/SpaceDelegationFacet.sol";
@@ -18,6 +20,7 @@ contract SpaceDelegationTest is
   ISpaceDelegationBase
 {
   using EnumerableSet for EnumerableSet.AddressSet;
+  using FixedPointMathLib for uint256;
 
   SpaceDelegationFacet internal spaceDelegation;
   EnumerableSet.AddressSet internal spaceSet;
@@ -34,12 +37,30 @@ contract SpaceDelegationTest is
 
   function test_addSpaceDelegation_revertIf_invalidSpace() public {
     vm.expectRevert(SpaceDelegation__InvalidSpace.selector);
-    spaceDelegation.addSpaceDelegation(address(this), address(0));
+    spaceDelegation.addSpaceDelegation(address(this), OPERATOR);
+  }
+
+  function test_addSpaceDelegation_revertIf_alreadyDelegated() public {
+    space = deploySpace(deployer);
+    vm.prank(deployer);
+    spaceDelegation.addSpaceDelegation(space, OPERATOR);
+
+    vm.expectRevert(SpaceDelegation__AlreadyDelegated.selector);
+    vm.prank(deployer);
+    spaceDelegation.addSpaceDelegation(space, OPERATOR);
+  }
+
+  function test_addSpaceDelegation_revertIf_invalidOperator() public {
+    space = deploySpace(deployer);
+    vm.expectRevert(SpaceDelegation__InvalidOperator.selector);
+    vm.prank(deployer);
+    spaceDelegation.addSpaceDelegation(space, address(this));
   }
 
   function test_fuzz_addSpaceDelegation(
-    address operator
-  ) public givenOperator(operator, 0) returns (address space) {
+    address operator,
+    uint256 commissionRate
+  ) public givenOperator(operator, commissionRate) returns (address space) {
     space = deploySpace(deployer);
 
     vm.prank(deployer);
@@ -47,6 +68,64 @@ contract SpaceDelegationTest is
 
     address assignedOperator = spaceDelegation.getSpaceDelegation(space);
     assertEq(assignedOperator, operator, "Space delegation failed");
+  }
+
+  /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+  /*                     REPLACE DELEGATION                     */
+  /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+  function test_fuzz_addSpaceDelegation_replace(
+    address[2] memory operators,
+    uint256[2] memory commissionRates,
+    uint256 rewardAmount,
+    uint256 timeLapse
+  ) public givenOperator(operators[1], commissionRates[1]) {
+    vm.assume(operators[0] != operators[1]);
+    commissionRates[0] = bound(commissionRates[0], 1, 10000);
+    address space = test_fuzz_addSpaceDelegation(
+      operators[0],
+      commissionRates[0]
+    );
+
+    rewardAmount = boundReward(rewardAmount);
+    bridgeTokensForUser(address(rewardsDistributionFacet), rewardAmount);
+
+    vm.prank(NOTIFIER);
+    rewardsDistributionFacet.notifyRewardAmount(rewardAmount);
+
+    uint96 amount = 1 ether;
+    bridgeTokensForUser(address(this), amount);
+
+    river.approve(address(rewardsDistributionFacet), amount);
+    rewardsDistributionFacet.stake(amount, space, address(this));
+
+    timeLapse = bound(timeLapse, 1, rewardDuration);
+    vm.warp(block.timestamp + timeLapse);
+
+    vm.expectEmit(true, true, true, false, address(spaceDelegation));
+    emit SpaceRewardsSwept(space, operators[0], 0);
+
+    vm.prank(deployer);
+    spaceDelegation.addSpaceDelegation(space, operators[1]);
+
+    StakingState memory state = rewardsDistributionFacet.stakingState();
+    StakingRewards.Treasure memory spaceTreasure = rewardsDistributionFacet
+      .treasureByBeneficiary(space);
+
+    assertEq(spaceTreasure.earningPower, (amount * commissionRates[0]) / 10000);
+    assertEq(
+      spaceTreasure.rewardPerTokenAccumulated,
+      state.rewardPerTokenAccumulated
+    );
+    assertEq(spaceTreasure.unclaimedRewardSnapshot, 0);
+
+    assertEq(
+      rewardsDistributionFacet
+        .treasureByBeneficiary(operators[0])
+        .unclaimedRewardSnapshot,
+      spaceTreasure.earningPower *
+        state.rewardRate.fullMulDiv(timeLapse, state.totalStaked)
+    );
   }
 
   /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -58,10 +137,8 @@ contract SpaceDelegationTest is
     spaceDelegation.removeSpaceDelegation(address(0));
   }
 
-  function test_fuzz_removeSpaceDelegation(
-    address operator
-  ) public givenOperator(operator, 0) {
-    address space = test_fuzz_addSpaceDelegation(operator);
+  function test_fuzz_removeSpaceDelegation(address operator) public {
+    address space = test_fuzz_addSpaceDelegation(operator, 0);
 
     vm.prank(deployer);
     spaceDelegation.removeSpaceDelegation(space);
@@ -75,8 +152,8 @@ contract SpaceDelegationTest is
   /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
   function test_fuzz_getSpaceDelegationsByOperator(address operator) public {
-    address space1 = test_fuzz_addSpaceDelegation(operator);
-    address space2 = test_fuzz_addSpaceDelegation(operator);
+    address space1 = test_fuzz_addSpaceDelegation(operator, 0);
+    address space2 = test_fuzz_addSpaceDelegation(operator, 0);
 
     address[] memory spaces = spaceDelegation.getSpaceDelegationsByOperator(
       operator

--- a/contracts/test/base/registry/SpaceDelegation.t.sol
+++ b/contracts/test/base/registry/SpaceDelegation.t.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// interfaces
+import {IOwnableBase} from "contracts/src/diamond/facets/ownable/IERC173.sol";
+import {ISpaceDelegationBase} from "contracts/src/base/registry/facets/delegation/ISpaceDelegation.sol";
+
+// libraries
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
+// contracts
+import {SpaceDelegationFacet} from "contracts/src/base/registry/facets/delegation/SpaceDelegationFacet.sol";
+import {BaseRegistryTest} from "./BaseRegistry.t.sol";
+
+contract SpaceDelegationTest is
+  BaseRegistryTest,
+  IOwnableBase,
+  ISpaceDelegationBase
+{
+  using EnumerableSet for EnumerableSet.AddressSet;
+
+  SpaceDelegationFacet internal spaceDelegation;
+  EnumerableSet.AddressSet internal spaceSet;
+  EnumerableSet.AddressSet internal operatorSet;
+
+  function setUp() public override {
+    super.setUp();
+    spaceDelegation = SpaceDelegationFacet(baseRegistry);
+  }
+
+  /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+  /*                       ADD DELEGATION                       */
+  /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+  function test_addSpaceDelegation_revertIf_invalidSpace() public {
+    vm.expectRevert(SpaceDelegation__InvalidSpace.selector);
+    spaceDelegation.addSpaceDelegation(address(this), address(0));
+  }
+
+  function test_fuzz_addSpaceDelegation(
+    address operator
+  ) public givenOperator(operator, 0) returns (address space) {
+    space = deploySpace(deployer);
+
+    vm.prank(deployer);
+    spaceDelegation.addSpaceDelegation(space, operator);
+
+    address assignedOperator = spaceDelegation.getSpaceDelegation(space);
+    assertEq(assignedOperator, operator, "Space delegation failed");
+  }
+
+  /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+  /*                      REMOVE DELEGATION                     */
+  /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+  function test_removeSpaceDelegation_revertIf_invalidSpace() public {
+    vm.expectRevert(SpaceDelegation__InvalidSpace.selector);
+    spaceDelegation.removeSpaceDelegation(address(0));
+  }
+
+  function test_fuzz_removeSpaceDelegation(
+    address operator
+  ) public givenOperator(operator, 0) {
+    address space = test_fuzz_addSpaceDelegation(operator);
+
+    vm.prank(deployer);
+    spaceDelegation.removeSpaceDelegation(space);
+
+    address afterRemovalOperator = spaceDelegation.getSpaceDelegation(space);
+    assertEq(afterRemovalOperator, address(0), "Space removal failed");
+  }
+
+  /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+  /*                           GETTERS                          */
+  /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+  function test_fuzz_getSpaceDelegationsByOperator(address operator) public {
+    address space1 = test_fuzz_addSpaceDelegation(operator);
+    address space2 = test_fuzz_addSpaceDelegation(operator);
+
+    address[] memory spaces = spaceDelegation.getSpaceDelegationsByOperator(
+      operator
+    );
+
+    assertEq(spaces.length, 2);
+    assertEq(spaces[0], space1);
+    assertEq(spaces[1], space2);
+  }
+
+  /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+  /*                           SETTERS                          */
+  /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+  function test_setRiverToken_revertIf_notOwner() public {
+    vm.expectRevert(
+      abi.encodeWithSelector(Ownable__NotOwner.selector, address(this))
+    );
+    spaceDelegation.setRiverToken(address(0));
+  }
+
+  function test_fuzz_setRiverToken(address newToken) public {
+    vm.assume(newToken != address(0));
+
+    vm.expectEmit(address(spaceDelegation));
+    emit RiverTokenChanged(newToken);
+
+    vm.prank(deployer);
+    spaceDelegation.setRiverToken(newToken);
+
+    address retrievedToken = spaceDelegation.riverToken();
+    assertEq(retrievedToken, newToken);
+  }
+
+  function test_fuzz_setSpaceFactory_revertIf_notOwner() public {
+    vm.expectRevert(
+      abi.encodeWithSelector(Ownable__NotOwner.selector, address(this))
+    );
+    spaceDelegation.setSpaceFactory(address(0));
+  }
+
+  function test_fuzz_setSpaceFactory(address newSpaceFactory) public {
+    vm.assume(newSpaceFactory != address(0));
+
+    vm.prank(deployer);
+    spaceDelegation.setSpaceFactory(newSpaceFactory);
+
+    address retrievedFactory = spaceDelegation.getSpaceFactory();
+    assertEq(retrievedFactory, newSpaceFactory);
+  }
+}


### PR DESCRIPTION
Introduce reward sweeping when updating space operators. This ensures that any unclaimed rewards are properly transferred to the current operator. Additionally, refactored validations and removed redundant checks for enhanced readability and maintainability.