### PR TITLE
rpc/archiver: ensure response exists after fetching  mini-blocks

### DIFF
--- a/core/node/rpc/archiver.go
+++ b/core/node/rpc/archiver.go
@@ -202,8 +202,7 @@ func (a *Archiver) ArchiveStream(ctx context.Context, stream *ArchiveStream) err
 			return err
 		}
 
-		msg := resp.Msg
-		if (err != nil && AsRiverError(err).Code == Err_NOT_FOUND) || len(msg.Miniblocks) == 0 {
+		if (err != nil && AsRiverError(err).Code == Err_NOT_FOUND) || resp.Msg == nil || len(resp.Msg.Miniblocks) == 0 {
 			log.Info(
 				"ArchiveStream: GetMiniblocks did not return data, remote storage is not up-to-date with contract yet",
 				"streamId",
@@ -220,6 +219,8 @@ func (a *Archiver) ArchiveStream(ctx context.Context, stream *ArchiveStream) err
 			})
 			return nil
 		}
+
+		msg := resp.Msg
 
 		// Validate miniblocks are sequential.
 		// TODO: validate miniblock signatures.


### PR DESCRIPTION
Continues integration tests fail [often](https://github.com/river-build/river/actions/runs/11854195132/job/33035852339#step:17:116) because get miniblock response error handling doesn't cover all paths.

