### PR TITLE
Add DecodedCheckOperationBuilder for validating constructed check ops

### DIFF
--- a/packages/web3/src/entitlement.test.ts
+++ b/packages/web3/src/entitlement.test.ts
@@ -1412,7 +1412,13 @@ describe('createOperationsTree', () => {
 })
 
 describe("DecodedCheckOpBuilder", () => {
-    test.only("ERC20s", () => {
+    test("Untyped", () => {
+        expect(() => {
+            new DecodedCheckOperationBuilder().build()
+        }).toThrow("DecodedCheckOperation requires a type")
+    })
+
+    test("ERC20s", () => {
         expect(() => {
             new DecodedCheckOperationBuilder().
                 setType(CheckOperationType.ERC20).
@@ -1439,9 +1445,24 @@ describe("DecodedCheckOpBuilder", () => {
                 build()
         }
         ).toThrow("DecodedCheckOperation of type ERC20 requires a threshold")
+
+        // Valid example
+        const decoded = new DecodedCheckOperationBuilder().
+            setType(CheckOperationType.ERC20).
+            setChainId(1n).
+            setAddress(zeroAddress).
+            setThreshold(5n).
+            build()
+
+        expect(decoded).toEqual({
+            type: CheckOperationType.ERC20,
+            chainId: 1n,
+            address: zeroAddress,
+            threshold: 5n
+        } as DecodedCheckOperation)
     })
 
-    test.only("ERC721s", () => {
+    test("ERC721s", () => {
         expect(() => {
             new DecodedCheckOperationBuilder().
                 setType(CheckOperationType.ERC721).
@@ -1468,6 +1489,143 @@ describe("DecodedCheckOpBuilder", () => {
                 build()
         }
         ).toThrow("DecodedCheckOperation of type ERC721 requires a threshold")
+
+        // Valid example
+        const decoded = new DecodedCheckOperationBuilder().
+            setType(CheckOperationType.ERC721).
+            setChainId(1n).
+            setAddress(zeroAddress).
+            setThreshold(5n).
+            build()
+
+        expect(decoded).toEqual({
+            type: CheckOperationType.ERC721,
+            chainId: 1n,
+            address: zeroAddress,
+            threshold: 5n
+        } as DecodedCheckOperation)
     })
 
+    test("ERC1155s", () => {
+        expect(() => {
+            new DecodedCheckOperationBuilder().
+                setType(CheckOperationType.ERC1155).
+                setAddress(zeroAddress).
+                setThreshold(1n).
+                setTokenId(5n).
+                build()
+        }
+        ).toThrow("DecodedCheckOperation of type ERC1155 requires a chainId")
+
+        expect(() => {
+            new DecodedCheckOperationBuilder().
+                setType(CheckOperationType.ERC1155).
+                setChainId(1n).
+                setThreshold(1n).
+                setTokenId(5n).
+                build()
+        }
+        ).toThrow("DecodedCheckOperation of type ERC1155 requires an address")
+
+        expect(() => {
+            new DecodedCheckOperationBuilder().
+                setType(CheckOperationType.ERC1155).
+                setChainId(1n).
+                setAddress(zeroAddress).
+                setTokenId(5n).
+                build()
+        }
+        ).toThrow("DecodedCheckOperation of type ERC1155 requires a threshold")
+
+        expect(() => {
+            new DecodedCheckOperationBuilder().
+                setType(CheckOperationType.ERC1155).
+                setChainId(1n).
+                setAddress(zeroAddress).
+                setThreshold(3n).
+                build()
+        }
+        ).toThrow("DecodedCheckOperation of type ERC1155 requires a tokenId")
+
+        // Valid example
+        const decoded = new DecodedCheckOperationBuilder().
+            setType(CheckOperationType.ERC1155).
+            setChainId(1n).
+            setAddress(zeroAddress).
+            setThreshold(5n).
+            setTokenId(9n).
+            build()
+
+        expect(decoded).toEqual({
+            type: CheckOperationType.ERC1155,
+            chainId: 1n,
+            address: zeroAddress,
+            threshold: 5n,
+            tokenId: 9n,
+        } as DecodedCheckOperation)
+    })
+
+    test("ETH_BALANCE", () => {
+        expect(() => {
+            new DecodedCheckOperationBuilder().
+                setType(CheckOperationType.ETH_BALANCE).
+                build()
+        }
+        ).toThrow("DecodedCheckOperation of type ETH_BALANCE requires a threshold")
+
+        // Valid example
+        const decoded = new DecodedCheckOperationBuilder().
+            setType(CheckOperationType.ETH_BALANCE).
+            setThreshold(5n).
+            build()
+
+        expect(decoded).toEqual({
+            type: CheckOperationType.ETH_BALANCE,
+            threshold: 5n
+        } as DecodedCheckOperation)
+    })
+
+    test.only("ISENTITLED", () => {
+        expect(() => {
+            new DecodedCheckOperationBuilder().
+                setType(CheckOperationType.ISENTITLED).
+                setAddress(zeroAddress).
+                setByteEncodedParams('0xabcdef1234').
+                build()
+        }
+        ).toThrow("DecodedCheckOperation of type ISENTITLED requires a chainId")
+
+        expect(() => {
+            new DecodedCheckOperationBuilder().
+                setType(CheckOperationType.ISENTITLED).
+                setChainId(1n).
+                setByteEncodedParams('0xabcdef1234').
+                build()
+        }
+        ).toThrow("DecodedCheckOperation of type ISENTITLED requires an address")
+
+        expect(() => {
+            new DecodedCheckOperationBuilder().
+                setType(CheckOperationType.ISENTITLED).
+                setChainId(1n).
+                setAddress(zeroAddress).
+                build()
+        }
+        ).toThrow("DecodedCheckOperation of type ISENTITLED requires byteEncodedParams")
+
+        // Valid example
+        const decoded = new DecodedCheckOperationBuilder().
+            setType(CheckOperationType.ISENTITLED).
+            setChainId(1n).
+            setAddress(zeroAddress).
+            setByteEncodedParams('0xabcdef1234').
+            build()
+
+        expect(decoded).toEqual({
+            type: CheckOperationType.ISENTITLED,
+            chainId: 1n,
+            address: zeroAddress,
+            byteEncodedParams: `0xabcdef1234`,
+        } as DecodedCheckOperation)
+    })
 })

--- a/packages/web3/src/entitlement.test.ts
+++ b/packages/web3/src/entitlement.test.ts
@@ -1585,7 +1585,7 @@ describe("DecodedCheckOpBuilder", () => {
         } as DecodedCheckOperation)
     })
 
-    test.only("ISENTITLED", () => {
+    test("ISENTITLED", () => {
         expect(() => {
             new DecodedCheckOperationBuilder().
                 setType(CheckOperationType.ISENTITLED).

--- a/packages/web3/src/entitlement.test.ts
+++ b/packages/web3/src/entitlement.test.ts
@@ -1292,7 +1292,7 @@ describe('createOperationsTree', () => {
                 type: CheckOperationType.ISENTITLED,
                 chainId: 1n,
                 address: MOCK_ADDRESS,
-                byteEncodedParams: `0xabcdef`
+                byteEncodedParams: `0xabcdef`,
             },
             {
                 type: CheckOperationType.ERC721,
@@ -1411,150 +1411,140 @@ describe('createOperationsTree', () => {
     })
 })
 
-describe("DecodedCheckOpBuilder", () => {
-    test("Untyped", () => {
+describe('DecodedCheckOpBuilder', () => {
+    test('Untyped', () => {
         expect(() => {
             new DecodedCheckOperationBuilder().build()
-        }).toThrow("DecodedCheckOperation requires a type")
+        }).toThrow('DecodedCheckOperation requires a type')
     })
 
-    test("ERC20s", () => {
+    test('ERC20s', () => {
         expect(() => {
-            new DecodedCheckOperationBuilder().
-                setType(CheckOperationType.ERC20).
-                setAddress(zeroAddress).
-                setThreshold(1n).
-                build()
-        }
-        ).toThrow("DecodedCheckOperation of type ERC20 requires a chainId")
+            new DecodedCheckOperationBuilder()
+                .setType(CheckOperationType.ERC20)
+                .setAddress(zeroAddress)
+                .setThreshold(1n)
+                .build()
+        }).toThrow('DecodedCheckOperation of type ERC20 requires a chainId')
 
         expect(() => {
-            new DecodedCheckOperationBuilder().
-                setType(CheckOperationType.ERC20).
-                setChainId(1n).
-                setThreshold(1n).
-                build()
-        }
-        ).toThrow("DecodedCheckOperation of type ERC20 requires an address")
+            new DecodedCheckOperationBuilder()
+                .setType(CheckOperationType.ERC20)
+                .setChainId(1n)
+                .setThreshold(1n)
+                .build()
+        }).toThrow('DecodedCheckOperation of type ERC20 requires an address')
 
         expect(() => {
-            new DecodedCheckOperationBuilder().
-                setType(CheckOperationType.ERC20).
-                setChainId(1n).
-                setAddress(zeroAddress).
-                build()
-        }
-        ).toThrow("DecodedCheckOperation of type ERC20 requires a threshold")
+            new DecodedCheckOperationBuilder()
+                .setType(CheckOperationType.ERC20)
+                .setChainId(1n)
+                .setAddress(zeroAddress)
+                .build()
+        }).toThrow('DecodedCheckOperation of type ERC20 requires a threshold')
 
         // Valid example
-        const decoded = new DecodedCheckOperationBuilder().
-            setType(CheckOperationType.ERC20).
-            setChainId(1n).
-            setAddress(zeroAddress).
-            setThreshold(5n).
-            build()
+        const decoded = new DecodedCheckOperationBuilder()
+            .setType(CheckOperationType.ERC20)
+            .setChainId(1n)
+            .setAddress(zeroAddress)
+            .setThreshold(5n)
+            .build()
 
         expect(decoded).toEqual({
             type: CheckOperationType.ERC20,
             chainId: 1n,
             address: zeroAddress,
-            threshold: 5n
+            threshold: 5n,
         } as DecodedCheckOperation)
     })
 
-    test("ERC721s", () => {
+    test('ERC721s', () => {
         expect(() => {
-            new DecodedCheckOperationBuilder().
-                setType(CheckOperationType.ERC721).
-                setAddress(zeroAddress).
-                setThreshold(1n).
-                build()
-        }
-        ).toThrow("DecodedCheckOperation of type ERC721 requires a chainId")
+            new DecodedCheckOperationBuilder()
+                .setType(CheckOperationType.ERC721)
+                .setAddress(zeroAddress)
+                .setThreshold(1n)
+                .build()
+        }).toThrow('DecodedCheckOperation of type ERC721 requires a chainId')
 
         expect(() => {
-            new DecodedCheckOperationBuilder().
-                setType(CheckOperationType.ERC721).
-                setChainId(1n).
-                setThreshold(1n).
-                build()
-        }
-        ).toThrow("DecodedCheckOperation of type ERC721 requires an address")
+            new DecodedCheckOperationBuilder()
+                .setType(CheckOperationType.ERC721)
+                .setChainId(1n)
+                .setThreshold(1n)
+                .build()
+        }).toThrow('DecodedCheckOperation of type ERC721 requires an address')
 
         expect(() => {
-            new DecodedCheckOperationBuilder().
-                setType(CheckOperationType.ERC721).
-                setChainId(1n).
-                setAddress(zeroAddress).
-                build()
-        }
-        ).toThrow("DecodedCheckOperation of type ERC721 requires a threshold")
+            new DecodedCheckOperationBuilder()
+                .setType(CheckOperationType.ERC721)
+                .setChainId(1n)
+                .setAddress(zeroAddress)
+                .build()
+        }).toThrow('DecodedCheckOperation of type ERC721 requires a threshold')
 
         // Valid example
-        const decoded = new DecodedCheckOperationBuilder().
-            setType(CheckOperationType.ERC721).
-            setChainId(1n).
-            setAddress(zeroAddress).
-            setThreshold(5n).
-            build()
+        const decoded = new DecodedCheckOperationBuilder()
+            .setType(CheckOperationType.ERC721)
+            .setChainId(1n)
+            .setAddress(zeroAddress)
+            .setThreshold(5n)
+            .build()
 
         expect(decoded).toEqual({
             type: CheckOperationType.ERC721,
             chainId: 1n,
             address: zeroAddress,
-            threshold: 5n
+            threshold: 5n,
         } as DecodedCheckOperation)
     })
 
-    test("ERC1155s", () => {
+    test('ERC1155s', () => {
         expect(() => {
-            new DecodedCheckOperationBuilder().
-                setType(CheckOperationType.ERC1155).
-                setAddress(zeroAddress).
-                setThreshold(1n).
-                setTokenId(5n).
-                build()
-        }
-        ).toThrow("DecodedCheckOperation of type ERC1155 requires a chainId")
+            new DecodedCheckOperationBuilder()
+                .setType(CheckOperationType.ERC1155)
+                .setAddress(zeroAddress)
+                .setThreshold(1n)
+                .setTokenId(5n)
+                .build()
+        }).toThrow('DecodedCheckOperation of type ERC1155 requires a chainId')
 
         expect(() => {
-            new DecodedCheckOperationBuilder().
-                setType(CheckOperationType.ERC1155).
-                setChainId(1n).
-                setThreshold(1n).
-                setTokenId(5n).
-                build()
-        }
-        ).toThrow("DecodedCheckOperation of type ERC1155 requires an address")
+            new DecodedCheckOperationBuilder()
+                .setType(CheckOperationType.ERC1155)
+                .setChainId(1n)
+                .setThreshold(1n)
+                .setTokenId(5n)
+                .build()
+        }).toThrow('DecodedCheckOperation of type ERC1155 requires an address')
 
         expect(() => {
-            new DecodedCheckOperationBuilder().
-                setType(CheckOperationType.ERC1155).
-                setChainId(1n).
-                setAddress(zeroAddress).
-                setTokenId(5n).
-                build()
-        }
-        ).toThrow("DecodedCheckOperation of type ERC1155 requires a threshold")
+            new DecodedCheckOperationBuilder()
+                .setType(CheckOperationType.ERC1155)
+                .setChainId(1n)
+                .setAddress(zeroAddress)
+                .setTokenId(5n)
+                .build()
+        }).toThrow('DecodedCheckOperation of type ERC1155 requires a threshold')
 
         expect(() => {
-            new DecodedCheckOperationBuilder().
-                setType(CheckOperationType.ERC1155).
-                setChainId(1n).
-                setAddress(zeroAddress).
-                setThreshold(3n).
-                build()
-        }
-        ).toThrow("DecodedCheckOperation of type ERC1155 requires a tokenId")
+            new DecodedCheckOperationBuilder()
+                .setType(CheckOperationType.ERC1155)
+                .setChainId(1n)
+                .setAddress(zeroAddress)
+                .setThreshold(3n)
+                .build()
+        }).toThrow('DecodedCheckOperation of type ERC1155 requires a tokenId')
 
         // Valid example
-        const decoded = new DecodedCheckOperationBuilder().
-            setType(CheckOperationType.ERC1155).
-            setChainId(1n).
-            setAddress(zeroAddress).
-            setThreshold(5n).
-            setTokenId(9n).
-            build()
+        const decoded = new DecodedCheckOperationBuilder()
+            .setType(CheckOperationType.ERC1155)
+            .setChainId(1n)
+            .setAddress(zeroAddress)
+            .setThreshold(5n)
+            .setTokenId(9n)
+            .build()
 
         expect(decoded).toEqual({
             type: CheckOperationType.ERC1155,
@@ -1565,61 +1555,55 @@ describe("DecodedCheckOpBuilder", () => {
         } as DecodedCheckOperation)
     })
 
-    test("ETH_BALANCE", () => {
+    test('ETH_BALANCE', () => {
         expect(() => {
-            new DecodedCheckOperationBuilder().
-                setType(CheckOperationType.ETH_BALANCE).
-                build()
-        }
-        ).toThrow("DecodedCheckOperation of type ETH_BALANCE requires a threshold")
+            new DecodedCheckOperationBuilder().setType(CheckOperationType.ETH_BALANCE).build()
+        }).toThrow('DecodedCheckOperation of type ETH_BALANCE requires a threshold')
 
         // Valid example
-        const decoded = new DecodedCheckOperationBuilder().
-            setType(CheckOperationType.ETH_BALANCE).
-            setThreshold(5n).
-            build()
+        const decoded = new DecodedCheckOperationBuilder()
+            .setType(CheckOperationType.ETH_BALANCE)
+            .setThreshold(5n)
+            .build()
 
         expect(decoded).toEqual({
             type: CheckOperationType.ETH_BALANCE,
-            threshold: 5n
+            threshold: 5n,
         } as DecodedCheckOperation)
     })
 
-    test("ISENTITLED", () => {
+    test('ISENTITLED', () => {
         expect(() => {
-            new DecodedCheckOperationBuilder().
-                setType(CheckOperationType.ISENTITLED).
-                setAddress(zeroAddress).
-                setByteEncodedParams('0xabcdef1234').
-                build()
-        }
-        ).toThrow("DecodedCheckOperation of type ISENTITLED requires a chainId")
+            new DecodedCheckOperationBuilder()
+                .setType(CheckOperationType.ISENTITLED)
+                .setAddress(zeroAddress)
+                .setByteEncodedParams('0xabcdef1234')
+                .build()
+        }).toThrow('DecodedCheckOperation of type ISENTITLED requires a chainId')
 
         expect(() => {
-            new DecodedCheckOperationBuilder().
-                setType(CheckOperationType.ISENTITLED).
-                setChainId(1n).
-                setByteEncodedParams('0xabcdef1234').
-                build()
-        }
-        ).toThrow("DecodedCheckOperation of type ISENTITLED requires an address")
+            new DecodedCheckOperationBuilder()
+                .setType(CheckOperationType.ISENTITLED)
+                .setChainId(1n)
+                .setByteEncodedParams('0xabcdef1234')
+                .build()
+        }).toThrow('DecodedCheckOperation of type ISENTITLED requires an address')
 
         expect(() => {
-            new DecodedCheckOperationBuilder().
-                setType(CheckOperationType.ISENTITLED).
-                setChainId(1n).
-                setAddress(zeroAddress).
-                build()
-        }
-        ).toThrow("DecodedCheckOperation of type ISENTITLED requires byteEncodedParams")
+            new DecodedCheckOperationBuilder()
+                .setType(CheckOperationType.ISENTITLED)
+                .setChainId(1n)
+                .setAddress(zeroAddress)
+                .build()
+        }).toThrow('DecodedCheckOperation of type ISENTITLED requires byteEncodedParams')
 
         // Valid example
-        const decoded = new DecodedCheckOperationBuilder().
-            setType(CheckOperationType.ISENTITLED).
-            setChainId(1n).
-            setAddress(zeroAddress).
-            setByteEncodedParams('0xabcdef1234').
-            build()
+        const decoded = new DecodedCheckOperationBuilder()
+            .setType(CheckOperationType.ISENTITLED)
+            .setChainId(1n)
+            .setAddress(zeroAddress)
+            .setByteEncodedParams('0xabcdef1234')
+            .build()
 
         expect(decoded).toEqual({
             type: CheckOperationType.ISENTITLED,

--- a/packages/web3/src/entitlement.ts
+++ b/packages/web3/src/entitlement.ts
@@ -873,10 +873,6 @@ export class DecodedCheckOperationBuilder {
                 return {
                     type: CheckOperationType.ETH_BALANCE,
                     threshold: this.decodedCheckOp.threshold!,
-
-                    // The following values are unused by the check but must be set
-                    address: zeroAddress,
-                    chainId: 1n,
                 }
             
             case CheckOperationType.ISENTITLED:
@@ -895,8 +891,8 @@ export class DecodedCheckOperationBuilder {
 
 export type DecodedCheckOperation = {
     type: CheckOperationType
-    chainId: bigint
-    address: Address
+    chainId?: bigint
+    address?: Address
     threshold?: bigint
     tokenId?: bigint
     byteEncodedParams?: Hex
@@ -940,8 +936,8 @@ export function createOperationsTree(
         return {
             opType: OperationType.CHECK,
             checkType: op.type,
-            chainId: op.chainId,
-            contractAddress: op.address,
+            chainId: op.chainId ?? 0n,
+            contractAddress: op.address ?? zeroAddress,
             params,
         }
     })

--- a/packages/web3/src/entitlement.ts
+++ b/packages/web3/src/entitlement.ts
@@ -1,7 +1,7 @@
-import { parseAbiParameters, type ExtractAbiFunction } from 'abitype'
+import { type ExtractAbiFunction } from 'abitype'
 import { IRuleEntitlementBase, IRuleEntitlementAbi } from './v3/IRuleEntitlementShim'
 import { IRuleEntitlementV2Base, IRuleEntitlementV2Abi } from './v3/IRuleEntitlementV2Shim'
-import { check, dlogger } from '@river-build/dlog'
+import { dlogger } from '@river-build/dlog'
 
 import {
     encodeAbiParameters,
@@ -14,7 +14,6 @@ import {
 import { ethers } from 'ethers'
 import { Address } from './ContractTypes'
 import { MOCK_ADDRESS } from './Utils'
-import { add } from 'lodash'
 
 const log = dlogger('csb:entitlement')
 

--- a/packages/web3/src/entitlement.ts
+++ b/packages/web3/src/entitlement.ts
@@ -824,7 +824,7 @@ export class DecodedCheckOperationBuilder {
 
         // threshold check
         switch (this.decodedCheckOp.type) {
-            case CheckOperationType.ERC1155: 
+            case CheckOperationType.ERC1155:
             case CheckOperationType.ETH_BALANCE:
             case CheckOperationType.ERC20:
             case CheckOperationType.ERC721:
@@ -856,7 +856,7 @@ export class DecodedCheckOperationBuilder {
                     type: this.decodedCheckOp.type,
                     chainId: this.decodedCheckOp.chainId!,
                     address: this.decodedCheckOp.address!,
-                    threshold: this.decodedCheckOp.threshold!
+                    threshold: this.decodedCheckOp.threshold!,
                 }
 
             case CheckOperationType.ERC1155:
@@ -867,23 +867,25 @@ export class DecodedCheckOperationBuilder {
                     threshold: this.decodedCheckOp.threshold!,
                     tokenId: this.decodedCheckOp.tokenId!,
                 }
-    
+
             case CheckOperationType.ETH_BALANCE:
                 return {
                     type: CheckOperationType.ETH_BALANCE,
                     threshold: this.decodedCheckOp.threshold!,
                 }
-            
+
             case CheckOperationType.ISENTITLED:
                 return {
                     type: CheckOperationType.ISENTITLED,
                     address: this.decodedCheckOp.address!,
                     chainId: this.decodedCheckOp.chainId!,
-                    byteEncodedParams: this.decodedCheckOp.byteEncodedParams!
+                    byteEncodedParams: this.decodedCheckOp.byteEncodedParams!,
                 }
 
             default:
-                throw new Error(`Check operation type ${opStr} unrecognized or not used in production`)
+                throw new Error(
+                    `Check operation type ${opStr} unrecognized or not used in production`,
+                )
         }
     }
 }
@@ -927,7 +929,7 @@ export function createOperationsTree(
                 break
             case CheckOperationType.ISENTITLED:
                 params = op.byteEncodedParams ?? `0x`
-                break;
+                break
             default:
                 params = '0x'
         }

--- a/packages/web3/src/entitlement.ts
+++ b/packages/web3/src/entitlement.ts
@@ -808,7 +808,6 @@ export class DecodedCheckOperationBuilder {
 
         const opStr = checkOpString(this.decodedCheckOp.type)
 
-
         // For contract-related checks, assert set values for chain id and contract address
         switch (this.decodedCheckOp.type) {
             case CheckOperationType.ERC1155:


### PR DESCRIPTION
Add a builder for DecodedCheckOperations that can be used in harmony for constructing rule datas. Eventually I'd like to move all DecodedCheckOperation code to harmony.

This is part of a planned set of PRs to consolidate logic for constructing rule datas and harden them with better library-provided validation.