### PR TITLE
Refactor storage stats to have it's own debug endpoint and add stream-related metadata

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -60,12 +60,13 @@ func GetDefaultConfig() *Config {
 			PrintStatsPeriod: 10 * time.Second,
 		},
 		DebugEndpoints: DebugEndpointsConfig{
-			Cache:           true,
-			Memory:          true,
-			PProf:           false,
-			Stacks:          true,
-			StacksMaxSizeKb: 5 * 1024,
-			TxPool:          true,
+			Cache:                 true,
+			Memory:                true,
+			PProf:                 false,
+			Stacks:                true,
+			StacksMaxSizeKb:       5 * 1024,
+			TxPool:                true,
+			EnableStorageEndpoint: true,
 		},
 		Scrubbing: ScrubbingConfig{
 			ScrubEligibleDuration: time.Hour,
@@ -381,6 +382,10 @@ type DebugEndpointsConfig struct {
 	Stacks          bool
 	StacksMaxSizeKb int
 	TxPool          bool
+
+	// Make storage statistics available via debug endpoints. This may involve running queries
+	// on the underlying database.
+	EnableStorageEndpoint bool
 }
 
 type RiverRegistryConfig struct {

--- a/core/node/rpc/debug.go
+++ b/core/node/rpc/debug.go
@@ -63,6 +63,7 @@ func (s *Service) registerDebugHandlers(enableDebugEndpoints bool, cfg config.De
 	mux := s.mux
 	handler := debugHandler{}
 	mux.HandleFunc("/debug", handler.ServeHTTP)
+	handler.HandleFunc(mux, "/debug/storage", s.handleDebugStorage)
 	handler.HandleFunc(mux, "/debug/multi", s.handleDebugMulti)
 	handler.HandleFunc(mux, "/debug/multi/json", s.handleDebugMultiJson)
 	handler.Handle(mux, "/debug/config", &onChainConfigHandler{onChainConfig: s.chainConfig})

--- a/core/node/rpc/debug.go
+++ b/core/node/rpc/debug.go
@@ -63,10 +63,13 @@ func (s *Service) registerDebugHandlers(enableDebugEndpoints bool, cfg config.De
 	mux := s.mux
 	handler := debugHandler{}
 	mux.HandleFunc("/debug", handler.ServeHTTP)
-	handler.HandleFunc(mux, "/debug/storage", s.handleDebugStorage)
 	handler.HandleFunc(mux, "/debug/multi", s.handleDebugMulti)
 	handler.HandleFunc(mux, "/debug/multi/json", s.handleDebugMultiJson)
 	handler.Handle(mux, "/debug/config", &onChainConfigHandler{onChainConfig: s.chainConfig})
+
+	if enableDebugEndpoints && cfg.EnableStorageEndpoint {
+		handler.HandleFunc(mux, "/debug/storage", s.handleDebugStorage)
+	}
 
 	if cfg.Cache || enableDebugEndpoints {
 		handler.Handle(mux, "/debug/cache", &cacheHandler{cache: s.cache})

--- a/core/node/rpc/multi.go
+++ b/core/node/rpc/multi.go
@@ -309,8 +309,11 @@ func GetRiverNetworkStatus(
 			go getEthBalance(ctx, &r.BaseEthBalance, baseChain, n.Address(), &wg)
 		}
 
-		// Report PostgresStatusResult for local node
-		if n.Address() == riverChain.Wallet.Address && storagePoolInfo != nil {
+		// Report PostgresStatusResult for local node only iff storage debug endpoint is enabled
+		if n.Address() == riverChain.Wallet.Address &&
+			storagePoolInfo != nil &&
+			cfg.EnableDebugEndpoints &&
+			cfg.DebugEndpoints.EnableStorageEndpoint {
 			wg.Add(1)
 
 			r.PostgresStatus = &storage.PostgresStatusResult{}

--- a/core/node/rpc/render/templates/debug/multi.template.html
+++ b/core/node/rpc/render/templates/debug/multi.template.html
@@ -81,7 +81,6 @@
       <th>Operator</th>
       <th>River Eth Balance</th>
       <th>Base Eth Balance</th>
-      <th>Postgres Status</th>
     </tr>
 
     <!-- Data rows for each Node -->
@@ -132,28 +131,6 @@ UTC: {{.StartTime}}</pre>
       <td>{{.Record.Operator}}</td>
       <td>{{.RiverEthBalance}}</td>
       <td>{{.BaseEthBalance}}</td>
-      <td>
-        <span class="tooltip">
-          {{.PostgresStatus.TotalConns}} total connections
-          <span class="tooltiptext">
-            Version: {{.PostgresStatus.Version}}
-            SystemId: {{.PostgresStatus.SystemId}}
-            Total Connections: {{.PostgresStatus.TotalConns}}
-            Acquired Connections: {{.PostgresStatus.AcquiredConns}}
-            Idle Connections: {{.PostgresStatus.IdleConns}}
-            Constructing Connections: {{.PostgresStatus.ConstructingConns}}
-            Max Connections: {{.PostgresStatus.MaxConns}}
-            New Connections Count: {{.PostgresStatus.NewConnsCount}}
-            Acquire Count: {{.PostgresStatus.AcquireCount}}
-            Empty Acquire Count: {{.PostgresStatus.EmptyAcquireCount}}
-            Canceled Acquire Count: {{.PostgresStatus.CanceledAcquireCount}}
-            Acquire Duration: {{.PostgresStatus.AcquireDuration}}
-            Max Lifetime Destroy Count: {{.PostgresStatus.MaxLifetimeDestroyCount}}
-            Max Idle Destroy Count: {{.PostgresStatus.MaxIdleDestroyCount}}
-
-          </span>
-        </span>
-      </td>
     </tr>
     {{end}}
   </table>

--- a/core/node/rpc/render/templates/debug/storage.template.html
+++ b/core/node/rpc/render/templates/debug/storage.template.html
@@ -30,26 +30,25 @@
 
   <body>
     <table>
-        <tr><th colspan="2"><h2>Storage statistics</h2></th></tr>
-    <tr><th>Total Connections</th><td>{{.Status.TotalConns}}</td></tr>
-    <tr><th>Version</th> <td>{{.Status.Version}}</td></tr>
-    <tr><th>SystemId</th><td>{{.Status.SystemId}}</td></tr>
-    <tr><th>Total Connections</th><td>{{.Status.TotalConns}}</td></tr>
-    <tr><th>Acquired Connections</th><td>{{.Status.AcquiredConns}}</td></tr>
-    <tr><th>Idle Connections</th><td>{{.Status.IdleConns}}</td></tr>
-    <tr><th>Constructing Connections</th><td>{{.Status.ConstructingConns}}</td></tr>
-    <tr><th>Max Connections</th><td>{{.Status.MaxConns}}</td></tr>
-    <tr><th>New Connections Count</th><td>{{.Status.NewConnsCount}}</td></tr>
-    <tr><th>Acquire Count</th><td>{{.Status.AcquireCount}}</td></tr>
-    <tr><th>Empty Acquire Count</th><td>{{.Status.EmptyAcquireCount}}</td></tr>
-    <tr><th>Canceled Acquire Count</th><td>{{.Status.CanceledAcquireCount}}</td></tr>
-    <tr><th>Acquire Duration</th><td>{{.Status.AcquireDuration}}</td></tr>
-    <tr><th>Max Lifetime Destroy Count</th><td>{{.Status.MaxLifetimeDestroyCount}}</td></tr>
-    <tr><th>Max Idle Destroy Count</th><td>{{.Status.MaxIdleDestroyCount}}</td></tr>
-    <tr><th>Unmigrated Streams</th><td>{{.Status.UnmigratedStreams}}</td></tr>
-    <tr><th>Migrated Streams</th><td>{{.Status.MigratedStreams}}</td></tr>
-    <tr><th>Partition Count</th><td>{{.Status.NumPartitions}}</td></tr>
-</table>
-
-</body>
+      <tr><th colspan="2"><h2>Storage statistics</h2></th></tr>
+      <tr><th>Total Connections</th><td>{{.Status.TotalConns}}</td></tr>
+      <tr><th>Version</th> <td>{{.Status.Version}}</td></tr>
+      <tr><th>SystemId</th><td>{{.Status.SystemId}}</td></tr>
+      <tr><th>Total Connections</th><td>{{.Status.TotalConns}}</td></tr>
+      <tr><th>Acquired Connections</th><td>{{.Status.AcquiredConns}}</td></tr>
+      <tr><th>Idle Connections</th><td>{{.Status.IdleConns}}</td></tr>
+      <tr><th>Constructing Connections</th><td>{{.Status.ConstructingConns}}</td></tr>
+      <tr><th>Max Connections</th><td>{{.Status.MaxConns}}</td></tr>
+      <tr><th>New Connections Count</th><td>{{.Status.NewConnsCount}}</td></tr>
+      <tr><th>Acquire Count</th><td>{{.Status.AcquireCount}}</td></tr>
+      <tr><th>Empty Acquire Count</th><td>{{.Status.EmptyAcquireCount}}</td></tr>
+      <tr><th>Canceled Acquire Count</th><td>{{.Status.CanceledAcquireCount}}</td></tr>
+      <tr><th>Acquire Duration</th><td>{{.Status.AcquireDuration}}</td></tr>
+      <tr><th>Max Lifetime Destroy Count</th><td>{{.Status.MaxLifetimeDestroyCount}}</td></tr>
+      <tr><th>Max Idle Destroy Count</th><td>{{.Status.MaxIdleDestroyCount}}</td></tr>
+      <tr><th>Unmigrated Streams</th><td>{{.Status.UnmigratedStreams}}</td></tr>
+      <tr><th>Migrated Streams</th><td>{{.Status.MigratedStreams}}</td></tr>
+      <tr><th>Partition Count</th><td>{{.Status.NumPartitions}}</td></tr>
+    </table>
+  </body>
 </html>

--- a/core/node/rpc/render/templates/debug/storage.template.html
+++ b/core/node/rpc/render/templates/debug/storage.template.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Storage statistics</title>
+    <style>
+      body {
+        font-family: monospace;
+      }
+
+      table,
+      th,
+      td {
+        border: 1px solid black;
+        border-collapse: collapse;
+      }
+
+      th,
+      td {
+        padding: 8px;
+        text-align: center;
+      }
+
+      table tr th {
+        text-align: left;
+      }
+    </style>
+  </head>
+  <!-- prettier-ignore -->
+
+  <body>
+    <table>
+        <tr><th colspan="2"><h2>Storage statistics</h2></th></tr>
+    <tr><th>Total Connections</th><td>{{.Status.TotalConns}}</td></tr>
+    <tr><th>Version</th> <td>{{.Status.Version}}</td></tr>
+    <tr><th>SystemId</th><td>{{.Status.SystemId}}</td></tr>
+    <tr><th>Total Connections</th><td>{{.Status.TotalConns}}</td></tr>
+    <tr><th>Acquired Connections</th><td>{{.Status.AcquiredConns}}</td></tr>
+    <tr><th>Idle Connections</th><td>{{.Status.IdleConns}}</td></tr>
+    <tr><th>Constructing Connections</th><td>{{.Status.ConstructingConns}}</td></tr>
+    <tr><th>Max Connections</th><td>{{.Status.MaxConns}}</td></tr>
+    <tr><th>New Connections Count</th><td>{{.Status.NewConnsCount}}</td></tr>
+    <tr><th>Acquire Count</th><td>{{.Status.AcquireCount}}</td></tr>
+    <tr><th>Empty Acquire Count</th><td>{{.Status.EmptyAcquireCount}}</td></tr>
+    <tr><th>Canceled Acquire Count</th><td>{{.Status.CanceledAcquireCount}}</td></tr>
+    <tr><th>Acquire Duration</th><td>{{.Status.AcquireDuration}}</td></tr>
+    <tr><th>Max Lifetime Destroy Count</th><td>{{.Status.MaxLifetimeDestroyCount}}</td></tr>
+    <tr><th>Max Idle Destroy Count</th><td>{{.Status.MaxIdleDestroyCount}}</td></tr>
+    <tr><th>Unmigrated Streams</th><td>{{.Status.UnmigratedStreams}}</td></tr>
+    <tr><th>Migrated Streams</th><td>{{.Status.MigratedStreams}}</td></tr>
+    <tr><th>Partition Count</th><td>{{.Status.NumPartitions}}</td></tr>
+</table>
+
+</body>
+</html>

--- a/core/node/rpc/render/types.go
+++ b/core/node/rpc/render/types.go
@@ -3,12 +3,13 @@ package render
 import (
 	"github.com/river-build/river/core/node/crypto"
 	"github.com/river-build/river/core/node/rpc/statusinfo"
+	"github.com/river-build/river/core/node/storage"
 )
 
 // RenderableData is the interface for all data that can be rendered
 type RenderableData interface {
 	*AvailableDebugHandlersData | *CacheData | *TransactionPoolData | *OnChainConfigData |
-		*GoRoutineData | *SystemStatsData | *InfoIndexData | *DebugMultiData
+		*GoRoutineData | *SystemStatsData | *InfoIndexData | *DebugMultiData | *StorageData
 
 	// TemplateName returns the name of the template to be used for rendering
 	TemplateName() string
@@ -110,6 +111,14 @@ type DebugMultiData struct {
 
 func (d DebugMultiData) TemplateName() string {
 	return "templates/debug/multi.template.html"
+}
+
+type StorageData struct {
+	Status *storage.PostgresStatusResult
+}
+
+func (s StorageData) TemplateName() string {
+	return "templates/debug/storage.template.html"
 }
 
 type OnChainConfigData struct {

--- a/core/node/rpc/statusinfo/node_status.go
+++ b/core/node/rpc/statusinfo/node_status.go
@@ -91,14 +91,14 @@ func (r GrpcResult) ToPrettyJson() string {
 }
 
 type NodeStatus struct {
-	Record          RegistryNodeInfo             `json:"record"`
-	Local           bool                         `json:"local,omitempty"`
-	Http11          HttpResult                   `json:"http11"`
-	Http20          HttpResult                   `json:"http20"`
-	Grpc            GrpcResult                   `json:"grpc"`
-	RiverEthBalance string                       `json:"river_eth_balance"`
-	BaseEthBalance  string                       `json:"base_eth_balance"`
-	PostgresStatus  storage.PostgresStatusResult `json:"postgres_status"`
+	Record          RegistryNodeInfo              `json:"record"`
+	Local           bool                          `json:"local,omitempty"`
+	Http11          HttpResult                    `json:"http11"`
+	Http20          HttpResult                    `json:"http20"`
+	Grpc            GrpcResult                    `json:"grpc"`
+	RiverEthBalance string                        `json:"river_eth_balance"`
+	BaseEthBalance  string                        `json:"base_eth_balance"`
+	PostgresStatus  *storage.PostgresStatusResult `json:"postgres_status,omitempty"`
 }
 
 type RiverStatus struct {


### PR DESCRIPTION
The PostgresStatusResult for the local node was incorrectly being reported for all nodes in the network on the debug/multi and debug/multi/json endpoints. This PR does the following:
- remove local postgres status result from external nodes on the json page
- remove the pg status column from the debug/multi table, since we can't compute it for external nodes
- add a separate storage debug endpoint for inspecting these metrics

We also add the following stream-related metadata to our postgres metrics:
- MigratedStreams
- UnmigratedStreams
- NumPartitions