### PR TITLE
sdk: string autocomplete for river environments

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -42,6 +42,7 @@
     },
     "devDependencies": {
         "@jest/globals": "^29.6.2",
+        "@river-build/generated": "workspace:^",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.2.1",
         "@types/debug": "^4.1.8",

--- a/packages/sdk/src/riverConfig.ts
+++ b/packages/sdk/src/riverConfig.ts
@@ -8,6 +8,9 @@ import {
 } from '@river-build/web3'
 import { isDefined } from './check'
 import { check } from '@river-build/dlog'
+import type DeploymentsJson from '@river-build/generated/config/deployments.json'
+
+type EnvironmentId = keyof typeof DeploymentsJson
 
 function getEnvironmentId(): string {
     if (typeof process === 'object') {
@@ -117,7 +120,9 @@ export function makeBaseChainConfig(environmentId?: string) {
 
 export type RiverConfig = ReturnType<typeof makeRiverConfig>
 
-export function makeRiverConfig(inEnvironmentId?: string) {
+// trick to get autocomplete for environment ids while allowing any string
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function makeRiverConfig(inEnvironmentId?: EnvironmentId | (string & {})) {
     const environmentId = inEnvironmentId ?? getEnvironmentId()
     const config = {
         environmentId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6455,6 +6455,7 @@ __metadata:
     "@jest/globals": ^29.6.2
     "@river-build/dlog": "workspace:^"
     "@river-build/encryption": "workspace:^"
+    "@river-build/generated": "workspace:^"
     "@river-build/proto": "workspace:^"
     "@river-build/web3": "workspace:^"
     "@testing-library/jest-dom": ^5.16.5


### PR DESCRIPTION
It is a bit tricky when you don't have all the river environment information context to create a river config

this PR adds autocomplete for river environments, I'll add a follow-up adding docs about environments

<img width="577" alt="image" src="https://github.com/user-attachments/assets/bb501e92-2d82-4ff3-a2d8-ef87e692f102">

It's a loose autocomplete, this function still accepts any other `string` values.
