### PR TITLE
fix(contract): refactor reward scaling to keep dust

### DIFF
--- a/contracts/src/base/registry/facets/distribution/v2/IRewardsDistribution.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/IRewardsDistribution.sol
@@ -134,11 +134,11 @@ interface IRewardsDistributionBase {
   /// @notice Emitted when space delegation rewards are swept to the operator
   /// @param space The address of the space
   /// @param operator The address of the operator
-  /// @param amount The amount of rewardToken that is swept
+  /// @param scaledReward The scaled amount of rewardToken that is swept
   event SpaceRewardsSwept(
     address indexed space,
     address indexed operator,
-    uint256 amount
+    uint256 scaledReward
   );
 }
 

--- a/contracts/src/base/registry/facets/distribution/v2/RewardsDistribution.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/RewardsDistribution.sol
@@ -451,7 +451,9 @@ contract RewardsDistribution is
     RewardsDistributionStorage.Layout storage ds = RewardsDistributionStorage
       .layout();
     return
-      ds.staking.currentReward(ds.staking.treasureByBeneficiary[beneficiary]);
+      ds.staking.currentRewardScaled(
+        ds.staking.treasureByBeneficiary[beneficiary]
+      ) / StakingRewards.SCALE_FACTOR;
   }
 
   /// @inheritdoc IRewardsDistribution

--- a/contracts/src/base/registry/facets/distribution/v2/RewardsDistributionBase.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/RewardsDistributionBase.sol
@@ -121,17 +121,17 @@ abstract contract RewardsDistributionBase is IRewardsDistributionBase {
       .treasureByBeneficiary[space];
     staking.updateReward(spaceTreasure);
 
-    uint256 reward = spaceTreasure.unclaimedRewardSnapshot;
-    if (reward == 0) return;
+    uint256 scaledReward = spaceTreasure.unclaimedRewardSnapshot;
+    if (scaledReward == 0) return;
 
     address operator = _getOperatorBySpace(space);
     StakingRewards.Treasure storage operatorTreasure = staking
       .treasureByBeneficiary[operator];
 
-    operatorTreasure.unclaimedRewardSnapshot += reward;
+    operatorTreasure.unclaimedRewardSnapshot += scaledReward;
     spaceTreasure.unclaimedRewardSnapshot = 0;
 
-    emit SpaceRewardsSwept(space, operator, reward);
+    emit SpaceRewardsSwept(space, operator, scaledReward);
   }
 
   /// @dev Checks if the delegatee is a space
@@ -182,12 +182,9 @@ abstract contract RewardsDistributionBase is IRewardsDistributionBase {
       }
       total +=
         treasure.unclaimedRewardSnapshot +
-        FixedPointMathLib.fullMulDiv(
-          treasure.earningPower,
-          rewardPerTokenGrowth,
-          StakingRewards.SCALE_FACTOR
-        );
+        (uint256(treasure.earningPower) * rewardPerTokenGrowth);
     }
+    total /= StakingRewards.SCALE_FACTOR;
   }
 
   /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/contracts/test/base/registry/RewardsDistributionV2.t.sol
+++ b/contracts/test/base/registry/RewardsDistributionV2.t.sol
@@ -38,6 +38,7 @@ contract RewardsDistributionV2Test is
     keccak256(
       "Stake(uint96 amount,address delegatee,address beneficiary,address owner,uint256 nonce,uint256 deadline)"
     );
+  uint256 internal constant REASONABLE_TOKEN_SUPPLY = 1e38;
 
   NodeOperatorFacet internal operatorFacet;
   River internal river;
@@ -892,7 +893,6 @@ contract RewardsDistributionV2Test is
     );
     commissionRate = bound(commissionRate, 0, 10000);
     timeLapse = bound(timeLapse, 0, rewardDuration);
-    rewardAmount = boundReward(rewardAmount);
 
     test_fuzz_notifyRewardAmount(rewardAmount);
     test_stake();
@@ -927,7 +927,6 @@ contract RewardsDistributionV2Test is
     commissionRate = bound(commissionRate, 0, 10000);
     timeLapse = bound(timeLapse, 0, rewardDuration);
     amount = uint96(bound(amount, 1 ether, type(uint96).max));
-    rewardAmount = boundReward(rewardAmount);
 
     test_fuzz_notifyRewardAmount(rewardAmount);
     test_fuzz_stake(
@@ -964,7 +963,6 @@ contract RewardsDistributionV2Test is
     commissionRate = bound(commissionRate, 0, 10000);
     timeLapse = bound(timeLapse, 0, rewardDuration);
     amount = uint96(bound(amount, 1 ether, type(uint96).max));
-    rewardAmount = boundReward(rewardAmount);
 
     test_fuzz_notifyRewardAmount(rewardAmount);
     test_fuzz_stake_toSpace(
@@ -1141,9 +1139,12 @@ contract RewardsDistributionV2Test is
       bound(
         reward,
         rewardDuration,
-        rewardDuration.fullMulDiv(
-          type(uint256).max,
-          StakingRewards.SCALE_FACTOR
+        FixedPointMathLib.min(
+          rewardDuration.fullMulDiv(
+            type(uint256).max,
+            StakingRewards.SCALE_FACTOR
+          ),
+          REASONABLE_TOKEN_SUPPLY
         )
       );
   }


### PR DESCRIPTION
Adjusted reward calculation to maintain fractional precision by scaling rewards correctly. Renamed `currentReward` to `currentRewardScaled` to indicate the scaling operation. Updated event naming and applied necessary changes across functions and tests to support the new reward scaling logic.