### PR TITLE
find most recently deployed pricing module

### DIFF
--- a/packages/web3/src/Utils.ts
+++ b/packages/web3/src/Utils.ts
@@ -113,7 +113,11 @@ export const getFixedPricingModule = async (spaceDapp: ISpaceDapp | undefined) =
 }
 
 export const findDynamicPricingModule = (pricingModules: PricingModuleStruct[]) =>
-    pricingModules.find((module) => module.name === TIERED_PRICING_ORACLE)
+    // TODO: reverse() is a temporary fix to find the most recently deployed pricing module
+    // but it's not a great solution, we need to filter the array by address
+    // which requires adding env var and reading it here
+    // or we need some other identifier for pricing module
+    [...pricingModules].reverse().find((module) => module.name === TIERED_PRICING_ORACLE)
 
 export const findFixedPricingModule = (pricingModules: PricingModuleStruct[]) =>
     pricingModules.find((module) => module.name === FIXED_PRICING)


### PR DESCRIPTION
There is going to be a bug once [this is deployed to omega](https://llama-testnet.river.build/orgs/river/base-sepolia/actions/236)

Gamma, where this is already deployed, is returning 2 elements where the name is `TieredLogPricingOracleV2`, and the client is grabbing the first, outdated one.

I don't like this solution, I'll defer to @giuseppecrj to comment on whether we can/should update the contract to have a different pricing module with a unique name or identifier. If pricing modules are removed or added in wrong order this has potential to not work.

```
[
  {
    "name": "FixedPricing",
    "description": "Fixed pricing for membership",
    "module": "0x1c5a61bf87c7040cD4e88c20374b21877A7a0417"
  },
  {
    "name": "TieredLogPricingOracle",
    "description": "Free for the first 100 members, then logarithmically increasing price",
    "module": "0xd6557a643427d36DBae33B69d30f54A17De606Ab"
  },
  {
    "name": "TieredLogPricingOracleV2",
    "description": "Free for the first 100 members, then logarithmically increasing price",
    "module": "0xd199c3107C3D22C9645775f0d5C8d237126e1FA6"
  },
  {
    "name": "TieredLogPricingOracleV2",
    "description": "Free for the first 100 members, then logarithmically increasing price",
    "module": "0x7472409D6044Ca9dee9FFC0aEEc339170AACf03e"
  }
]
```