### PR TITLE
Fix harmony userOps tests by changing default chainId back to 1n for DecodedCheckOps

### DIFF
--- a/packages/web3/src/entitlement.ts
+++ b/packages/web3/src/entitlement.ts
@@ -936,7 +936,7 @@ export function createOperationsTree(
         return {
             opType: OperationType.CHECK,
             checkType: op.type,
-            chainId: op.chainId ?? 0n,
+            chainId: op.chainId ?? 1n,
             contractAddress: op.address ?? zeroAddress,
             params,
         }


### PR DESCRIPTION
Tested against harmony and should fix the river merge.