### PR TITLE
Add unpackEnvelopeOpts to the stress client

### DIFF
--- a/packages/sdk/src/sync-agent/syncAgent.ts
+++ b/packages/sdk/src/sync-agent/syncAgent.ts
@@ -24,6 +24,7 @@ import { makeStreamRpcClient, type MakeRpcClientType } from '../makeStreamRpcCli
 import type { EncryptionDeviceInitOpts } from '@river-build/encryption'
 import { Gdms, type GdmsModel } from './gdms/gdms'
 import { Dms, DmsModel } from './dms/dms'
+import { UnpackEnvelopeOpts } from '../sign'
 
 export interface SyncAgentConfig {
     context: SignerContext
@@ -37,6 +38,7 @@ export interface SyncAgentConfig {
     makeRpcClient?: MakeRpcClientType
     encryptionDevice?: EncryptionDeviceInitOpts
     onTokenExpired?: () => void
+    unpackEnvelopeOpts?: UnpackEnvelopeOpts
 }
 
 export class SyncAgent {
@@ -92,6 +94,7 @@ export class SyncAgent {
                 rpcRetryParams: config.retryParams,
                 encryptionDevice: config.encryptionDevice,
                 onTokenExpired: config.onTokenExpired,
+                unpackEnvelopeOpts: config.unpackEnvelopeOpts,
             },
         )
 

--- a/packages/stress/src/utils/stressClient.ts
+++ b/packages/stress/src/utils/stressClient.ts
@@ -42,6 +42,10 @@ export async function makeStressClient(
     const agent = await bot.makeSyncAgent({
         disablePersistenceStore: true,
         makeRpcClient: makeHttp2StreamRpcClient,
+        unpackEnvelopeOpts: {
+            disableHashValidation: true,
+            disableSignatureValidation: true,
+        },
         encryptionDevice: {
             fromExportedDevice: device,
             pickleKey: sha256(botPrivateKey),


### PR DESCRIPTION
This cuts way down on the amount of cpu that they need to run.