### PR TITLE
notifications: delete expired webpush subscription automatically

### DIFF
--- a/core/node/notifications/event_processor.go
+++ b/core/node/notifications/event_processor.go
@@ -332,16 +332,14 @@ func (p *MessageToNotificationsProcessor) sendNotification(
 					"event", event.Hash,
 					"channelID", channelID,
 				)
-			} else {
+			} else if !subscriptionExpired {
 				p.log.Error("Unable to send web push notification",
 					"user",
 					user, "err", err,
 					"event", event.Hash,
 					"channelID", channelID,
 				)
-			}
-
-			if subscriptionExpired {
+			} else {
 				if err := p.cache.RemoveExpiredWebPushSubscription(ctx, userPref.UserID, sub.Sub); err != nil {
 					p.log.Error("Unable to remove expired webpush subscription from cache",
 						"user", userPref.UserID, "err", err)
@@ -387,7 +385,7 @@ func (p *MessageToNotificationsProcessor) sendNotification(
 					"deviceToken", sub.DeviceToken,
 					"env", sub.Environment,
 				)
-			} else {
+			} else if !subscriptionExpired {
 				p.log.Error("Unable to send APN notification",
 					"user", user,
 					"user", user,
@@ -396,9 +394,7 @@ func (p *MessageToNotificationsProcessor) sendNotification(
 					"deviceToken", sub.DeviceToken,
 					"env", sub.Environment,
 					"err", err)
-			}
-
-			if subscriptionExpired {
+			} else {
 				if err := p.cache.RemoveAPNSubscription(ctx, sub.DeviceToken, userPref.UserID); err != nil {
 					p.log.Error("Unable to remove expired APN subscription from cache",
 						"user", userPref.UserID, "deviceToken", sub.DeviceToken, "err", err)

--- a/core/node/notifications/push/push_test.go
+++ b/core/node/notifications/push/push_test.go
@@ -61,8 +61,10 @@ func TestAPNSPushNotification(t *testing.T) {
 		Environment: protocol.APNEnvironment_APN_ENVIRONMENT_SANDBOX,
 	}
 
-	req.NoError(notifier.SendApplePushNotification(
-		ctx, &sub, common.Hash{1}, payload), "send APN notification")
+	expired, err := notifier.SendApplePushNotification(
+		ctx, &sub, common.Hash{1}, payload)
+	req.False(expired, "subscription should not be expired")
+	req.NoError(err, "send APN notification")
 }
 
 func TestWebPushWithVapid(t *testing.T) {
@@ -117,6 +119,7 @@ func TestWebPushWithVapid(t *testing.T) {
 
 	//payload := payload2.NewPayload().Alert("Sry to bother you if this works...")
 
-	req.NoError(notifier.SendWebPushNotification(ctx, subscription, common.Hash{1}, payload),
-		"send web push notification")
+	expired, err := notifier.SendWebPushNotification(ctx, subscription, common.Hash{1}, payload)
+	req.False(expired, "expired")
+	req.NoError(err, "send web push notification")
 }

--- a/core/node/notifications/sync/streams_tracker_worker_connectgo.go
+++ b/core/node/notifications/sync/streams_tracker_worker_connectgo.go
@@ -263,7 +263,7 @@ func (s *StreamTrackerConnectGo) Run(
 
 				// apply update
 				for _, event := range update.GetStream().GetEvents() {
-					if err := trackedStream.HandleEvent(event); err != nil {
+					if err := trackedStream.HandleEvent(ctx, event); err != nil {
 						log.Error("Unable to handle event", "stream", streamID, "err", err)
 					}
 				}

--- a/core/node/notifications/user_preferences_store.go
+++ b/core/node/notifications/user_preferences_store.go
@@ -320,6 +320,22 @@ func (up *UserPreferencesCache) AddWebPushSubscription(
 	return nil
 }
 
+func (up *UserPreferencesCache) RemoveExpiredWebPushSubscription(
+	ctx context.Context,
+	userID common.Address,
+	webPushSubscription *webpush.Subscription,
+) error {
+	err := up.persistent.RemoveExpiredWebPushSubscription(ctx, userID, webPushSubscription)
+	if err != nil {
+		return err
+	}
+
+	// force reload next time user userPreferencesCache are requested
+	up.userPreferencesCache.Delete(userID)
+
+	return nil
+}
+
 // RemoveWebPushSubscription deleted a web push subscription.
 func (up *UserPreferencesCache) RemoveWebPushSubscription(
 	ctx context.Context,

--- a/core/node/rpc/notification_test.go
+++ b/core/node/rpc/notification_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
-	"github.com/river-build/river/core/node/notifications/types"
 	"math/big"
 	"net"
 	"net/http"
@@ -22,6 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/river-build/river/core/node/crypto"
 	"github.com/river-build/river/core/node/events"
+	"github.com/river-build/river/core/node/notifications/types"
 	. "github.com/river-build/river/core/node/protocol"
 	"github.com/river-build/river/core/node/protocol/protocolconnect"
 	. "github.com/river-build/river/core/node/shared"
@@ -1259,7 +1259,7 @@ func (nc *notificationCapture) SendWebPushNotification(
 	subscription *webpush.Subscription,
 	eventHash common.Hash,
 	_ []byte,
-) error {
+) (bool, error) {
 	nc.WebPushNotificationsMu.Lock()
 	defer nc.WebPushNotificationsMu.Unlock()
 
@@ -1272,7 +1272,7 @@ func (nc *notificationCapture) SendWebPushNotification(
 	events[common.HexToAddress(subscription.Endpoint)]++
 	nc.WebPushNotifications[eventHash] = events
 
-	return nil
+	return false, nil
 }
 
 func (nc *notificationCapture) SendApplePushNotification(
@@ -1280,7 +1280,7 @@ func (nc *notificationCapture) SendApplePushNotification(
 	sub *types.APNPushSubscription,
 	eventHash common.Hash,
 	_ *payload2.Payload,
-) error {
+) (bool, error) {
 	nc.ApnPushNotificationsMu.Lock()
 	defer nc.ApnPushNotificationsMu.Unlock()
 
@@ -1293,5 +1293,5 @@ func (nc *notificationCapture) SendApplePushNotification(
 	events[common.BytesToAddress(sub.DeviceToken)]++
 	nc.ApnPushNotifications[eventHash] = events
 
-	return nil
+	return false, nil
 }

--- a/core/node/rpc/notification_test.go
+++ b/core/node/rpc/notification_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"math/big"
 	"net"
 	"net/http"
@@ -21,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/river-build/river/core/node/crypto"
 	"github.com/river-build/river/core/node/events"
+	"github.com/river-build/river/core/node/notifications/push"
 	"github.com/river-build/river/core/node/notifications/types"
 	. "github.com/river-build/river/core/node/protocol"
 	"github.com/river-build/river/core/node/protocol/protocolconnect"
@@ -30,6 +32,62 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestSubscriptionExpired ensures that web/apn subscriptions for which the notification API
+// returns 410 - Gone /expired are automatically purged.
+func TestSubscriptionExpired(t *testing.T) {
+	tester := newServiceTester(t, serviceTesterOpts{numNodes: 1, start: true})
+	ctx, cancel := context.WithCancel(tester.ctx)
+	defer cancel()
+
+	var notifications notificationExpired
+
+	notificationService := initNotificationService(ctx, tester, notifications)
+	notificationClient := protocolconnect.NewNotificationServiceClient(
+		http.DefaultClient, "http://"+notificationService.listener.Addr().String())
+	authClient := protocolconnect.NewAuthenticationServiceClient(
+		http.DefaultClient, "http://"+notificationService.listener.Addr().String())
+
+	t.Run("webpush", func(t *testing.T) {
+		test := setupDMNotificationTest(ctx, tester, notificationClient, authClient)
+		test.subscribeWebPush(ctx, test.initiator)
+		test.subscribeWebPush(ctx, test.member)
+
+		// ensure that subscription for member is dropped after subscription expired.
+		_ = test.sendMessageWithTags(
+			ctx, test.initiator, "hi!", &Tags{})
+
+		test.req.Eventuallyf(func() bool {
+			settings := test.getSettings(ctx, test.initiator)
+			if len(settings.WebSubscriptions) != 1 {
+				return false
+			}
+
+			settings = test.getSettings(ctx, test.member)
+			return len(settings.WebSubscriptions) == 0
+		}, 15*time.Second, 100*time.Millisecond, "webpush subscription not deleted")
+	})
+
+	t.Run("APN", func(t *testing.T) {
+		test := setupDMNotificationTest(ctx, tester, notificationClient, authClient)
+		test.subscribeApnPush(ctx, test.initiator)
+		test.subscribeApnPush(ctx, test.member)
+
+		// ensure that subscription for member is dropped after subscription expired.
+		_ = test.sendMessageWithTags(
+			ctx, test.initiator, "hi!", &Tags{})
+
+		test.req.Eventuallyf(func() bool {
+			settings := test.getSettings(ctx, test.initiator)
+			if len(settings.ApnSubscriptions) != 1 {
+				return false
+			}
+
+			settings = test.getSettings(ctx, test.member)
+			return len(settings.ApnSubscriptions) == 0
+		}, 15*time.Second, 100*time.Millisecond, "APN subscription not deleted")
+	})
+}
+
 // TestNotifications is designed in such a way that all tests are run in parallel
 // and share the same set of nodes, notification service and client.
 func TestNotifications(t *testing.T) {
@@ -37,7 +95,12 @@ func TestNotifications(t *testing.T) {
 	ctx, cancel := context.WithCancel(tester.ctx)
 	defer cancel()
 
-	notificationService, notifications := initNotificationService(ctx, tester)
+	notifications := &notificationCapture{
+		WebPushNotifications: make(map[common.Hash]map[common.Address]int),
+		ApnPushNotifications: make(map[common.Hash]map[common.Address]int),
+	}
+
+	notificationService := initNotificationService(ctx, tester, notifications)
 	notificationClient := protocolconnect.NewNotificationServiceClient(
 		http.DefaultClient, "http://"+notificationService.listener.Addr().String())
 
@@ -585,14 +648,13 @@ func testSpaceChannelMentionTag(
 	}, 5*time.Second, 100*time.Millisecond, "Received too unexpected notifications")
 }
 
-func initNotificationService(ctx context.Context, tester *serviceTester) (*Service, *notificationCapture) {
+func initNotificationService(
+	ctx context.Context,
+	tester *serviceTester,
+	notifier push.MessageNotifier,
+) *Service {
 	listener, err := net.Listen("tcp", "localhost:0")
 	tester.require.NoError(err)
-
-	nc := &notificationCapture{
-		WebPushNotifications: make(map[common.Hash]map[common.Address]int),
-		ApnPushNotifications: make(map[common.Hash]map[common.Address]int),
-	}
 
 	var key [32]byte
 	_, err = rand.Read(key[:])
@@ -602,10 +664,10 @@ func initNotificationService(ctx context.Context, tester *serviceTester) (*Servi
 	cfg.Notifications.Authentication.SessionToken.Key.Algorithm = "HS256"
 	cfg.Notifications.Authentication.SessionToken.Key.Key = hex.EncodeToString(key[:])
 
-	service, err := StartServerInNotificationMode(ctx, cfg, tester.btc.DeployerBlockchain, listener, nc)
+	service, err := StartServerInNotificationMode(ctx, cfg, tester.btc.DeployerBlockchain, listener, notifier)
 	tester.require.NoError(err)
 
-	return service, nc
+	return service
 }
 
 func setupSpaceChannelNotificationTest(
@@ -1051,7 +1113,6 @@ func (tc *dmChannelNotificationsTestContext) setChannel(
 	user *crypto.Wallet,
 	setting DmChannelSettingValue,
 ) {
-
 	request := connect.NewRequest(&SetDmChannelSettingRequest{
 		DmChannelId: tc.dmStreamID[:],
 		Value:       setting,
@@ -1062,6 +1123,20 @@ func (tc *dmChannelNotificationsTestContext) setChannel(
 	_, err := tc.notificationClient.SetDmChannelSetting(ctx, request)
 
 	tc.req.NoError(err, "setChannel failed")
+}
+
+func (tc *dmChannelNotificationsTestContext) getSettings(
+	ctx context.Context,
+	user *crypto.Wallet,
+) *GetSettingsResponse {
+	request := connect.NewRequest(&GetSettingsRequest{})
+
+	authorize(ctx, tc.req, tc.authClient, user, request)
+
+	response, err := tc.notificationClient.GetSettings(ctx, request)
+	tc.req.NoError(err, "getSettings failed")
+
+	return response.Msg
 }
 
 func (tc *dmChannelNotificationsTestContext) muteGlobal(
@@ -1294,4 +1369,24 @@ func (nc *notificationCapture) SendApplePushNotification(
 	nc.ApnPushNotifications[eventHash] = events
 
 	return false, nil
+}
+
+type notificationExpired struct{}
+
+func (notificationExpired) SendWebPushNotification(
+	_ context.Context,
+	_ *webpush.Subscription,
+	_ common.Hash,
+	_ []byte,
+) (bool, error) {
+	return true, fmt.Errorf("subscription expired")
+}
+
+func (notificationExpired) SendApplePushNotification(
+	_ context.Context,
+	_ *types.APNPushSubscription,
+	_ common.Hash,
+	_ *payload2.Payload,
+) (bool, error) {
+	return true, fmt.Errorf("subscription expired")
 }


### PR DESCRIPTION
When the notification service tries to send a webpush notification and receives a `410 - Gone` the subscription is expired. This indicates that either:

- the user unsubscribed from notifications in the browser
- the browser has renewed the subscription and the notification service didn't got an update with the new endpoint.

This change deletes the expired subscription from the database. It takes the endpoint into considering meaning that in case the user refreshed the subscription with the new endpoint there is no race condition that deletes it immediately due to the 410 error.

