### PR TITLE
docs: add playground in the getting started section

### DIFF
--- a/packages/docs/sdk/react-sdk/getting-started.mdx
+++ b/packages/docs/sdk/react-sdk/getting-started.mdx
@@ -19,7 +19,10 @@ By default, this will create a new app using the Playground template - a full-fe
 ### Available Templates
 
 #### Playground Template (default)
-The playground template provides a complete example application with all River features implemented:
+
+The [River Playground](https://river-sample-app.vercel.app) is a full-featured example application that demonstrates River's capabilities and how to use the SDK.
+
+You can use it as a starting point to build your own application.
 
 ```bash
 yarn create river-build-app my-app
@@ -28,6 +31,7 @@ yarn create river-build-app my-app --template playground
 ```
 
 #### React Templates
+
 You can also start with a minimal React setup using either TypeScript or JavaScript:
 
 ```bash


### PR DESCRIPTION
As we're pushing the playground as the sample river app, we should mention it at the docs.