### PR TITLE
Don’t allow more than one simultaneous stream/media/client request in stream-metadata service

### DIFF
--- a/packages/stream-metadata/package.json
+++ b/packages/stream-metadata/package.json
@@ -39,6 +39,7 @@
 		"esbuild-plugin-pino": "^2.2.0",
 		"ethers": "^5.7.2",
 		"fastify": "^4.28.1",
+		"lru-cache": "^11.0.1",
 		"magic-bytes.js": "^1.10.0",
 		"pino": "^8.17.1",
 		"pino-pretty": "^10.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6179,6 +6179,7 @@ __metadata:
     fastify: ^4.28.1
     jest: ^29.6.2
     jest-transform-stub: ^2.0.0
+    lru-cache: ^11.0.1
     magic-bytes.js: ^1.10.0
     pino: ^8.17.1
     pino-pretty: ^10.2.3


### PR DESCRIPTION
I think this is a first step before adding a LRU cache outlined here: https://github.com/river-build/river/pull/1345

This service is super bursty, if we have lots of traffic coming into it hopefully this will serve everything with the same resources.

Decrypting the space image is already debounced at the StreamStateView level, so this should make a visible impact.