### PR TITLE
Get rid of goofy conversions in the stream-metadata service

### DIFF
--- a/packages/stream-metadata/src/riverStreamRpcClient.ts
+++ b/packages/stream-metadata/src/riverStreamRpcClient.ts
@@ -18,7 +18,7 @@ import { filetypemime } from 'magic-bytes.js'
 import { FastifyBaseLogger } from 'fastify'
 import { LRUCache } from 'lru-cache'
 
-import { MediaContent, StreamIdHex } from './types'
+import { MediaContent } from './types'
 import { getNodeForStream } from './streamRegistry'
 
 const STREAM_METADATA_SERVICE_DEFAULT_UNPACK_OPTS: UnpackEnvelopeOpts = {
@@ -52,7 +52,7 @@ export function makeStreamRpcClient(url: string): StreamRpcClient {
 	return client
 }
 
-async function _getStreamClient(logger: FastifyBaseLogger, streamId: `0x${string}`) {
+async function _getStreamClient(logger: FastifyBaseLogger, streamId: string) {
 	let url = streamLocationCache.get(streamId)
 	if (!url) {
 		const node = await getNodeForStream(logger, streamId)
@@ -70,7 +70,7 @@ async function _getStreamClient(logger: FastifyBaseLogger, streamId: `0x${string
 
 async function getStreamClient(
 	logger: FastifyBaseLogger,
-	streamId: `0x${string}`,
+	streamId: string,
 ): Promise<StreamRpcClient> {
 	const existing = streamClientRequests.get(streamId)
 	if (existing) {
@@ -178,19 +178,12 @@ async function mediaContentFromStreamView(
 	}
 }
 
-function stripHexPrefix(hexString: string): string {
-	if (hexString.startsWith('0x')) {
-		return hexString.slice(2)
-	}
-	return hexString
-}
-
 export async function _getStream(
 	logger: FastifyBaseLogger,
 	streamId: string,
 	opts: UnpackEnvelopeOpts = STREAM_METADATA_SERVICE_DEFAULT_UNPACK_OPTS,
 ): Promise<StreamStateView> {
-	const client = await getStreamClient(logger, `0x${streamId}`)
+	const client = await getStreamClient(logger, streamId)
 	logger.info(
 		{
 			nodeUrl: client.url,
@@ -244,11 +237,10 @@ export async function getStream(
 
 export async function _getMediaStreamContent(
 	logger: FastifyBaseLogger,
-	fullStreamId: StreamIdHex,
+	streamId: string,
 	secret: Uint8Array,
 	iv: Uint8Array,
 ): Promise<MediaContent> {
-	const streamId = stripHexPrefix(fullStreamId)
 	const sv = await getStream(logger, streamId)
 	const result = await mediaContentFromStreamView(logger, sv, secret, iv)
 	return result
@@ -256,17 +248,17 @@ export async function _getMediaStreamContent(
 
 export async function getMediaStreamContent(
 	logger: FastifyBaseLogger,
-	fullStreamId: StreamIdHex,
+	streamId: string,
 	secret: Uint8Array,
 	iv: Uint8Array,
 ): Promise<MediaContent> {
-	const existing = mediaRequests.get(fullStreamId)
+	const existing = mediaRequests.get(streamId)
 	if (existing) {
 		return existing
 	}
-	const promise = _getMediaStreamContent(logger, fullStreamId, secret, iv)
-	mediaRequests.set(fullStreamId, promise)
+	const promise = _getMediaStreamContent(logger, streamId, secret, iv)
+	mediaRequests.set(streamId, promise)
 	const result = await promise
-	mediaRequests.delete(fullStreamId)
+	mediaRequests.delete(streamId)
 	return result
 }

--- a/packages/stream-metadata/src/routes/media.ts
+++ b/packages/stream-metadata/src/routes/media.ts
@@ -4,7 +4,6 @@ import { isValidStreamId } from '@river-build/sdk'
 import { bin_fromHexString } from '@river-build/dlog'
 
 import { getMediaStreamContent } from '../riverStreamRpcClient'
-import type { StreamIdHex } from '../types'
 
 const paramsSchema = z.object({
 	mediaStreamId: z
@@ -56,10 +55,9 @@ export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 	const { mediaStreamId } = paramsResult.data
 	const { key, iv } = queryResult.data
 	logger.info({ mediaStreamId, key, iv }, 'Fetching media stream content')
-	const fullStreamId: StreamIdHex = `0x${mediaStreamId}`
-
+	
 	try {
-		const { data, mimeType } = await getMediaStreamContent(logger, fullStreamId, key, iv)
+		const { data, mimeType } = await getMediaStreamContent(logger, mediaStreamId, key, iv)
 		if (!data || !mimeType) {
 			logger.error(
 				{

--- a/packages/stream-metadata/src/routes/media.ts
+++ b/packages/stream-metadata/src/routes/media.ts
@@ -55,7 +55,7 @@ export async function fetchMedia(request: FastifyRequest, reply: FastifyReply) {
 	const { mediaStreamId } = paramsResult.data
 	const { key, iv } = queryResult.data
 	logger.info({ mediaStreamId, key, iv }, 'Fetching media stream content')
-	
+
 	try {
 		const { data, mimeType } = await getMediaStreamContent(logger, mediaStreamId, key, iv)
 		if (!data || !mimeType) {

--- a/packages/stream-metadata/src/routes/spaceImage.ts
+++ b/packages/stream-metadata/src/routes/spaceImage.ts
@@ -45,14 +45,15 @@ export async function fetchSpaceImage(request: FastifyRequest, reply: FastifyRep
 	logger.info({ spaceAddress, eventId }, 'Fetching space image')
 
 	let stream: StreamStateView
+	const streamId = makeStreamId(StreamPrefix.Space, spaceAddress)
 	try {
-		const streamId = makeStreamId(StreamPrefix.Space, spaceAddress)
 		stream = await getStream(logger, streamId)
 	} catch (error) {
 		logger.error(
 			{
 				err: error,
 				spaceAddress,
+				streamId,
 			},
 			'Failed to get stream',
 		)

--- a/packages/stream-metadata/src/streamRegistry.ts
+++ b/packages/stream-metadata/src/streamRegistry.ts
@@ -2,7 +2,6 @@ import { BigNumber } from 'ethers'
 import { FastifyBaseLogger } from 'fastify'
 import { streamIdAsBytes } from '@river-build/sdk'
 
-import { StreamIdHex } from './types'
 import { getRiverRegistry } from './evmRpcClient'
 
 type CachedStreamData = {
@@ -16,7 +15,7 @@ const cache: Record<string, CachedStreamData> = {}
 // TODO: remove this entire file
 export async function getNodeForStream(
 	logger: FastifyBaseLogger,
-	streamId: StreamIdHex,
+	streamId: string,
 ): Promise<{ url: string; lastMiniblockNum: BigNumber }> {
 	logger.info({ streamId }, 'find node for stream')
 

--- a/packages/stream-metadata/src/types.d.ts
+++ b/packages/stream-metadata/src/types.d.ts
@@ -1,7 +1,4 @@
-export type Address = `0x${string}`
 
-// todo: this one needs to be 0x.... 64 characters
-export type StreamIdHex = `0x${string}`
 
 export interface MediaContent {
 	data: ArrayBuffer

--- a/packages/stream-metadata/src/types.d.ts
+++ b/packages/stream-metadata/src/types.d.ts
@@ -1,5 +1,3 @@
-
-
 export interface MediaContent {
 	data: ArrayBuffer
 	mimeType: string


### PR DESCRIPTION
ref TOWNS-15132

we’re still seeing issues looking up nodes for spaces and I don’t really get what’s going on, but this bit can’t be helping. I’m assuming somewhere we either add an extra 0x or miss an 0x? either way we don’t need it.