### PR TITLE
Update space membership join to use isSpaceMember

### DIFF
--- a/core/node/rules/can_add_event.go
+++ b/core/node/rules/can_add_event.go
@@ -976,6 +976,8 @@ func (ru *aeMembershipRules) channelMembershipEntitlements() (*auth.ChainAuthArg
 	if err != nil {
 		return nil, err
 	}
+
+
 	// ModifyBanning is a space level permission
 	// but users with this entitlement should also be entitled to kick users from the channel
 	if permission == auth.PermissionModifyBanning {

--- a/core/node/rules/can_add_event.go
+++ b/core/node/rules/can_add_event.go
@@ -976,7 +976,6 @@ func (ru *aeMembershipRules) channelMembershipEntitlements() (*auth.ChainAuthArg
 	if err != nil {
 		return nil, err
 	}
-
 	// ModifyBanning is a space level permission
 	// but users with this entitlement should also be entitled to kick users from the channel
 	if permission == auth.PermissionModifyBanning {

--- a/core/node/rules/can_add_event.go
+++ b/core/node/rules/can_add_event.go
@@ -942,11 +942,18 @@ func (ru *aeMembershipRules) spaceMembershipEntitlements() (*auth.ChainAuthArgs,
 		return nil, nil
 	}
 
-	chainAuthArgs := auth.NewChainAuthArgsForSpace(
-		*streamId,
-		permissionUser,
-		permission,
-	)
+	var chainAuthArgs *auth.ChainAuthArgs
+	// Space joins are a special case as they do not require an entitlement check. We simply
+	// verify that the user is a space member.
+	if ru.membership.Op == MembershipOp_SO_JOIN {
+		chainAuthArgs = auth.NewChainAuthArgsForIsSpaceMember(*streamId, permissionUser)
+	} else {
+		chainAuthArgs = auth.NewChainAuthArgsForSpace(
+			*streamId,
+			permissionUser,
+			permission,
+		)
+	}
 	return chainAuthArgs, nil
 }
 
@@ -969,7 +976,6 @@ func (ru *aeMembershipRules) channelMembershipEntitlements() (*auth.ChainAuthArg
 	if err != nil {
 		return nil, err
 	}
-
 
 	// ModifyBanning is a space level permission
 	// but users with this entitlement should also be entitled to kick users from the channel


### PR DESCRIPTION
#1643 

This change updates the entitlement check for a adding a user to the space stream to check for space membership instead of looking for the READ permission. Since the requested auth was previously of kind `chainAuthKindSpace`, previously the authorization module would look for at least 1 role on the space with READ permission that the wallet satisfied in order to allow the join event, which makes no sense. However, we ended up satisfying this in practice because the member role is typically an EVERYONE User Entitlement role, and it has the READ permission attached.

The new check is a a chainAuthArgs of kind `chainAuthKindIsSpaceMember`, which does not check any entitlements at all, it just validates that the user is a space member.

This permissions check actually relaxes the strictness of checks here because all auth checks already include a space membership check - so we were already preventing all non-members from adding themselves to the space stream. We just don't also include the erroneous check for a READ entitlement anymore. The system behavior likely will not change as a result of this change unless a space owner or other admin modifies the member role.