### PR TITLE
banning: change to Permission.ModifyBanning and fix entitlement check

### DIFF
--- a/core/node/auth/permissions.go
+++ b/core/node/auth/permissions.go
@@ -9,7 +9,7 @@ const (
 	PermissionInvite
 	PermissionJoin
 	PermissionRedact
-	PermissionBan
+	PermissionModifyBanning
 	PermissionPinMessage
 	PermissionAddRemoveChannels
 	PermissionModifySpaceSettings
@@ -30,8 +30,8 @@ func (p Permission) String() string {
 		return "Join"
 	case PermissionRedact:
 		return "Redact"
-	case PermissionBan:
-		return "Ban"
+	case PermissionModifyBanning:
+		return "ModifyBanning"
 	case PermissionPinMessage:
 		return "PinMessage"
 	case PermissionAddRemoveChannels:

--- a/core/node/rules/can_add_event.go
+++ b/core/node/rules/can_add_event.go
@@ -970,6 +970,17 @@ func (ru *aeMembershipRules) channelMembershipEntitlements() (*auth.ChainAuthArg
 		return nil, err
 	}
 
+
+	// ModifyBanning is a space level permission
+	// but users with this entitlement should also be entitled to kick users from the channel
+	if permission == auth.PermissionModifyBanning {
+		return auth.NewChainAuthArgsForSpace(
+			spaceId,
+			permissionUser,
+			permission,
+		), nil
+	}
+
 	chainAuthArgs := auth.NewChainAuthArgsForChannel(
 		spaceId,
 		*ru.params.streamView.StreamId(),
@@ -1136,7 +1147,7 @@ func (ru *aeMembershipRules) getPermissionForMembershipOp() (auth.Permission, st
 			)
 		}
 		if userId != initiatorId {
-			return auth.PermissionBan, initiatorId, nil
+			return auth.PermissionModifyBanning, initiatorId, nil
 		} else {
 			return auth.PermissionUndefined, userId, nil
 		}

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1824,7 +1824,15 @@ export class Client
                 if (
                     userStream.userContent.streamMemberships[channelId]?.op === MembershipOp.SO_JOIN
                 ) {
-                    await this.removeUser(channelId, userId)
+                    try {
+                        await this.removeUser(channelId, userId)
+                    } catch (error) {
+                        this.logError('Failed to remove user from channel', {
+                            channelId,
+                            userId,
+                            error,
+                        })
+                    }
                 }
             }
         }

--- a/packages/sdk/src/spaceWithEntitlements.test.ts
+++ b/packages/sdk/src/spaceWithEntitlements.test.ts
@@ -21,6 +21,7 @@ import {
     twoNftRuleData,
     waitFor,
     createRole,
+    createSpaceAndDefaultChannel,
 } from './util.test'
 import { dlog } from '@river-build/dlog'
 import { MembershipOp } from '@river-build/proto'
@@ -170,24 +171,28 @@ describe('spaceWithEntitlements', () => {
     test('user with banning permission can ban other users', async () => {
         log('start user with banning permission can ban other users')
         const {
-            alice,
             bob,
-            carol,
-            bobSpaceDapp,
             bobProvider,
+            bobSpaceDapp,
+            alice,
             aliceSpaceDapp,
             aliceProvider,
             alicesWallet,
-            spaceId,
-            channelId,
-            carolSpaceDapp,
-            carolProvider,
+            carol,
             carolsWallet,
-        } = await createTownWithRequirements({
-            everyone: true,
-            users: [],
-            ruleData: NoopRuleData,
-        })
+            carolProvider,
+            carolSpaceDapp,
+        } = await setupWalletsAndContexts()
+
+        const everyoneMembership = await everyoneMembershipStruct(bobSpaceDapp, bob)
+
+        const { spaceId, defaultChannelId: channelId } = await createSpaceAndDefaultChannel(
+            bob,
+            bobSpaceDapp,
+            bobProvider.wallet,
+            "bob's town",
+            everyoneMembership,
+        )
 
         log('Alice should be able to join space')
         await expectUserCanJoin(

--- a/packages/web3/src/ContractTypes.ts
+++ b/packages/web3/src/ContractTypes.ts
@@ -26,7 +26,7 @@ export const Permission = {
     Invite: 'Invite',
     JoinSpace: 'JoinSpace',
     Redact: 'Redact',
-    Ban: 'Ban',
+    ModifyBanning: 'ModifyBanning',
     PinMessage: 'PinMessage',
     AddRemoveChannels: 'AddRemoveChannels',
     ModifySpaceSettings: 'ModifySpaceSettings',


### PR DESCRIPTION
Banning only worked for space owners
- contract uses Permission.ModifyBanning. Updates both TS and go code to match
- calling removeUser on space recursively calls removeUser for each channel, but the entitlement check for booting from channel was failing for a non-owner user w/ banning permission. Fixes so that in the case of ModifyBanning, the channel entitlement check will check space permissions