### PR TITLE
playground: use tsconfig path vite plugin

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -60,6 +60,7 @@
         "typescript": "^5.1.6",
         "vite": "^5.3.1",
         "vite-plugin-checker": "^0.8.0",
-        "vite-plugin-replace": "^0.1.1"
+        "vite-plugin-replace": "^0.1.1",
+        "vite-tsconfig-paths": "^5.1.3"
     }
 }

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, loadEnv } from 'vite'
 import { default as checker } from 'vite-plugin-checker'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import { replaceCodePlugin } from 'vite-plugin-replace'
+import tsconfigPaths from 'vite-tsconfig-paths'
 import path from 'path'
 
 // https://vitejs.dev/config/
@@ -15,6 +16,7 @@ export default ({ mode }: { mode: string }) => {
             'process.browser': true,
         },
         plugins: [
+            tsconfigPaths(),
             replaceCodePlugin({
                 replacements: [
                     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6264,6 +6264,7 @@ __metadata:
     vite-plugin-checker: ^0.8.0
     vite-plugin-node-polyfills: ^0.22.0
     vite-plugin-replace: ^0.1.1
+    vite-tsconfig-paths: ^5.1.3
     wagmi: ^1.4.12
     zod: ^3.21.4
   languageName: unknown
@@ -27940,6 +27941,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsconfck@npm:^3.0.3":
+  version: 3.1.4
+  resolution: "tsconfck@npm:3.1.4"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    tsconfck: bin/tsconfck.js
+  checksum: 007b92ca65e95c3511cf52d78020fedb322b98862474507d129d14f28eaf43f2d9ff6337da643ba6fd67a2041884f81191d1e384006c579fd4cac6597063cf1b
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths@npm:^3.14.1":
   version: 3.14.2
   resolution: "tsconfig-paths@npm:3.14.2"
@@ -29483,6 +29498,22 @@ __metadata:
   peerDependencies:
     vite: ^2
   checksum: 247ccdc61605f0a2e097e25fd31cc3528ecb8682dc691fdb5944cc67e427f2ca66864f3bdb21cfb80f835f62366fec8d86f38a2e427f11e016acdbc51219a117
+  languageName: node
+  linkType: hard
+
+"vite-tsconfig-paths@npm:^5.1.3":
+  version: 5.1.3
+  resolution: "vite-tsconfig-paths@npm:5.1.3"
+  dependencies:
+    debug: ^4.1.1
+    globrex: ^0.1.2
+    tsconfck: ^3.0.3
+  peerDependencies:
+    vite: "*"
+  peerDependenciesMeta:
+    vite:
+      optional: true
+  checksum: d4a172bb3e4db97e190868b381698151982f30d2699f4e395c5ed5fcbedbf7549e7686792d9ff520c31f4c6f788f14be527bc1f50b2153fae992e3a2859f8bd3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This fix the warnings around using `@river-build/sdk` and  `@river-build/react-sdk` from `workspace:^`