### PR TITLE
Another attempt at fixing the flaky waitFor timeout waiting for streamMembershipUpdated

### DIFF
--- a/packages/sdk/src/util.test.ts
+++ b/packages/sdk/src/util.test.ts
@@ -77,6 +77,7 @@ import {
     XchainConfig,
     UpdateRoleParams,
 } from '@river-build/web3'
+import { SyncState } from './syncedStreamsLoop'
 
 const log = dlog('csb:test:util')
 
@@ -633,6 +634,8 @@ export async function expectUserCanJoin(
 
     await client.initializeUser({ spaceId })
     client.startSync()
+
+    await waitFor(() => client.streams.syncState === SyncState.Syncing)
 
     await expect(client.joinStream(spaceId)).toResolve()
     await expect(client.joinStream(channelId)).toResolve()


### PR DESCRIPTION
These are always failing when they go through this utility

Our sync startup code is wild. Really hard to trace it all. My gut tells me there is a race where we either subscribe to a stream too soon or too late and we don’t get the push that the membership event was added to the space stream, but I can’t figure out where it is. If this fixes it we should burn all that code down and make something simpler.