### PR TITLE
fix(contract): Tiered log pricing module bug

### DIFF
--- a/contracts/deployments/gamma/base/addresses/tieredLogPricing.json
+++ b/contracts/deployments/gamma/base/addresses/tieredLogPricing.json
@@ -1,1 +1,3 @@
-{"address":"0xd6557a643427d36DBae33B69d30f54A17De606Ab"}
+{
+  "address": "0x7472409D6044Ca9dee9FFC0aEEc339170AACf03e"
+}

--- a/contracts/src/spaces/facets/membership/pricing/tiered/TieredLogPricingOracle.sol
+++ b/contracts/src/spaces/facets/membership/pricing/tiered/TieredLogPricingOracle.sol
@@ -128,13 +128,13 @@ contract TieredLogPricingOracle is IMembershipPricing, IntrospectionFacet {
     if (totalMinted > tier3) {
       return basePriceTier3;
     } else if (totalMinted > tier2) {
-      // Logarithmin scaling for tier 2
-      uint256 logScale = _calculateLogScale(totalMinted - tier2 + 1);
-      return logScale * 22 + basePriceTier2; // The multiplier 22 is an arbitrary scaling factor
+      // Logarithmic scaling for tier 2
+      uint256 logScale = _calculateLogScale(totalMinted);
+      return logScale * 22 + basePriceTier2;
     } else if (totalMinted > tier1) {
       // Logarithmic scaling for tier 1
-      uint256 logScale = _calculateLogScale(totalMinted - tier1 + 1);
-      return logScale * 3 + basePriceTier1; // The multiplier 3 is an arbitrary scaling factor
+      uint256 logScale = _calculateLogScale(totalMinted);
+      return logScale * 3 + basePriceTier1;
     } else {
       // Below tier 1
       if (freeAllocation > totalMinted) return 0;

--- a/contracts/test/spaces/membership/pricing/TieredLogPricing.t.sol
+++ b/contracts/test/spaces/membership/pricing/TieredLogPricing.t.sol
@@ -53,7 +53,7 @@ contract TieredLogPricingTest is TestUtils {
       freeAllocation: 0,
       totalMinted: 1001
     });
-    assertEq(_getCentsFromWei(price1001), 7600); // $98.00 USD
+    assertEq(_getCentsFromWei(price1001), 7600); // $76.00 USD
 
     uint256 price10000 = pricingModule.getPrice({
       freeAllocation: 0,

--- a/contracts/test/spaces/membership/pricing/TieredLogPricing.t.sol
+++ b/contracts/test/spaces/membership/pricing/TieredLogPricing.t.sol
@@ -22,32 +22,51 @@ contract TieredLogPricingTest is TestUtils {
       address(new TieredLogPricingOracle(address(oracle)))
     );
 
-    // tier 0 < 1000
+    // tier 0 -> 100
     uint256 price0 = pricingModule.getPrice({
       freeAllocation: 0,
       totalMinted: 0
     });
     assertEq(_getCentsFromWei(price0), 100); // $1 USD
 
-    uint256 price1 = pricingModule.getPrice({
+    uint256 price100 = pricingModule.getPrice({
       freeAllocation: 0,
-      totalMinted: 2
+      totalMinted: 100
     });
-    assertEq(_getCentsFromWei(price1), 115); // $1.15 USD
+    assertEq(_getCentsFromWei(price100), 200); // $2.00 USD
 
-    // tier 1 > 1000
+    // tier 101 -> 1000
+    uint256 price101 = pricingModule.getPrice({
+      freeAllocation: 0,
+      totalMinted: 101
+    });
+    assertEq(_getCentsFromWei(price101), 700); // $7.00 USD
+
     uint256 price1000 = pricingModule.getPrice({
       freeAllocation: 0,
       totalMinted: 1000
     });
-    assertEq(_getCentsFromWei(price1000), 985); // $9.85 USD
+    assertEq(_getCentsFromWei(price1000), 1000); // $10.00 USD
 
-    // tier 2 > 10000
+    // tier 1001 -> 10000
+    uint256 price1001 = pricingModule.getPrice({
+      freeAllocation: 0,
+      totalMinted: 1001
+    });
+    assertEq(_getCentsFromWei(price1001), 7600); // $98.00 USD
+
     uint256 price10000 = pricingModule.getPrice({
       freeAllocation: 0,
       totalMinted: 10000
     });
-    assertEq(_getCentsFromWei(price10000), 9690); // $96.90 USD
+    assertEq(_getCentsFromWei(price10000), 9800); // $98.00 USD
+
+    // tier 10_000+
+    uint256 price10001 = pricingModule.getPrice({
+      freeAllocation: 0,
+      totalMinted: 10001
+    });
+    assertEq(_getCentsFromWei(price10001), 10000); // $100.00 USD
   }
 
   // =============================================================


### PR DESCRIPTION
The issue was that we were resetting the logarithmic scale at each tier boundary by subtracting the tier threshold. This caused the price to drop when moving to a new tier because we were essentially starting the logarithmic scaling from 1 again.