### PR TITLE
feat(contract): add `getDepositIdByDelegator` to `MainnetDelegation`

### DIFF
--- a/contracts/scripts/deployments/facets/DeployMainnetDelegation.s.sol
+++ b/contracts/scripts/deployments/facets/DeployMainnetDelegation.s.sol
@@ -24,6 +24,7 @@ contract DeployMainnetDelegation is FacetHelper, Deployer {
     addSelector(MainnetDelegation.getProxyDelegation.selector);
     addSelector(MainnetDelegation.getMessenger.selector);
     addSelector(MainnetDelegation.removeDelegations.selector);
+    addSelector(MainnetDelegation.getDepositIdByDelegator.selector);
   }
 
   function initializer() public pure override returns (bytes4) {

--- a/contracts/src/tokens/river/base/delegation/MainnetDelegation.sol
+++ b/contracts/src/tokens/river/base/delegation/MainnetDelegation.sol
@@ -60,6 +60,12 @@ contract MainnetDelegation is
     return address(_getProxyDelegation());
   }
 
+  function getDepositIdByDelegator(
+    address delegator
+  ) external view returns (uint256) {
+    return _getDepositIdByDelegator(delegator);
+  }
+
   // =============================================================
   //                       Remove Delegators
   // =============================================================

--- a/contracts/src/tokens/river/base/delegation/MainnetDelegationBase.sol
+++ b/contracts/src/tokens/river/base/delegation/MainnetDelegationBase.sol
@@ -135,6 +135,12 @@ abstract contract MainnetDelegationBase is IMainnetDelegationBase {
     }
   }
 
+  function _getDepositIdByDelegator(
+    address delegator
+  ) internal view returns (uint256) {
+    return MainnetDelegationStorage.layout().depositIdByDelegator[delegator];
+  }
+
   function _getDelegationByDelegator(
     address delegator
   ) internal view returns (Delegation memory) {


### PR DESCRIPTION
Implemented `getDepositIdByDelegator` in `MainnetDelegation` to retrieve deposit IDs by delegator. Updated related deployment script and delegation base contract to support this new function.