### PR TITLE
fix(contract): fix possible staking overflow

### DIFF
--- a/contracts/src/base/registry/facets/distribution/v2/IRewardsDistribution.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/IRewardsDistribution.sol
@@ -15,7 +15,7 @@ interface IRewardsDistributionBase {
   /// @param nextDepositId The next deposit ID that will be used
   struct StakingState {
     address riverToken;
-    uint256 totalStaked;
+    uint96 totalStaked;
     uint256 rewardDuration;
     uint256 rewardEndTime;
     uint256 lastUpdateTime;
@@ -285,7 +285,7 @@ interface IRewardsDistribution is IRewardsDistributionBase {
   /// @return amount The amount of stakeToken that is staked by the depositor
   function stakedByDepositor(
     address depositor
-  ) external view returns (uint256 amount);
+  ) external view returns (uint96 amount);
 
   /// @notice Returns the deposit IDs for a particular depositor
   /// @param depositor The address of the depositor

--- a/contracts/src/base/registry/facets/distribution/v2/RewardsDistribution.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/RewardsDistribution.sol
@@ -377,7 +377,7 @@ contract RewardsDistribution is
   /// @inheritdoc IRewardsDistribution
   function stakedByDepositor(
     address depositor
-  ) external view returns (uint256 amount) {
+  ) external view returns (uint96 amount) {
     RewardsDistributionStorage.Layout storage ds = RewardsDistributionStorage
       .layout();
     amount = ds.staking.stakedByDepositor[depositor];

--- a/contracts/src/base/registry/facets/distribution/v2/StakingRewards.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/StakingRewards.sol
@@ -61,14 +61,14 @@ library StakingRewards {
   struct Layout {
     address rewardToken;
     address stakeToken;
-    uint256 totalStaked;
+    uint96 totalStaked;
     uint256 rewardDuration;
     uint256 rewardEndTime;
     uint256 lastUpdateTime;
     uint256 rewardRate;
     uint256 rewardPerTokenAccumulated;
     uint256 nextDepositId;
-    mapping(address depositor => uint256 amount) stakedByDepositor;
+    mapping(address depositor => uint96 amount) stakedByDepositor;
     mapping(address beneficiary => Treasure) treasureByBeneficiary;
     mapping(uint256 depositId => Deposit) depositById;
   }
@@ -97,7 +97,7 @@ library StakingRewards {
   ) internal view returns (uint256) {
     // cache storage reads
     (
-      uint256 totalStaked,
+      uint96 totalStaked,
       uint256 lastUpdateTime,
       uint256 rewardRate,
       uint256 rewardPerTokenAccumulated

--- a/contracts/test/base/registry/RewardsDistributionV2.t.sol
+++ b/contracts/test/base/registry/RewardsDistributionV2.t.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.23;
 import {IOwnableBase} from "contracts/src/diamond/facets/ownable/IERC173.sol";
 
 // libraries
+import {stdError} from "forge-std/StdError.sol";
 import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 import {StakingRewards} from "contracts/src/base/registry/facets/distribution/v2/StakingRewards.sol";
@@ -81,6 +82,17 @@ contract RewardsDistributionV2Test is
   function test_stake_revertIf_beneficiaryIsZero() public {
     vm.expectRevert(StakingRewards.StakingRewards__InvalidAddress.selector);
     rewardsDistributionFacet.stake(1, OPERATOR, address(0));
+  }
+
+  function test_stake_revertIf_overflow() public givenOperator(OPERATOR, 0) {
+    bridgeTokensForUser(address(this), 1 << 97);
+
+    river.approve(address(rewardsDistributionFacet), type(uint256).max);
+
+    rewardsDistributionFacet.stake(type(uint96).max, OPERATOR, address(this));
+
+    vm.expectRevert(stdError.arithmeticError);
+    rewardsDistributionFacet.stake(type(uint96).max, OPERATOR, address(this));
   }
 
   function test_stake() public returns (uint256 depositId) {

--- a/contracts/test/base/registry/RewardsDistributionV2.t.sol
+++ b/contracts/test/base/registry/RewardsDistributionV2.t.sol
@@ -932,24 +932,27 @@ contract RewardsDistributionV2Test is
   /// forge-config: default.fuzz.runs = 64
   function test_fuzz_claimReward_multipleDepositors(
     address[32] memory depositors,
-    uint96[32] memory amounts,
+    uint256[32] memory amounts,
     address beneficiary,
     uint256 rewardAmount,
     uint256 timeLapse
   ) public {
     depositors[0] = beneficiary;
+    sanitizeAmounts(amounts);
     timeLapse = bound(timeLapse, 0, rewardDuration);
 
     test_fuzz_notifyRewardAmount(rewardAmount);
 
     for (uint256 i; i < 32; ++i) {
-      amounts[i] = uint96(bound(amounts[i], 1, type(uint88).max));
-
       bridgeTokensForUser(depositors[i], amounts[i]);
 
       vm.startPrank(depositors[i]);
       river.approve(address(rewardsDistributionFacet), amounts[i]);
-      rewardsDistributionFacet.stake(amounts[i], OPERATOR, depositors[i]);
+      rewardsDistributionFacet.stake(
+        uint96(amounts[i]),
+        OPERATOR,
+        depositors[i]
+      );
       vm.stopPrank();
     }
 

--- a/contracts/test/base/registry/RewardsDistributionV2.t.sol
+++ b/contracts/test/base/registry/RewardsDistributionV2.t.sol
@@ -580,6 +580,7 @@ contract RewardsDistributionV2Test is
         operator != depositors[1]
     );
     vm.assume(OPERATOR != depositors[0] && OPERATOR != depositors[1]);
+    amounts[1] = uint96(bound(amounts[1], 0, type(uint96).max - amounts[0]));
     timeLapse = bound(timeLapse, 0, rewardDuration);
 
     test_notifyRewardAmount();
@@ -905,6 +906,7 @@ contract RewardsDistributionV2Test is
         beneficiary != address(this) &&
         beneficiary != address(rewardsDistributionFacet)
     );
+    amount = uint96(bound(amount, 1, type(uint96).max - 1 ether));
     timeLapse = bound(timeLapse, 0, rewardDuration);
 
     test_fuzz_notifyRewardAmount(rewardAmount);

--- a/contracts/test/base/registry/StakingRewards.t.sol
+++ b/contracts/test/base/registry/StakingRewards.t.sol
@@ -35,6 +35,6 @@ contract StakingRewardsTest is Test {
     assembly {
       length := sub(slotAfterLayout.slot, layout.slot)
     }
-    assertEq(length, 12);
+    assertEq(length, 11);
   }
 }


### PR DESCRIPTION
This commit introduces a test to check for overflow scenarios in the stake function of the RewardsDistributionV2 contract. It simulates an overflow condition using stdError and ensures that the correct revert behavior is triggered.

Change the `totalStaked` and `stakedByDepositor` data types from `uint256` to `uint96` across multiple contracts to optimize storage. Ensure that the test suite properly bounds values within the new `uint96` range.