### PR TITLE
node/http_client: enable http2 pings on idle connections

### DIFF
--- a/core/node/http_client/client.go
+++ b/core/node/http_client/client.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"golang.org/x/net/http2"
 
@@ -60,6 +61,8 @@ func GetHttpClient(ctx context.Context) (*http.Client, error) {
 	return &http.Client{
 		Transport: &http2.Transport{
 			TLSClientConfig: getTLSConfig(ctx),
+			ReadIdleTimeout: 20 * time.Second, // send http2 ping on idle connection for keep alive
+			PingTimeout:     15 * time.Second, // http2 ping must be received within 15s, if not connection is closed
 		},
 	}, nil
 }


### PR DESCRIPTION
This enables http2 ping on idle connections that haven't received a single frame in 20s. Connection is closed when pong isn't received in 15s.