### PR TITLE
reduce verbosity of get entitlement data fetch call

### DIFF
--- a/core/node/auth/space_contract_v3.go
+++ b/core/node/auth/space_contract_v3.go
@@ -307,7 +307,7 @@ func (sc *SpaceContractV3) GetSpaceEntitlementsForPermission(
 		&bind.CallOpts{Context: ctx},
 		permission.String(),
 	)
-	log.Info(
+	log.Debug(
 		"Got entitlement data",
 		"err",
 		err,


### PR DESCRIPTION
if this didn’t error do we need to know the fetch succeeded?