### PR TITLE
stop current decryption extensions in “resetCrypto” function

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -2200,6 +2200,8 @@ export class Client
             throw new Error('userId must be set to reset crypto')
         }
         this.cryptoBackend = undefined
+        await this.decryptionExtensions?.stop()
+        this.decryptionExtensions = undefined
         await this.cryptoStore.deleteAccount(this.userId)
         await this.initCrypto()
         await this.uploadDeviceKeys()


### PR DESCRIPTION
I guess I forgot that this function was here, because I’m not sure who else would have written it, but apparently we have a test that calls resetCrypo in a loop, and I noticed in the new vite tests its throwing warnings about 10+ listeners added to the same event https://github.com/river-build/river/actions/runs/11942779116/job/33290511830?pr=1582

this pr fixes this issue. This function isn’t called anywhere but the tests.