### PR TITLE
Fix build protobufs task in tasks.json to build all protobufs

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -313,7 +313,7 @@
     {
       "label": "BuildProtobufs",
       "type": "shell",
-      "command": "yarn csb:build",
+      "command": "./scripts/build-protobufs.sh",
       "isBackground": true,
       "problemMatcher": [],
       "presentation": {


### PR DESCRIPTION
I’ve been wondering why i was failing to check in go protobuf definitions lately.