### PR TITLE
Fix archiver race condition

### DIFF
--- a/core/node/rpc/archiver_test.go
+++ b/core/node/rpc/archiver_test.go
@@ -243,9 +243,9 @@ func TestArchiveOneStream(t *testing.T) {
 	)
 	require.NoError(err)
 
-	dbCfg, schema, schemaDeleter, err := dbtestutils.ConfigureDB(ctx)
+	dbCfg, schema, _, err := dbtestutils.ConfigureDB(ctx)
 	require.NoError(err)
-	defer schemaDeleter()
+	// defer schemaDeleter()
 
 	pool, err := storage.CreateAndValidatePgxPool(ctx, dbCfg, schema, nil)
 	require.NoError(err)
@@ -446,7 +446,7 @@ func TestArchiveContinuous(t *testing.T) {
 			assert.NoError(c, err)
 			assert.Zero(c, num)
 		},
-		5*time.Second,
+		10*time.Second,
 		10*time.Millisecond,
 	)
 
@@ -459,7 +459,7 @@ func TestArchiveContinuous(t *testing.T) {
 			assert.NoError(c, err)
 			assert.Equal(c, lastMB.Num, num)
 		},
-		5*time.Second,
+		10*time.Second,
 		10*time.Millisecond,
 	)
 
@@ -482,7 +482,7 @@ func TestArchiveContinuous(t *testing.T) {
 			assert.NoError(c, err)
 			assert.Equal(c, lastMB2.Num, num)
 		},
-		5*time.Second,
+		10*time.Second,
 		10*time.Millisecond,
 	)
 

--- a/core/node/rpc/archiver_test.go
+++ b/core/node/rpc/archiver_test.go
@@ -243,9 +243,9 @@ func TestArchiveOneStream(t *testing.T) {
 	)
 	require.NoError(err)
 
-	dbCfg, schema, _, err := dbtestutils.ConfigureDB(ctx)
+	dbCfg, schema, schemaDeleter, err := dbtestutils.ConfigureDB(ctx)
 	require.NoError(err)
-	// defer schemaDeleter()
+	defer schemaDeleter()
 
 	pool, err := storage.CreateAndValidatePgxPool(ctx, dbCfg, schema, nil)
 	require.NoError(err)


### PR DESCRIPTION
for the Continuous test case, streams are added because they are detected in the registry, and the call to ReadMiniblocks on the stream node may result in a stream not found since the stream node may not have yet allocated the stream node in storage.

This PR adds a retry in the archiver when a NOT_FOUND error is returned and extends test waits to accommodate the longer execution time.