### PR TITLE
Enable test apis when running locally by default

### DIFF
--- a/core/env/local/common/common.yaml
+++ b/core/env/local/common/common.yaml
@@ -46,6 +46,7 @@ chains: '31337:http://localhost:8545,31338:http://localhost:8546,84532:https://s
 xChainBlockchains: '31337,31338,84532,11155111'
 
 enableDebugEndpoints: true
+enableTestAPIs: true
 
 standByOnStart: false
 

--- a/core/node/rpc/info.go
+++ b/core/node/rpc/info.go
@@ -63,7 +63,12 @@ func (s *Service) info(
 		}
 
 		if s.config.EnableTestAPIs {
-			if debug == "panic" {
+			if debug == "ping" {
+				log.Info("PINGED")
+				return connect.NewResponse(&InfoResponse{
+					Graffiti: "pong",
+				}), nil
+			} else if debug == "panic" {
 				log.Error("panic requested through Info request")
 				panic("panic requested through Info request")
 			} else if debug == "flush_cache" {

--- a/packages/sdk/src/streamRpcClient.test.ts
+++ b/packages/sdk/src/streamRpcClient.test.ts
@@ -312,6 +312,16 @@ describe('streamRpcClient', () => {
         expect(result.graffiti).toEqual('River Node welcomes you!')
     })
 
+    test('ping', async () => {
+        // ping is a debug endpoint, so it's not available in production
+        const client = await makeTestRpcClient()
+        log('ping', 'url', client.url)
+        expect(client).toBeDefined()
+        const result = await client.info({ debug: ['ping'] })
+        expect(result).toBeDefined()
+        expect(result.graffiti).toEqual('pong')
+    })
+
     test('error', async () => {
         const client = await makeTestRpcClient()
         expect(client).toBeDefined()


### PR DESCRIPTION
I think we have these off because when we set them up there wasn't a great local config that we could put them into right?