### PR TITLE
docs: remove mintlify dashboard link on header

### DIFF
--- a/packages/docs/mint.json
+++ b/packages/docs/mint.json
@@ -37,10 +37,6 @@
       "url": "https://github.com/river-build"
     }
   ],
-  "topbarCtaButton": {
-    "name": "Dashboard",
-    "url": "https://dashboard.mintlify.com"
-  },
   "tabs": [
   ],
   "navigation": [


### PR DESCRIPTION
not useful for the final user

prev:
![docs header contain a button with the text "Dashboard", that points to mintlify dashboard](https://github.com/user-attachments/assets/4932c94e-8054-4c5f-93fa-9ec1763601ec)
now:
![docs header doesn't contain the "Dashboard" button](https://github.com/user-attachments/assets/47be2ecb-3330-4070-ba4f-f16e7cc5ec84)
