### PR TITLE
Fix goroutine leaks in core/node/crypto

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -34,6 +34,7 @@ require (
 	go.opentelemetry.io/otel/exporters/zipkin v1.32.0
 	go.opentelemetry.io/otel/sdk v1.32.0
 	go.opentelemetry.io/otel/trace v1.32.0
+	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.29.0
 	golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f
 	golang.org/x/net v0.31.0

--- a/core/node/crypto/chain_txpool.go
+++ b/core/node/crypto/chain_txpool.go
@@ -17,13 +17,14 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/river-build/river/core/config"
 	. "github.com/river-build/river/core/node/base"
 	"github.com/river-build/river/core/node/dlog"
 	"github.com/river-build/river/core/node/infra"
 	. "github.com/river-build/river/core/node/protocol"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 type (
@@ -141,6 +142,7 @@ var (
 )
 
 func newPendingTransactionPool(
+	ctx context.Context,
 	monitor ChainMonitor,
 	client BlockchainClient,
 	chainID *big.Int,
@@ -205,7 +207,7 @@ func newPendingTransactionPool(
 		transactionGasTip:                 transactionGasTip.MustCurryWith(curryLabels),
 	}
 
-	go ptp.run()
+	go ptp.run(ctx)
 
 	monitor.OnHeader(ptp.checkPendingTransactions)
 
@@ -216,17 +218,26 @@ func (pool *pendingTransactionPool) PendingTransactionsCount() int64 {
 	return pool.pendingTxCount.Load()
 }
 
-func (pool *pendingTransactionPool) run() {
-	for ptx := range pool.addPendingTx {
-		pool.pendingTxs.Store(ptx.tx.Nonce(), ptx)
-		pool.pendingTxCount.Add(1)
+func (pool *pendingTransactionPool) appendPendingTx(ctx context.Context, ptx *txPoolPendingTransaction) {
+	pool.pendingTxs.Store(ptx.tx.Nonce(), ptx)
+	pool.pendingTxCount.Add(1)
 
-		// metrics
-		gasCap, _ := ptx.tx.GasFeeCap().Float64()
-		tipCap, _ := ptx.tx.GasTipCap().Float64()
-		pool.transactionsPending.Add(1)
-		pool.transactionGasCap.With(prometheus.Labels{"replacement": "false"}).Set(gasCap)
-		pool.transactionGasTip.With(prometheus.Labels{"replacement": "false"}).Set(tipCap)
+	// metrics
+	gasCap, _ := ptx.tx.GasFeeCap().Float64()
+	tipCap, _ := ptx.tx.GasTipCap().Float64()
+	pool.transactionsPending.Add(1)
+	pool.transactionGasCap.With(prometheus.Labels{"replacement": "false"}).Set(gasCap)
+	pool.transactionGasTip.With(prometheus.Labels{"replacement": "false"}).Set(tipCap)
+}
+
+func (pool *pendingTransactionPool) run(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ptx := <-pool.addPendingTx:
+			pool.appendPendingTx(ctx, ptx)
+		}
 	}
 }
 
@@ -494,7 +505,7 @@ func NewTransactionPoolWithPolicies(
 		transactionSubmitted: transactionsSubmittedCounter.MustCurryWith(curryLabels),
 		walletBalance:        walletBalance.With(curryLabels),
 		pendingTransactionPool: newPendingTransactionPool(
-			chainMonitor, client, chainID, wallet, replacePolicy, pricePolicy, metrics),
+			ctx, chainMonitor, client, chainID, wallet, replacePolicy, pricePolicy, metrics),
 	}
 
 	chainMonitor.OnHeader(txPool.Balance)

--- a/core/node/crypto/main_test.go
+++ b/core/node/crypto/main_test.go
@@ -1,0 +1,15 @@
+package crypto
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	c := m.Run()
+	if c != 0 {
+		os.Exit(c)
+	}
+
+	TestMainForLeaksIgnoreGeth()
+}

--- a/core/node/crypto/testutil.go
+++ b/core/node/crypto/testutil.go
@@ -685,10 +685,12 @@ func TestMainForLeaksIgnoreGeth() {
 		msg := err.Error()
 
 		stacks := strings.Split(msg, "Goroutine ")
+		if len(stacks) > 1 {
+			stacks = stacks[1:]
+		}
 		stacks = slices.DeleteFunc(stacks, func(s string) bool {
 			return strings.Contains(s, "created by github.com/ethereum/go-ethereum/") ||
-				strings.Contains(s, "created by github.com/syndtr/goleveldb/") ||
-				strings.HasPrefix(s, "found unexpected goroutines:")
+				strings.Contains(s, "created by github.com/syndtr/goleveldb/")
 		})
 
 		if len(stacks) > 0 {
@@ -698,7 +700,7 @@ func TestMainForLeaksIgnoreGeth() {
 			)
 			for _, s := range stacks {
 				fmt.Println()
-				fmt.Println(s)
+				fmt.Println("Goroutine", s)
 				fmt.Println()
 			}
 			os.Exit(1)

--- a/core/node/crypto/testutil.go
+++ b/core/node/crypto/testutil.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -20,6 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient/simulated"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	"github.com/river-build/river/core/config"
 	"github.com/river-build/river/core/contracts/river"
@@ -55,9 +58,11 @@ func (w *autoMiningClientWrapper) SendTransaction(ctx context.Context, tx *types
 }
 
 type TestParams struct {
-	NumKeys  int
-	MineOnTx bool
-	AutoMine bool
+	NumKeys         int
+	MineOnTx        bool
+	AutoMine        bool
+	NoDeployer      bool
+	NoOnChainConfig bool
 }
 
 type BlockchainTestContext struct {
@@ -296,7 +301,9 @@ func NewBlockchainTestContext(ctx context.Context, params TestParams) (*Blockcha
 	}
 
 	// Add deployer as operator so it can register nodes
-	btc.DeployerBlockchain = makeTestBlockchain(ctx, wallets[len(wallets)-1], client)
+	if !params.NoDeployer {
+		btc.DeployerBlockchain = makeTestBlockchain(ctx, wallets[len(wallets)-1], client)
+	}
 
 	// commit the river registry deployment transaction
 	if !params.MineOnTx {
@@ -305,11 +312,13 @@ func NewBlockchainTestContext(ctx context.Context, params TestParams) (*Blockcha
 		}
 	}
 
-	blockNum := btc.BlockNum(ctx)
-	btc.OnChainConfig, err = NewOnChainConfig(
-		ctx, btc.Client(), btc.RiverRegistryAddress, blockNum, btc.DeployerBlockchain.ChainMonitor)
-	if err != nil {
-		return nil, err
+	if !params.NoOnChainConfig {
+		blockNum := btc.BlockNum(ctx)
+		btc.OnChainConfig, err = NewOnChainConfig(
+			ctx, btc.Client(), btc.RiverRegistryAddress, blockNum, btc.DeployerBlockchain.ChainMonitor)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return btc, nil
@@ -657,3 +666,42 @@ func (NoopChainMonitor) OnContractEvent(BlockNumber, common.Address, OnChainEven
 func (NoopChainMonitor) OnContractWithTopicsEvent(BlockNumber, common.Address, [][]common.Hash, OnChainEventCallback) {
 }
 func (NoopChainMonitor) OnStopped(OnChainMonitorStoppedCallback) {}
+
+// TestMainForLeaksIgnoreGeth is a helper function to check if there are goroutine leaks.
+// It ignores goroutines created by Geth's simulated backend.
+// It should be called in TestMain after m.Run().
+// If there are leaks, it will print the goroutine stacks and os.Exit with non-zero code.
+// Using t.Parallel() makes it impossible to test for leaks in individual tests,
+// so leak testing is done on package level from TestMain.
+// Run individual tests with -run to find specific leaking tests.
+func TestMainForLeaksIgnoreGeth() {
+	// Geth's simulated backend leaks a lot of goroutines.
+	// Unfortunately goleak doesn't have optiosn to ignore by module or package,
+	// so some custom error string parsing is required to filter them out.
+	now := time.Now()
+	err := goleak.Find()
+	elapsed := time.Since(now)
+	if err != nil {
+		msg := err.Error()
+
+		stacks := strings.Split(msg, "Goroutine ")
+		stacks = slices.DeleteFunc(stacks, func(s string) bool {
+			return strings.Contains(s, "created by github.com/ethereum/go-ethereum/") ||
+				strings.Contains(s, "created by github.com/syndtr/goleveldb/") ||
+				strings.HasPrefix(s, "found unexpected goroutines:")
+		})
+
+		if len(stacks) > 0 {
+			fmt.Println(
+				"goleak: Errors on successful test run: found unexpected goroutines =", len(stacks),
+				"elapsed =", elapsed,
+			)
+			for _, s := range stacks {
+				fmt.Println()
+				fmt.Println(s)
+				fmt.Println()
+			}
+			os.Exit(1)
+		}
+	}
+}


### PR DESCRIPTION
Clean shutdown is required so it's possible to simulate node restarts in the test.
This is first PR fixing shutdown cleanup across packages.