### PR TITLE
perf(contract): aesthetic touch

### DIFF
--- a/contracts/src/diamond/facets/ownable/token/TokenOwnableBase.sol
+++ b/contracts/src/diamond/facets/ownable/token/TokenOwnableBase.sol
@@ -25,7 +25,7 @@ abstract contract TokenOwnableBase is ITokenOwnableBase {
   }
 
   function _owner() internal view returns (address owner) {
-    TokenOwnableStorage.Layout memory ds = TokenOwnableStorage.layout();
+    TokenOwnableStorage.Layout storage ds = TokenOwnableStorage.layout();
     return IERC721(ds.collection).ownerOf(ds.tokenId);
   }
 
@@ -33,7 +33,7 @@ abstract contract TokenOwnableBase is ITokenOwnableBase {
     address oldOwner = _owner();
     if (newOwner == address(0)) revert Ownable__ZeroAddress();
 
-    TokenOwnableStorage.Layout memory ds = TokenOwnableStorage.layout();
+    TokenOwnableStorage.Layout storage ds = TokenOwnableStorage.layout();
 
     IERC721(ds.collection).safeTransferFrom(_owner(), newOwner, ds.tokenId);
     emit OwnershipTransferred(oldOwner, newOwner);

--- a/contracts/src/spaces/facets/membership/MembershipFacet.sol
+++ b/contracts/src/spaces/facets/membership/MembershipFacet.sol
@@ -50,7 +50,8 @@ contract MembershipFacet is
 
   /// @inheritdoc IMembership
   function joinSpace(address receiver) external payable nonReentrant {
-    _joinSpaceWithReferral(receiver, ReferralTypes(address(0), address(0), ""));
+    ReferralTypes memory emptyReferral;
+    _joinSpaceWithReferral(receiver, emptyReferral);
   }
 
   /// @inheritdoc IMembership


### PR DESCRIPTION
Refactor the `joinSpace` function to use a properly initialized `ReferralTypes` struct instead of passing explicit default values. This change enhances code readability and follows best practices for struct initialization.