### PR TITLE
Fix space entitlement tests to properly create legacy spaces when configured to do so

### DIFF
--- a/packages/sdk/src/util.test.ts
+++ b/packages/sdk/src/util.test.ts
@@ -510,7 +510,7 @@ export async function createVersionedSpaceFromMembership(
                     syncEntitlements: false,
                     ruleData: convertRuleDataV2ToV1(
                         decodeRuleDataV2(currentMembership.requirements.ruleData),
-                    ) as IRuleEntitlementBase.RuleDataStructV1,
+                    ) as IRuleEntitlementBase.RuleDataStruct,
                 },
             } as LegacyMembershipStruct
             return await spaceDapp.createLegacySpace(

--- a/packages/sdk/src/util.test.ts
+++ b/packages/sdk/src/util.test.ts
@@ -496,6 +496,10 @@ export async function createVersionedSpaceFromMembership(
             },
             wallet,
         )
+    } else if (useLegacySpaces()) {
+        // Escalate if this test case should have produced a legacy space
+        // but did not.
+        throw new Error('Cannot create legacy space with V2 membership')
     } else {
         if (isLegacyMembershipType(membership)) {
             // Convert legacy space params to current space params
@@ -1057,7 +1061,7 @@ export async function createTownWithRequirements(requirements: {
     }
     requirements.users = requirements.users.map((user) => userNameToWallet[user])
 
-    const membershipInfo: MembershipStruct = {
+    const membershipInfo: LegacyMembershipStruct = {
         settings: {
             name: 'Everyone',
             symbol: 'MEMBER',
@@ -1073,7 +1077,7 @@ export async function createTownWithRequirements(requirements: {
         requirements: {
             everyone: requirements.everyone,
             users: requirements.users,
-            ruleData: encodeRuleDataV2(requirements.ruleData),
+            ruleData: convertRuleDataV2ToV1(requirements.ruleData),
             syncEntitlements: false,
         },
     }

--- a/packages/sdk/src/util.test.ts
+++ b/packages/sdk/src/util.test.ts
@@ -499,18 +499,17 @@ export async function createVersionedSpaceFromMembership(
                 wallet,
             )
         } else {
-            const currentMembership = membership as MembershipStruct
             // Convert space params to legacy space params
             const legacyMembership = {
-                settings: currentMembership.settings,
-                permissions: currentMembership.permissions,
+                settings: membership.settings,
+                permissions: membership.permissions,
                 requirements: {
-                    everyone: currentMembership.requirements.everyone,
-                    users: [],
-                    syncEntitlements: false,
+                    everyone: membership.requirements.everyone,
+                    users: membership.requirements.users,
+                    syncEntitlements: membership.requirements.syncEntitlements,
                     ruleData: convertRuleDataV2ToV1(
-                        decodeRuleDataV2(currentMembership.requirements.ruleData),
-                    ) as IRuleEntitlementBase.RuleDataStruct,
+                        decodeRuleDataV2(membership.requirements.ruleData as `0x${string}`),
+                    ),
                 },
             } as LegacyMembershipStruct
             return await spaceDapp.createLegacySpace(
@@ -518,15 +517,11 @@ export async function createVersionedSpaceFromMembership(
                     spaceName: `${name}-space`,
                     uri: `${name}-space-metadata`,
                     channelName: 'general',
-                    legacyMembership,
+                    membership: legacyMembership,
                 },
                 wallet,
             )
         }
-    } else if (useLegacySpaces()) {
-        // Escalate if this test case should have produced a legacy space
-        // but did not.
-        throw new Error('Cannot create legacy space with V2 membership')
     } else {
         if (isLegacyMembershipType(membership)) {
             // Convert legacy space params to current space params


### PR DESCRIPTION
legacy tests for space entitlements were incorrectly running against v2 spaces. This change fixes that and also adds error throwing to catch this issue anywhere else it may occur.