### PR TITLE
river_node: add support to dump stream event

### DIFF
--- a/core/cmd/stream_cmd.go
+++ b/core/cmd/stream_cmd.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strconv"
+
+	"connectrpc.com/connect"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/river-build/river/core/node/crypto"
+	"github.com/river-build/river/core/node/events"
+	"github.com/river-build/river/core/node/infra"
+	"github.com/river-build/river/core/node/nodes"
+	"github.com/river-build/river/core/node/protocol"
+	"github.com/river-build/river/core/node/protocol/protocolconnect"
+	"github.com/river-build/river/core/node/registries"
+	"github.com/river-build/river/core/node/shared"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"net/http"
+)
+
+func runStreamGetEventCmd(cmd *cobra.Command, args []string) error {
+	ctx := context.Background() // lint:ignore context.Background() is fine here
+	streamID, err := shared.StreamIdFromString(args[0])
+	if err != nil {
+		return err
+	}
+	eventHash := common.HexToHash(args[1])
+	blockchain, err := crypto.NewBlockchain(
+		ctx,
+		&cmdConfig.RiverChain,
+		nil,
+		infra.NewMetricsFactory(nil, "river", "cmdline"),
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	registryContract, err := registries.NewRiverRegistryContract(
+		ctx,
+		blockchain,
+		&cmdConfig.RegistryContract,
+		&cmdConfig.RiverRegistry,
+	)
+	if err != nil {
+		return err
+	}
+
+	stream, err := registryContract.StreamRegistry.GetStream(nil, streamID)
+	if err != nil {
+		return err
+	}
+
+	nodes := nodes.NewStreamNodes(stream.Nodes, common.Address{})
+	remoteNodeAddress := nodes.GetStickyPeer()
+
+	remote, err := registryContract.NodeRegistry.GetNode(nil, remoteNodeAddress)
+	if err != nil {
+		return err
+	}
+
+	remoteClient := protocolconnect.NewStreamServiceClient(http.DefaultClient, remote.Url)
+
+	response, err := remoteClient.GetStream(ctx, connect.NewRequest(&protocol.GetStreamRequest{
+		StreamId: streamID[:],
+		Optional: false,
+	}))
+
+	if err != nil {
+		return err
+	}
+
+	streamAndCookie := response.Msg.GetStream()
+
+	to := streamAndCookie.GetNextSyncCookie().GetMinipoolGen()
+	blockRange := int64(100)
+	if len(args) == 3 {
+		blockRange, err = strconv.ParseInt(args[2], 10, 64)
+		if err != nil {
+			return err
+		}
+	}
+	from := max(to-blockRange, 0)
+
+	miniblocks, err := remoteClient.GetMiniblocks(ctx, connect.NewRequest(&protocol.GetMiniblocksRequest{
+		StreamId:      streamID[:],
+		FromInclusive: from,
+		ToExclusive:   to,
+	}))
+
+	if err != nil {
+		return err
+	}
+
+	for n, miniblock := range miniblocks.Msg.GetMiniblocks() {
+		// Parse header
+		info, err := events.NewMiniblockInfoFromProto(
+			miniblock,
+			events.NewMiniblockInfoFromProtoOpts{
+				ExpectedBlockNumber: from + int64(n),
+			},
+		)
+
+		if err != nil {
+			return err
+		}
+
+		for _, event := range info.Proto.GetEvents() {
+			if bytes.Equal(eventHash[:], event.GetHash()) {
+				var streamEvent protocol.StreamEvent
+				if err := proto.Unmarshal(event.Event, &streamEvent); err != nil {
+					return err
+				}
+
+				fmt.Printf("\n%s\n", protojson.Format(&streamEvent))
+
+				return nil
+			}
+		}
+	}
+
+	fmt.Printf("Event %s not found in stream %s (block range [%d...%d])\n", eventHash, streamID, from, to)
+
+	return nil
+}
+
+func init() {
+	cmdStream := &cobra.Command{
+		Use:   "stream",
+		Short: "Access stream data",
+	}
+
+	cmdStreamGetEvent := &cobra.Command{
+		Use:   "event",
+		Short: "Get event <stream-id> <event-hash> [max-block-range]",
+		Long: `Dump stream event to stdout.
+max-block-range is optional and limits the number of blocks to consider (default=100)`,
+		Args: cobra.RangeArgs(2, 3),
+		RunE: runStreamGetEventCmd,
+	}
+
+	cmdStream.AddCommand(cmdStreamGetEvent)
+	rootCmd.AddCommand(cmdStream)
+}


### PR DESCRIPTION
Adds support to the river_node binary to dump a stream event. This is useful for debugging purposes.

```
$ ./env/omega/run.sh stream event 88a126f40682b1f7ea23a387822e210e74b5ea820909822e60153c0d2d049605 1c0fef8a81be6661bb7aee269e9d8d4e268a94acd171eb208f3c5a5645221129 50

{
  "creatorAddress": "6YCbyIuHD3Q2Hskfo1c3NKIG/sw=",
  "delegateSig": "bABTh/Pw3J/sclGv27XA+9KZFr40SGUemy5sOguqQ3shzmxYPKs7226kcCdB9ztAG/Ik9NfKY1lI5CAn6GNN8xs=",
  "salt": "5Fnr/mz8RacmI1+Q3gX97g==",
  "prevMiniblockHash": "1PprwlOjbdYRwuyXwjo6FAWEa6d+XCxJL4yxeDCt9qI=",
  "createdAtEpochMs": "1732697450905",
  "tags": {
    "messageInteractionType": "MESSAGE_INTERACTION_TYPE_POST"
  },
  "dmChannelPayload": {
    "message": {
      "ciphertext": "AwjGARLAEvJ9pFV9pmhu/4oW6cXl3Ow+M8lTd+augXq3NmH9HNxpcMJmU1Ai9rukvEAyQiWsjRSMdUPjuK6GjwnVjXqV1mLxcl3HP26g0GAokFQpU5d3NCEKi9MFxuQqq9Nm+I6xDRfR1+mtLV+8FcbpINuI/2us5pdxZLXcXfExwaLm23mW7IKrbE5ErNAxTKDf702f6iX08x+IARtEZgcZPGyHnEr/6xnyGUmvnPqOOx9L4oYeRK/2V0CO9vQR5DsGU4nEpBna66PCi1Jp0SFGRdLyVEoeuhXIeTCOyFIqFcrMXJ2T7hJb+Q2SDwaRjMRwsKnA03jb+Eh+n5G0/5j3S0ocJNHbCNlCEn1tUpjZz3heOV10X+l3clttqgCg93M3aFJg2Un1ZAOtdirnZz0FcTt9yQJG/Uu0Hj1mfXCoGzio80lXe/6ANWtcYVsP+eGL+EkJhf9oeUoid3Ni20h4OJnQZRW9g82LthkVn22e6MvGes1FBuXRnIkWzuAkUW4RDun16+ZqJvw/bIU0i8Dx0vbPfIZJlsfsTW5fNcIe4ZMWlXUGjyQZKj5bE+1VhqeJJzoAb0AKz+BoarslvtvaRV0kwfgUwN4N20hAjERYLGAk+A3LH2dcEzUiDeXM4FWjwlQgzDVKobg5V+8JhYg2B3l3S5MhXQjzpmOv5cG38hPkgeOdxWlxwfEb5P06b2art6jfGuw4JUp+u2qtuH0VNbBUTFDj6iiE8h4SNg2wiu8sozBBS9l6PerQrHHnjuARHwiUKO2Iuhd2vEmeyUMpD1sJe4uh3jEZ0rBxamF95v10pBr9taiqPHUe3PkinGTrMknBnvyE2JWnJAk7m6mvWsAbp+Xkm4GnrppL/NLjngEK50aXjv/NHtF0vgEP8c2Ntldxy4JqVVYFDMbooa2ofiPliS2pQwecHnw44lmwfm1Zayup5qYClK1fPDbnLre01BdG3OZkOfBXJ/rlqD5SwUzpOafVaPEIdcbsjL2tlnK3TWwHNjPc7ROM5Hxth6eETFf0wbunG6HasNxTjyglM9kr0XB0lOypxgQMsHoPtu8qeCzNV5DV/BdL85aYNPM/QkrO/2lbCcE5TsSDr3rbZ9/9+4+9Lg4mvOrJgl0isVCol+XJNCW8Ji6kYQFYH5fu4gCTrOzJmJptoA/ysgcRVBwlt/70mheWPEjffhoz5gk3wWIJRyyfXUAJi7Lq9z9oOiC77e0A+/Zrm/CgrqyP67ArFLs6f2zyVcRCR/lw+ANgZ1SiI6Oe8vfAJOMzD74+IppdTO0NI8gsVi+DJEExLEkQjq/JxzGNC/HPQYGj5a+iJ8gHK8GMOKPTKZA+lAvhiCCklRl2rlBb/y32BfF9pMyuHhsceIYxNi/Cz3ohVNMcKUok5n0SioY++DlxaU78bwcaC6O/dISntPS3zNGhdqDpJ9k2UjJ2yaoe7sjyuQdKq4Rm0D0fsYe5ANg8kFwnppCauqjxFYyAMTQ0gX3CXTVLOSqYybkhwzeVW9sFK6D+x1h0YWVCEn3TLDwqJ+UazC7q5ZzX8nWz4iPx9ya/hngEu8dV1oKM4Hv84Xx44im4u8aEJFfaKQM/TgaXD2S/RhBEqflFLsORxxaI+0IA51r0AwpfvwH2CF6cTY5zdA1AJTDubwFlINyFIgWVJ8EDRHqjeGaWxzj+wQhRWYF2rtP8R5MoyvdYnp1VKyHWjKJJWs8KkeqORWdWVkiBZ4YCvL0YXutaxDTlfNK3ni9NyCKsJpsngiUu4dRtFDtHRPk9D51vpV1/9B8vLgj6apz1QUSqT6mMRDlk79KINRkfOsprNT9BFw2BL6hx1sUDxJAPrru8ygrdobxpkT6Ln7XkDDJ3y/EJ8/qZAl00mnl5aaYbDazMPmRimLaVELkhe58RsKtpQjQawucfyF/kxaHHgWvpTSOwV+xx+7AAmkJRT/dy9Xm+yGNfSC1n+zWs55P37eNEjK0ZxZDI5hqsW7+DkGJYB6B3fHwp4Z+KaO4JygsgmdCjh+MkFg6Opo5UxA+uYXDY//Ex4+JgccitKZEkpeuEn7bNvvGMtxrAI27LiD2jX2x2AonkR49NrbKY03omNOa+BvovOboIayO8LSAzEcFeJ62BQiM5pWpDPOR+d7TkYtpbO0Aj4/8XagSnRhGYo+qoOzcGKWMqfkp5rzwOtv17am0aUmDUp7LgFeG8yDa8N2f7+2USH2CX6He7RFbJN6fpYWjEKDA0aCg/FThMd3SVOeIufQJzF8q8YoGqUrxUt0zTE+DDWhBFHxI3IijmRApsqPCSlHtjB+OVfOft1nceDfxvzbgfwj/xF8S8dQZqylF7C0iDMRuek8y/DNKintoniqhm6RVbj6s10vCE1pkp0h7Pa8+/agO4iUU3Hp8vXbpU8c/PYZialKDKApJaS6WHJ5psZKrEHKkw+/i4e4RKIyASM0neJdMmIz/6GG6Q2G/b5KWjCAHA+19VQHsn1afkcGfTuZEfHkRxjbOJkD/umDF1JFl78ESsf/2Pnn/Sy+p984azU8Zj3VqLsKEkx5yHwurikJfSr371DbcZrAxhfBtbAYciDGappiuAT5+hqeskv8cMi9KprSYpVc2U9r761wLCVOtk2O856Es8UwoeL0vdfDYpzAzitBLr7M9rzuOvp9kwRJT4OryR1kmZ1Uhc61HFHpfhPnWo3LG8KqdWTwWoiMVpHkUnyn6D8VxslprJk4Je3cNvIfh6idNLFJcY9wlGoiwZmzbvC0qj6wvs8/68e1nmVmtboaGmnoQpnb98/vjiJ/KYUXRMBMlYCmI3wlhSx5W33oyCPyWvYrvMrdlg0A3o+eRGilWOvzifI4xngmBxg2xieFBa7yLeKcrJl4JZD0KrIm1AnUJKngI1pLtLRmHRXVS+8JKtEjOGpbqV560YXbejBT9ihs4joPmwIyG9htBcU294NnxKsDvM7XL9tVjW2WWkrX4XbVWvergcxSU2zePD/r05TPsrRTD4pRkYJb7yo67zZzLv1iYUgp1N4scRKNbm0EzhuJAJhi1bnFpssQZ16AHUyn4t+iY1LwWb1QqxRZ1bNwF04cfeuqtUmNfjqjVOt5l/RwNDMmbXeFXhNcUvhv4M/LBF7CLevQ4ECLWpm1Pj6M9x9SkwteuRenfkE75oiGi4BJBojtJsqK2Yf6dHW5+uLDw/FoJGV96+iaBxgIDKBNDzuHmwrAznsx0MkH5HlWeEslvf1FmMkvoy5xgfr1trwOEi4YaFbqgn+l2JRQk",
      "algorithm": "r.group-encryption.v1.aes-sha2",
      "senderKey": "77XKpbkyWIV8iQbdCe/r49aI5gWWye7FmeSKyMHnlVM",
      "sessionId": "rg9rfCc/TGtlWzDVe40tTABmH5ouKF0EmM9zSbQiYn4"
    }
  }
}
```