### PR TITLE
docs: fix typo readme.md

### DIFF
--- a/contracts/src/diamond/readme.md
+++ b/contracts/src/diamond/readme.md
@@ -27,7 +27,7 @@ interface ISampleBase {
   event ValueSet(uint256 value);
 }
 
-inteface ISample is ISampleBase {
+interface ISample is ISampleBase {
   function setValue(uint256) external;
 }
 


### PR DESCRIPTION
Fixed a typo to make the documentation clearer. Hope this helps.