### PR TITLE
Call riverRegistry.getStream with streamIdAsBytes

### DIFF
--- a/packages/stream-metadata/src/streamRegistry.ts
+++ b/packages/stream-metadata/src/streamRegistry.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from 'ethers'
 import { FastifyBaseLogger } from 'fastify'
+import { streamIdAsBytes } from '@river-build/sdk'
 
 import { StreamIdHex } from './types'
 import { getRiverRegistry } from './evmRpcClient'
@@ -28,7 +29,7 @@ export async function getNodeForStream(
 	}
 
 	const riverRegistry = getRiverRegistry()
-	const streamData = await riverRegistry.streamRegistry.read.getStream(streamId)
+	const streamData = await riverRegistry.getStream(streamIdAsBytes(streamId))
 
 	if (streamData.nodes.length === 0) {
 		const error = new Error(`No nodes found for stream ${streamId}`)


### PR DESCRIPTION
why did this start failing?

looking at fei's new space here https://fast-app.towns.com/t/0x2f104bd8e48ad006f2a6ce1a2a07d283a310543a/

this space exists, i can query the river registry for it and pull data from the river network, but when the stream registry tries to do it, it errors from the contract with NOT_FOUND

so far I think i've verified that

the stream registry address is the same
the calls to the stream registry haven't changed
can anybody think of other places to look?

here's the log
https://app.datadoghq.com/logs?query=env%3Aomega%20service%3Astream-metadata%20%40req.params.spaceAddress%3A0x2f104bd8e48ad006f2a6ce1a2a07d283a310543a&agg_m=count&agg_m_source=base&agg_t=count&cols=env%2Cservice%2Ccontainer_index&event=AwAAAZNWLm3Nb5dUOwAAABhBWk5XTG5jSkFBQ3RUYjRQdWFhOTJnQUMAAAAkMDE5MzU2MmUtOTk2MS00OTMzLWFmNGQtNGMyYzM0NmM0ZDY4AAAAGg&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=2705025&storage=hot&stream_sort=desc&viz=stream&from_ts=1732254290248&to_ts=1732255190248&live=true

with the error:

Error: call revert exception; VM Exception while processing transaction: reverted with reason string "NOT_FOUND" [ See: https://links.ethers.org/v5-errors-CALL_EXCEPTION ]

I can repro locally - calling with the string fails, calling with the bytes succeeds