### PR TITLE
Add checks for defined stream ids

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -2101,12 +2101,14 @@ export class Client
         tags?: PlainMessage<Tags>,
         retryCount?: number,
     ): Promise<{ prevMiniblockHash: Uint8Array; eventId: string; error?: AddEventResponse_Error }> {
+        const streamIdStr = streamIdAsString(streamId)
+        check(isDefined(streamIdStr) && streamIdStr !== '', 'streamId must be defined')
         const event = await makeEvent(this.signerContext, payload, prevMiniblockHash)
         const eventId = bin_toHexString(event.hash)
         if (localId) {
             // when we have a localId, we need to update the local event with the eventId
             const stream = this.streams.get(streamId)
-            assert(stream !== undefined, 'unknown stream ' + streamIdAsString(streamId))
+            assert(stream !== undefined, 'unknown stream ' + streamIdStr)
             stream.updateLocalEvent(localId, eventId, 'sending')
         }
 

--- a/packages/sdk/src/syncedStreams.ts
+++ b/packages/sdk/src/syncedStreams.ts
@@ -1,5 +1,5 @@
 import { SyncCookie } from '@river-build/proto'
-import { DLogger, dlog, dlogError, shortenHexString } from '@river-build/dlog'
+import { DLogger, check, dlog, dlogError, shortenHexString } from '@river-build/dlog'
 import { StreamRpcClient } from './makeStreamRpcClient'
 import { SyncedStreamEvents } from './streamEvents'
 import TypedEmitter from 'typed-emitter'
@@ -62,7 +62,9 @@ export class SyncedStreams {
 
     public set(streamId: string | Uint8Array, stream: SyncedStream): void {
         this.log('stream set', streamId)
-        this.streams.set(streamIdAsString(streamId), stream)
+        const id = streamIdAsString(streamId)
+        check(id.length > 0, 'streamId cannot be empty')
+        this.streams.set(id, stream)
     }
 
     public delete(inStreamId: string | Uint8Array): void {


### PR DESCRIPTION
I don’t think this is happening, but want to rule it out.