### PR TITLE
refactor(contract): move calculation of river points

### DIFF
--- a/contracts/scripts/deployments/facets/DeployRiverPoints.s.sol
+++ b/contracts/scripts/deployments/facets/DeployRiverPoints.s.sol
@@ -15,6 +15,7 @@ contract DeployRiverPoints is Deployer, FacetHelper {
   constructor() {
     addSelector(RiverPoints.mint.selector);
     addSelector(RiverPoints.batchMintPoints.selector);
+    addSelector(RiverPoints.getPoints.selector);
     addSelector(RiverPoints.balanceOf.selector);
     addSelector(RiverPoints.totalSupply.selector);
   }

--- a/contracts/src/spaces/facets/membership/join/MembershipJoin.sol
+++ b/contracts/src/spaces/facets/membership/join/MembershipJoin.sol
@@ -303,15 +303,18 @@ abstract contract MembershipJoin is
     _captureData(transactionId, "");
 
     // calculate points and credit them
-    address pointsToken = IImplementationRegistry(_getSpaceFactory())
-      .getLatestImplementation(bytes32("RiverAirdrop"));
-    uint256 points = RiverPoints(pointsToken).getPoints(
+    RiverPoints pointsToken = RiverPoints(
+      IImplementationRegistry(_getSpaceFactory()).getLatestImplementation(
+        bytes32("RiverAirdrop")
+      )
+    );
+    uint256 points = pointsToken.getPoints(
       IRiverPointsBase.Action.JoinSpace,
       abi.encode(protocolFee)
     );
 
-    RiverPoints(pointsToken).mint(sender, points);
-    RiverPoints(pointsToken).mint(_owner(), points);
+    pointsToken.mint(sender, points);
+    pointsToken.mint(_owner(), points);
   }
 
   /// @notice Issues a membership token to the receiver

--- a/contracts/src/spaces/facets/membership/join/MembershipJoin.sol
+++ b/contracts/src/spaces/facets/membership/join/MembershipJoin.sol
@@ -8,6 +8,7 @@ import {IImplementationRegistry} from "contracts/src/factory/facets/registry/IIm
 import {IRolesBase} from "contracts/src/spaces/facets/roles/IRoles.sol";
 import {IRuleEntitlement} from "contracts/src/spaces/entitlements/rule/IRuleEntitlement.sol";
 import {IMembership} from "contracts/src/spaces/facets/membership/IMembership.sol";
+import {IRiverPointsBase} from "contracts/src/tokens/points/IRiverPoints.sol";
 
 // libraries
 import {Permissions} from "contracts/src/spaces/facets/Permissions.sol";
@@ -287,25 +288,6 @@ abstract contract MembershipJoin is
     );
   }
 
-  /// @notice Computes the points for the protocol fee
-  function _getPoints(uint256 protocolFee) internal pure returns (uint256) {
-    if (protocolFee <= 0.0003 ether) {
-      return protocolFee * 1_000_000;
-    } else if (protocolFee <= 0.001 ether) {
-      return protocolFee * 2_000_000;
-    } else {
-      return protocolFee * 3_000_000;
-    }
-  }
-
-  function _creditPoints(address receiver, uint256 points) internal {
-    address pointsToken = IImplementationRegistry(_getSpaceFactory())
-      .getLatestImplementation(bytes32("RiverAirdrop"));
-
-    // Equivalent to `pointsToken.mint(receiver, points);`
-    RiverPoints(pointsToken).mint(receiver, points);
-  }
-
   function _afterChargeForJoinSpace(
     bytes32 transactionId,
     address sender,
@@ -321,9 +303,15 @@ abstract contract MembershipJoin is
     _captureData(transactionId, "");
 
     // calculate points and credit them
-    uint256 points = _getPoints(protocolFee);
-    _creditPoints(sender, points);
-    _creditPoints(_owner(), points);
+    address pointsToken = IImplementationRegistry(_getSpaceFactory())
+      .getLatestImplementation(bytes32("RiverAirdrop"));
+    uint256 points = RiverPoints(pointsToken).getPoints(
+      IRiverPointsBase.Action.JoinSpace,
+      abi.encode(protocolFee)
+    );
+
+    RiverPoints(pointsToken).mint(sender, points);
+    RiverPoints(pointsToken).mint(_owner(), points);
   }
 
   /// @notice Issues a membership token to the receiver

--- a/contracts/src/tokens/points/IRiverPoints.sol
+++ b/contracts/src/tokens/points/IRiverPoints.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+interface IRiverPointsBase {
+  enum Action {
+    JoinSpace,
+    RubBelly
+  }
+
+  error RiverPoints__InvalidSpace();
+  error RiverPoints__InvalidArrayLength();
+}
+
+interface IRiverPoints is IRiverPointsBase {
+  /// @notice Batch mint points to multiple users
+  /// @dev Only callable by the owner
+  /// @param accounts The addresses to mint the points to
+  /// @param values The amounts of points to mint
+  function batchMintPoints(
+    address[] calldata accounts,
+    uint256[] calldata values
+  ) external;
+
+  /// @notice Mint points to a user
+  /// @dev Only spaces can mint points
+  /// @param to The address to mint the points to
+  /// @param value The amount of points to mint
+  function mint(address to, uint256 value) external;
+
+  /// @notice Get the points from an eligible action
+  /// @param action The action to get the points from
+  /// @param data The data of the action
+  function getPoints(
+    Action action,
+    bytes calldata data
+  ) external pure returns (uint256);
+}

--- a/contracts/src/tokens/points/RiverPoints.sol
+++ b/contracts/src/tokens/points/RiverPoints.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.23;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {IArchitect} from "contracts/src/factory/facets/architect/IArchitect.sol";
+import {IRiverPoints} from "./IRiverPoints.sol";
 
 // libraries
 import {CustomRevert} from "contracts/src/utils/libraries/CustomRevert.sol";
@@ -15,10 +16,13 @@ import {Facet} from "contracts/src/diamond/facets/Facet.sol";
 import {IntrospectionFacet} from "contracts/src/diamond/facets/introspection/IntrospectionFacet.sol";
 import {OwnableBase} from "contracts/src/diamond/facets/ownable/OwnableBase.sol";
 
-contract RiverPoints is Facet, IntrospectionFacet, OwnableBase, IERC20Metadata {
-  error RiverPoints__InvalidSpace();
-  error RiverPoints__InvalidArrayLength();
-
+contract RiverPoints is
+  Facet,
+  IntrospectionFacet,
+  OwnableBase,
+  IERC20Metadata,
+  IRiverPoints
+{
   function __RiverPoints_init(address spaceFactory) external onlyInitializing {
     RiverPointsStorage.Layout storage ds = RiverPointsStorage.layout();
     ds.spaceFactory = spaceFactory;
@@ -26,6 +30,10 @@ contract RiverPoints is Facet, IntrospectionFacet, OwnableBase, IERC20Metadata {
     _addInterface(type(IERC20).interfaceId);
     _addInterface(type(IERC20Metadata).interfaceId);
   }
+
+  /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+  /*                           POINTS                           */
+  /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
   modifier onlySpace() {
     address spaceFactory = RiverPointsStorage.layout().spaceFactory;
@@ -35,8 +43,7 @@ contract RiverPoints is Facet, IntrospectionFacet, OwnableBase, IERC20Metadata {
     _;
   }
 
-  /// @notice Batch mint points to multiple users
-  /// @dev Only callable by the owner
+  /// @inheritdoc IRiverPoints
   function batchMintPoints(
     address[] calldata accounts,
     uint256[] calldata values
@@ -51,6 +58,23 @@ contract RiverPoints is Facet, IntrospectionFacet, OwnableBase, IERC20Metadata {
     }
   }
 
+  /// @inheritdoc IRiverPoints
+  function getPoints(
+    Action action,
+    bytes calldata data
+  ) external pure returns (uint256 points) {
+    if (action == Action.JoinSpace) {
+      uint256 protocolFee = abi.decode(data, (uint256));
+      if (protocolFee <= 0.0003 ether) {
+        points = protocolFee * 1_000_000;
+      } else if (protocolFee <= 0.001 ether) {
+        points = protocolFee * 2_000_000;
+      } else {
+        points = protocolFee * 3_000_000;
+      }
+    }
+  }
+
   /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
   /*                           ERC20                            */
   /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
@@ -61,8 +85,7 @@ contract RiverPoints is Facet, IntrospectionFacet, OwnableBase, IERC20Metadata {
     return true;
   }
 
-  /// @notice Mint points to a user
-  /// @dev Only spaces can mint points
+  /// @inheritdoc IRiverPoints
   function mint(address to, uint256 value) external onlySpace {
     RiverPointsStorage.layout().inner.mint(to, value);
   }

--- a/contracts/test/airdrop/RiverPoints.t.sol
+++ b/contracts/test/airdrop/RiverPoints.t.sol
@@ -7,6 +7,7 @@ import {DeployRiverAirdrop} from "contracts/scripts/deployments/diamonds/DeployR
 //interfaces
 import {IDiamond} from "contracts/src/diamond/Diamond.sol";
 import {IOwnableBase} from "contracts/src/diamond/facets/ownable/IERC173.sol";
+import {IRiverPointsBase} from "contracts/src/tokens/points/IRiverPoints.sol";
 
 //libraries
 
@@ -15,7 +16,12 @@ import {River} from "contracts/src/tokens/river/base/River.sol";
 import {RiverPoints} from "contracts/src/tokens/points/RiverPoints.sol";
 import {BaseRegistryTest} from "../base/registry/BaseRegistry.t.sol";
 
-contract RiverPointsTest is BaseRegistryTest, IOwnableBase, IDiamond {
+contract RiverPointsTest is
+  BaseRegistryTest,
+  IOwnableBase,
+  IDiamond,
+  IRiverPointsBase
+{
   RiverPoints internal pointsFacet;
 
   function setUp() public override {
@@ -39,7 +45,7 @@ contract RiverPointsTest is BaseRegistryTest, IOwnableBase, IDiamond {
   }
 
   function test_mint_revertIf_invalidSpace() public {
-    vm.expectRevert(RiverPoints.RiverPoints__InvalidSpace.selector);
+    vm.expectRevert(RiverPoints__InvalidSpace.selector);
     pointsFacet.mint(_randomAddress(), 1 ether);
   }
 
@@ -51,7 +57,7 @@ contract RiverPointsTest is BaseRegistryTest, IOwnableBase, IDiamond {
 
   function test_batchMintPoints_revertIf_invalidArrayLength() public {
     vm.prank(deployer);
-    vm.expectRevert(RiverPoints.RiverPoints__InvalidArrayLength.selector);
+    vm.expectRevert(RiverPoints__InvalidArrayLength.selector);
     pointsFacet.batchMintPoints(new address[](1), new uint256[](2));
   }
 


### PR DESCRIPTION
Created `IRiverPoints` interface to standardize points management across contracts. Moved point calculation logic to `RiverPoints` contract and updated `MembershipJoin` to use the new interface. Adjusted tests to reflect these changes.