### PR TITLE
Fix the retry interceptor

### DIFF
--- a/core/node/rpc/info.go
+++ b/core/node/rpc/info.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"time"
 
 	"github.com/river-build/river/core/node/rpc/sync"
 	"github.com/river-build/river/core/node/utils"
@@ -83,6 +84,23 @@ func (s *Service) info(
 				return connect.NewResponse(&InfoResponse{
 					Graffiti: "exiting...",
 				}), nil
+			} else if debug == "sleep" {
+				sleepDuration := 30 * time.Second 
+				log.Info("SLEEPING FOR", "sleepDuration", sleepDuration)
+				select {
+				case <-time.After(sleepDuration):
+					// Sleep completed
+					log.Info("Sleep completed")
+					return connect.NewResponse(&InfoResponse{
+						Graffiti: fmt.Sprintf("slept for %v", sleepDuration),
+					}), nil
+				case <-ctx.Done():
+					// Context was canceled
+					log.Info("Sleep canceled due to context cancellation")
+					return connect.NewResponse(&InfoResponse{
+						Graffiti: "Context canceled",
+					}), nil
+				}
 			}
 		}
 	}

--- a/packages/sdk/src/makeAuthenticationRpcClient.ts
+++ b/packages/sdk/src/makeAuthenticationRpcClient.ts
@@ -3,8 +3,8 @@ import { ConnectTransportOptions, createConnectTransport } from '@connectrpc/con
 import { AuthenticationService } from '@river-build/proto'
 import { dlog } from '@river-build/dlog'
 import { getEnvVar, randomUrlSelector } from './utils'
-import { loggingInterceptor, retryInterceptor } from './rpcInterceptors'
-import { RpcOptions, DEFAULT_RETRY_PARAMS, DEFAULT_TIMEOUT_MS } from './rpcOptions'
+import { DEFAULT_RETRY_PARAMS, loggingInterceptor, retryInterceptor } from './rpcInterceptors'
+import { RpcOptions } from './rpcOptions'
 
 const logInfo = dlog('csb:auto-rpc:info')
 
@@ -18,7 +18,6 @@ export function makeAuthenticationRpcClient(
 ): AuthenticationRpcClient {
     const transportId = nextRpcClientNum++
     const retryParams = opts?.retryParams ?? DEFAULT_RETRY_PARAMS
-    const defaultTimeoutMs = opts?.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS
     const url = randomUrlSelector(dest)
     logInfo(
         'makeAuthenticationRpcClient: Connecting to url=',
@@ -31,11 +30,11 @@ export function makeAuthenticationRpcClient(
     const options: ConnectTransportOptions = {
         baseUrl: url,
         interceptors: [
-            retryInterceptor(retryParams),
-            loggingInterceptor(transportId, 'AuthenticationService'),
             ...(opts?.interceptors ?? []),
+            loggingInterceptor(transportId, 'AuthenticationService'),
+            retryInterceptor(retryParams),
         ],
-        defaultTimeoutMs: defaultTimeoutMs,
+        defaultTimeoutMs: undefined, // default timeout is undefined, we add a timeout in the retryInterceptor
     }
     if (getEnvVar('RIVER_DEBUG_TRANSPORT') !== 'true') {
         options.useBinaryFormat = true

--- a/packages/sdk/src/rpcInterceptors.ts
+++ b/packages/sdk/src/rpcInterceptors.ts
@@ -12,10 +12,18 @@ import { genShortId, streamIdAsString } from './id'
 import { isBaseUrlIncluded, isIConnectError } from './utils'
 import { dlog, dlogError, check } from '@river-build/dlog'
 
+export const DEFAULT_RETRY_PARAMS: RetryParams = {
+    maxAttempts: 3,
+    initialRetryDelay: 2000,
+    maxRetryDelay: 6000,
+    defaultTimeoutMs: 30000, // 30 seconds for long running requests
+}
+
 export type RetryParams = {
     maxAttempts: number
     initialRetryDelay: number
     maxRetryDelay: number
+    defaultTimeoutMs: number
     refreshNodeUrl?: () => Promise<string>
 }
 
@@ -38,6 +46,7 @@ const histogramIntervalMs = 5000
 export const retryInterceptor: (retryParams: RetryParams) => Interceptor = (
     retryParams: RetryParams,
 ) => {
+    logError('retryInterceptor', 'retryParams=', retryParams)
     return (next) =>
         async (
             req: UnaryRequest<AnyMessage, AnyMessage> | StreamRequest<AnyMessage, AnyMessage>,
@@ -45,17 +54,61 @@ export const retryInterceptor: (retryParams: RetryParams) => Interceptor = (
             if (req.stream) {
                 return await next(req)
             }
+            const requestStart = Date.now()
             let attempt = 0
+            const id = req.header.get('x-river-request-id')
+            if (!id) {
+                throw new Error(
+                    'No request id, expected header x-river-request-id which is set by loggingInterceptor',
+                )
+            }
+            const orignalAbortSignal = req.signal
             // eslint-disable-next-line no-constant-condition
             while (true) {
+                const loopStart = Date.now()
+                const abortController = new AbortController()
+                const signal = abortController.signal
+                const originalAbortHandler = () => {
+                    const elapsed = Date.now() - requestStart
+                    logError(
+                        'Orignial request aborted in retryInterceptor',
+                        'rpc:',
+                        req.method.name,
+                        id,
+                        'elapsed=',
+                        elapsed,
+                    )
+                    abortController.abort()
+                }
+                // listen to the original abort signal and abort the request if it's aborted
+                orignalAbortSignal?.addEventListener('abort', originalAbortHandler)
+                // set a timeout on the request
+                const requestTimeoutId = setTimeout(() => {
+                    const elapsed = Date.now() - loopStart
+                    logError(
+                        'Request timed out in retryInterceptor',
+                        'rpc:',
+                        req.method.name,
+                        id,
+                        'elapsed=',
+                        elapsed,
+                    )
+                    abortController.abort({
+                        message: 'The operation was aborted.',
+                        name: 'AbortError',
+                    })
+                }, retryParams.defaultTimeoutMs)
+
                 attempt++
                 try {
                     // Clone the request before each attempt
-                    const clonedReq = cloneUnaryRequest(req)
+                    const clonedReq = cloneUnaryRequest(req, signal)
                     return await next(clonedReq)
                 } catch (e) {
-                    const retryDelay = getRetryDelay(e, attempt, retryParams)
-                    if (retryDelay <= 0) {
+                    const elapsed = Date.now() - loopStart
+                    const retryDelay = getRetryDelay(e, signal.aborted, attempt, retryParams)
+                    // if the request was aborted, or we've run out of retries, throw the error
+                    if (orignalAbortSignal.aborted || retryDelay <= 0) {
                         throw e
                     }
                     if (retryParams.refreshNodeUrl) {
@@ -67,17 +120,25 @@ export const retryInterceptor: (retryParams: RetryParams) => Interceptor = (
                         }
                     }
                     logError(
-                        req.method.name,
                         'ERROR RETRYING',
+                        'rpc:',
+                        req.method.name,
+                        id,
+                        'attempt=',
                         attempt,
                         'of',
                         retryParams.maxAttempts,
+                        'elapsed:',
+                        elapsed,
                         'retryDelay:',
                         retryDelay,
                         'error:',
                         e,
                     )
                     await new Promise((resolve) => setTimeout(resolve, retryDelay))
+                } finally {
+                    clearTimeout(requestTimeoutId)
+                    orignalAbortSignal?.removeEventListener('abort', originalAbortHandler)
                 }
             }
         }
@@ -219,7 +280,7 @@ export const loggingInterceptor: (transportId: number, serviceName?: string) => 
                         e.code === (Code.NotFound as number)
                     )
                 ) {
-                    logError(req.method.name, 'ERROR', id, e)
+                    logError('ERROR calling rpc:', req.method.name, id, e)
                     updateHistogram(req.method.name, streamId, true)
                 }
                 throw e
@@ -329,13 +390,22 @@ export function getRetryDelayMs(attempts: number, retryParams: RetryParams): num
     )
 }
 
-function getRetryDelay(error: unknown, attempts: number, retryParams: RetryParams): number {
+function getRetryDelay(
+    error: unknown,
+    didTimeout: boolean,
+    attempts: number,
+    retryParams: RetryParams,
+): number {
     check(attempts >= 1, 'attempts must be >= 1')
     // aellis wondering if we should retry forever if there's no internet connection
     if (attempts > retryParams.maxAttempts) {
         return -1 // no more attempts
     }
     const retryDelay = getRetryDelayMs(attempts, retryParams)
+
+    if (didTimeout) {
+        return retryDelay
+    }
 
     // we don't get a lot of info off of these errors... retry the ones that we know we need to
     if (error !== null && typeof error === 'object') {
@@ -380,6 +450,7 @@ function getRetryDelay(error: unknown, attempts: number, retryParams: RetryParam
 // Function to clone a UnaryRequest
 function cloneUnaryRequest<I extends Message<I>, O extends Message<O>>(
     req: UnaryRequest<I, O>,
+    signal: AbortSignal,
 ): UnaryRequest<I, O> {
     // Clone the message
     const clonedMessage = req.message.clone()
@@ -387,14 +458,19 @@ function cloneUnaryRequest<I extends Message<I>, O extends Message<O>>(
     // Clone headers
     const clonedHeader = new Headers(req.header)
 
-    // Since RequestInit and ContextValues are typically immutable or not modified during the request,
-    // we can reuse them. However, if they are mutable in your implementation, consider cloning them as well.
+    // Clone init
+    const clonedInit = { ...req.init }
+
+    // Clone contextValues
+    const clonedContextValues = { ...req.contextValues }
 
     // Return a new UnaryRequest with cloned properties
     return {
         ...req,
         message: clonedMessage,
         header: clonedHeader,
-        // Keep other properties as they are
+        init: clonedInit,
+        contextValues: clonedContextValues,
+        signal: signal,
     }
 }

--- a/packages/sdk/src/rpcOptions.ts
+++ b/packages/sdk/src/rpcOptions.ts
@@ -2,12 +2,8 @@ import { Interceptor, Transport } from '@connectrpc/connect'
 import { ConnectTransportOptions } from '@connectrpc/connect-web'
 import { type RetryParams } from './rpcInterceptors'
 
-export const DEFAULT_RETRY_PARAMS = { maxAttempts: 3, initialRetryDelay: 2000, maxRetryDelay: 6000 }
-export const DEFAULT_TIMEOUT_MS = 10000
-
 export interface RpcOptions {
     retryParams?: RetryParams
     interceptors?: Interceptor[]
-    defaultTimeoutMs?: number
     createConnectTransport?: (options: ConnectTransportOptions) => Transport
 }

--- a/packages/sdk/src/util.test.ts
+++ b/packages/sdk/src/util.test.ts
@@ -81,6 +81,7 @@ import {
 } from '@river-build/web3'
 import { RiverTimelineEvent, type TimelineEvent } from './sync-agent/timeline/models/timeline-types'
 import { SyncState } from './syncedStreamsLoop'
+import { RetryParams } from './rpcInterceptors'
 
 const log = dlog('csb:test:util')
 
@@ -130,9 +131,9 @@ const getNextTestUrl = async (): Promise<{
     }
 }
 
-export const makeTestRpcClient = async () => {
+export const makeTestRpcClient = async (opts?: { retryParams?: RetryParams }) => {
     const { urls: url, refreshNodeUrl } = await getNextTestUrl()
-    return makeStreamRpcClient(url, undefined, refreshNodeUrl)
+    return makeStreamRpcClient(url, opts?.retryParams, refreshNodeUrl, undefined)
 }
 
 export const makeEvent_test = async (

--- a/packages/stress/src/utils/rpc-http2.ts
+++ b/packages/stress/src/utils/rpc-http2.ts
@@ -7,13 +7,14 @@ import {
     retryInterceptor,
     StreamRpcClient,
     type RetryParams,
+    DEFAULT_RETRY_PARAMS,
 } from '@river-build/sdk'
 
 let nextRpcClientNum = 0
 
 export function makeHttp2StreamRpcClient(
     urls: string,
-    retryParams: RetryParams = { maxAttempts: 3, initialRetryDelay: 2000, maxRetryDelay: 6000 },
+    retryParams: RetryParams = DEFAULT_RETRY_PARAMS,
     refreshNodeUrl?: () => Promise<string>,
 ): StreamRpcClient {
     const transportId = nextRpcClientNum++
@@ -25,7 +26,7 @@ export function makeHttp2StreamRpcClient(
             loggingInterceptor(transportId),
             retryInterceptor({ ...retryParams, refreshNodeUrl }),
         ],
-        defaultTimeoutMs: 20000,
+        defaultTimeoutMs: undefined, // default timeout is undefined, we add a timeout in the retryInterceptor
     }
     if (!process.env.RIVER_DEBUG_TRANSPORT) {
         options.useBinaryFormat = true
@@ -40,6 +41,6 @@ export function makeHttp2StreamRpcClient(
 
     const client = createPromiseClient(StreamService, transport) as StreamRpcClient
     client.url = url
-    client.opts = { retryParams, defaultTimeoutMs: options.defaultTimeoutMs }
+    client.opts = { retryParams }
     return client
 }


### PR DESCRIPTION
Previously a timeout would trigger the global abort signal and subsequent requests would die imediately and trigger weird errors on the node. Use a local abort signal in the interceptor, but still respect the global abort signal. Set timers and clean everything up properly.

Test plan:
Wrote a test and improved logs