### PR TITLE
Speed up notifications tests

### DIFF
--- a/core/node/rpc/archiver_test.go
+++ b/core/node/rpc/archiver_test.go
@@ -334,7 +334,7 @@ func TestArchiveOneStream(t *testing.T) {
 }
 
 func makeTestServerOpts(tester *serviceTester) *ServerStartOpts {
-	listener, _ := makeTestListener(tester.t)
+	listener, _ := tester.makeTestListener()
 	return &ServerStartOpts{
 		RiverChain:      tester.btc.NewWalletAndBlockchain(tester.ctx),
 		Listener:        listener,

--- a/core/node/rpc/notification_test.go
+++ b/core/node/rpc/notification_test.go
@@ -49,9 +49,8 @@ func TestSubscriptionExpired(t *testing.T) {
 	authClient := protocolconnect.NewAuthenticationServiceClient(
 		httpClient, "https://"+notificationService.listener.Addr().String())
 
-	t.Run("webpush", func(t *testing.T) {
-		t.Parallel()
-
+	tester.parallelSubtest("webpush", func(tester *serviceTester) {
+		ctx := tester.ctx
 		test := setupDMNotificationTest(ctx, tester, notificationClient, authClient)
 		test.subscribeWebPush(ctx, test.initiator)
 		test.subscribeWebPush(ctx, test.member)
@@ -71,8 +70,8 @@ func TestSubscriptionExpired(t *testing.T) {
 		}, 15*time.Second, 100*time.Millisecond, "webpush subscription not deleted")
 	})
 
-	t.Run("APN", func(t *testing.T) {
-		t.Parallel()
+	tester.parallelSubtest("APN", func(tester *serviceTester) {
+		ctx := tester.ctx
 
 		test := setupDMNotificationTest(ctx, tester, notificationClient, authClient)
 		test.subscribeApnPush(ctx, test.initiator)
@@ -114,31 +113,27 @@ func TestNotifications(t *testing.T) {
 	authClient := protocolconnect.NewAuthenticationServiceClient(
 		httpClient, "https://"+notificationService.listener.Addr().String())
 
-	t.Run("DMNotifications", func(t *testing.T) {
-		t.Parallel()
-		testDMNotifications(t, ctx, tester, notificationClient, authClient, notifications)
+	tester.parallelSubtest("DMNotifications", func(tester *serviceTester) {
+		testDMNotifications(tester, notificationClient, authClient, notifications)
 	})
 
-	t.Run("GDMNotifications", func(t *testing.T) {
-		t.Parallel()
-		testGDMNotifications(t, ctx, tester, notificationClient, authClient, notifications)
+	tester.parallelSubtest("GDMNotifications", func(tester *serviceTester) {
+		testGDMNotifications(tester, notificationClient, authClient, notifications)
 	})
 
-	t.Run("SpaceChannelNotification", func(t *testing.T) {
-		t.Parallel()
-		SpaceChannelNotification(t, ctx, tester, notificationClient, authClient, notifications)
+	tester.parallelSubtest("SpaceChannelNotification", func(tester *serviceTester) {
+		testSpaceChannelNotifications(tester, notificationClient, authClient, notifications)
 	})
 }
 
 func testGDMNotifications(
-	t *testing.T,
-	ctx context.Context,
 	tester *serviceTester,
 	notificationClient protocolconnect.NotificationServiceClient,
 	authClient protocolconnect.AuthenticationServiceClient,
 	notifications *notificationCapture,
 ) {
-	t.Run("MessageWithNoMentionsRepliesAndReaction", func(t *testing.T) {
+	tester.parallelSubtest("MessageWithNoMentionsRepliesAndReaction", func(tester *serviceTester) {
+		ctx := tester.ctx
 		test := setupGDMNotificationTest(ctx, tester, notificationClient, authClient)
 		testGDMMessageWithNoMentionsRepliesAndReaction(ctx, test, notifications)
 	})
@@ -225,29 +220,31 @@ func testGDMMessageWithNoMentionsRepliesAndReaction(
 }
 
 func testDMNotifications(
-	t *testing.T,
-	ctx context.Context,
 	tester *serviceTester,
 	notificationClient protocolconnect.NotificationServiceClient,
 	authClient protocolconnect.AuthenticationServiceClient,
 	notifications *notificationCapture,
 ) {
-	t.Run("MessageWithDefaultUserNotificationsPreferences", func(t *testing.T) {
+	tester.parallelSubtest("MessageWithDefaultUserNotificationsPreferences", func(tester *serviceTester) {
+		ctx := tester.ctx
 		test := setupDMNotificationTest(ctx, tester, notificationClient, authClient)
 		testDMMessageWithDefaultUserNotificationsPreferences(ctx, test, notifications)
 	})
 
-	t.Run("DMMessageWithNotificationsMutedOnDmChannel", func(t *testing.T) {
+	tester.parallelSubtest("DMMessageWithNotificationsMutedOnDmChannel", func(tester *serviceTester) {
+		ctx := tester.ctx
 		test := setupDMNotificationTest(ctx, tester, notificationClient, authClient)
 		testDMMessageWithNotificationsMutedOnDmChannel(ctx, test, notifications)
 	})
 
-	t.Run("DMMessageWithNotificationsMutedGlobal", func(t *testing.T) {
+	tester.parallelSubtest("DMMessageWithNotificationsMutedGlobal", func(tester *serviceTester) {
+		ctx := tester.ctx
 		test := setupDMNotificationTest(ctx, tester, notificationClient, authClient)
 		testDMMessageWithNotificationsMutedGlobal(ctx, test, notifications)
 	})
 
-	t.Run("MessageWithBlockedUser", func(t *testing.T) {
+	tester.parallelSubtest("MessageWithBlockedUser", func(tester *serviceTester) {
+		ctx := tester.ctx
 		test := setupDMNotificationTest(ctx, tester, notificationClient, authClient)
 		testDMMessageWithBlockedUser(ctx, test, notifications)
 	})
@@ -411,30 +408,32 @@ func testDMMessageWithBlockedUser(
 	}, time.Second, 100*time.Millisecond, "Received unexpected notifications")
 }
 
-func SpaceChannelNotification(
-	t *testing.T,
-	ctx context.Context,
+func testSpaceChannelNotifications(
 	tester *serviceTester,
 	notificationClient protocolconnect.NotificationServiceClient,
 	authClient protocolconnect.AuthenticationServiceClient,
 	notifications *notificationCapture,
 ) {
-	t.Run("TestPlainMessage", func(t *testing.T) {
+	tester.parallelSubtest("TestPlainMessage", func(tester *serviceTester) {
+		ctx := tester.ctx
 		test := setupSpaceChannelNotificationTest(ctx, tester, notificationClient, authClient)
 		testSpaceChannelPlainMessage(ctx, test, notifications)
 	})
 
-	t.Run("TestAtChannelTag", func(t *testing.T) {
+	tester.parallelSubtest("TestAtChannelTag", func(tester *serviceTester) {
+		ctx := tester.ctx
 		test := setupSpaceChannelNotificationTest(ctx, tester, notificationClient, authClient)
 		testSpaceChannelAtChannelTag(ctx, test, notifications)
 	})
 
-	t.Run("TestMentionsTag", func(t *testing.T) {
+	tester.parallelSubtest("TestMentionsTag", func(tester *serviceTester) {
+		ctx := tester.ctx
 		test := setupSpaceChannelNotificationTest(ctx, tester, notificationClient, authClient)
 		testSpaceChannelMentionTag(ctx, test, notifications)
 	})
 
-	t.Run("Settings", func(t *testing.T) {
+	tester.parallelSubtest("Settings", func(tester *serviceTester) {
+		ctx := tester.ctx
 		test := setupSpaceChannelNotificationTest(ctx, tester, notificationClient, authClient)
 		spaceChannelSettings(ctx, test)
 	})

--- a/core/node/rpc/notification_test.go
+++ b/core/node/rpc/notification_test.go
@@ -132,7 +132,7 @@ func testGDMNotifications(
 	authClient protocolconnect.AuthenticationServiceClient,
 	notifications *notificationCapture,
 ) {
-	tester.parallelSubtest("MessageWithNoMentionsRepliesAndReaction", func(tester *serviceTester) {
+	tester.sequentialSubtest("MessageWithNoMentionsRepliesAndReaction", func(tester *serviceTester) {
 		ctx := tester.ctx
 		test := setupGDMNotificationTest(ctx, tester, notificationClient, authClient)
 		testGDMMessageWithNoMentionsRepliesAndReaction(ctx, test, notifications)
@@ -225,25 +225,25 @@ func testDMNotifications(
 	authClient protocolconnect.AuthenticationServiceClient,
 	notifications *notificationCapture,
 ) {
-	tester.parallelSubtest("MessageWithDefaultUserNotificationsPreferences", func(tester *serviceTester) {
+	tester.sequentialSubtest("MessageWithDefaultUserNotificationsPreferences", func(tester *serviceTester) {
 		ctx := tester.ctx
 		test := setupDMNotificationTest(ctx, tester, notificationClient, authClient)
 		testDMMessageWithDefaultUserNotificationsPreferences(ctx, test, notifications)
 	})
 
-	tester.parallelSubtest("DMMessageWithNotificationsMutedOnDmChannel", func(tester *serviceTester) {
+	tester.sequentialSubtest("DMMessageWithNotificationsMutedOnDmChannel", func(tester *serviceTester) {
 		ctx := tester.ctx
 		test := setupDMNotificationTest(ctx, tester, notificationClient, authClient)
 		testDMMessageWithNotificationsMutedOnDmChannel(ctx, test, notifications)
 	})
 
-	tester.parallelSubtest("DMMessageWithNotificationsMutedGlobal", func(tester *serviceTester) {
+	tester.sequentialSubtest("DMMessageWithNotificationsMutedGlobal", func(tester *serviceTester) {
 		ctx := tester.ctx
 		test := setupDMNotificationTest(ctx, tester, notificationClient, authClient)
 		testDMMessageWithNotificationsMutedGlobal(ctx, test, notifications)
 	})
 
-	tester.parallelSubtest("MessageWithBlockedUser", func(tester *serviceTester) {
+	tester.sequentialSubtest("MessageWithBlockedUser", func(tester *serviceTester) {
 		ctx := tester.ctx
 		test := setupDMNotificationTest(ctx, tester, notificationClient, authClient)
 		testDMMessageWithBlockedUser(ctx, test, notifications)
@@ -414,25 +414,25 @@ func testSpaceChannelNotifications(
 	authClient protocolconnect.AuthenticationServiceClient,
 	notifications *notificationCapture,
 ) {
-	tester.parallelSubtest("TestPlainMessage", func(tester *serviceTester) {
+	tester.sequentialSubtest("TestPlainMessage", func(tester *serviceTester) {
 		ctx := tester.ctx
 		test := setupSpaceChannelNotificationTest(ctx, tester, notificationClient, authClient)
 		testSpaceChannelPlainMessage(ctx, test, notifications)
 	})
 
-	tester.parallelSubtest("TestAtChannelTag", func(tester *serviceTester) {
+	tester.sequentialSubtest("TestAtChannelTag", func(tester *serviceTester) {
 		ctx := tester.ctx
 		test := setupSpaceChannelNotificationTest(ctx, tester, notificationClient, authClient)
 		testSpaceChannelAtChannelTag(ctx, test, notifications)
 	})
 
-	tester.parallelSubtest("TestMentionsTag", func(tester *serviceTester) {
+	tester.sequentialSubtest("TestMentionsTag", func(tester *serviceTester) {
 		ctx := tester.ctx
 		test := setupSpaceChannelNotificationTest(ctx, tester, notificationClient, authClient)
 		testSpaceChannelMentionTag(ctx, test, notifications)
 	})
 
-	tester.parallelSubtest("Settings", func(tester *serviceTester) {
+	tester.sequentialSubtest("Settings", func(tester *serviceTester) {
 		ctx := tester.ctx
 		test := setupSpaceChannelNotificationTest(ctx, tester, notificationClient, authClient)
 		spaceChannelSettings(ctx, test)

--- a/core/node/rpc/shutdown_test.go
+++ b/core/node/rpc/shutdown_test.go
@@ -22,7 +22,7 @@ func TestShutdown(t *testing.T) {
 		exitStatus <- firstExit
 	}()
 
-	listener, _ := makeTestListener(tester.t)
+	listener, _ := tester.makeTestListener()
 
 	// Start the second node with same address
 	require.NoError(tester.startSingle(0, startOpts{listeners: []net.Listener{listener}}))

--- a/core/node/rpc/tester_test.go
+++ b/core/node/rpc/tester_test.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"hash/fnv"
 	"io"
 	"log"
@@ -69,12 +70,17 @@ type serviceTesterOpts struct {
 	start             bool
 }
 
-func makeTestListener(t *testing.T) (net.Listener, string) {
+func makeTestListenerNoCleanup(t *testing.T) (net.Listener, string) {
 	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 	listener = tls.NewListener(listener, testcert.GetHttp2LocalhostTLSConfig())
-	t.Cleanup(func() { _ = listener.Close() })
 	return listener, "https://" + listener.Addr().String()
+}
+
+func makeTestListener(t *testing.T) (net.Listener, string) {
+	l, url := makeTestListenerNoCleanup(t)
+	t.Cleanup(func() { _ = l.Close() })
+	return l, url
 }
 
 func newServiceTester(t *testing.T, opts serviceTesterOpts) *serviceTester {
@@ -89,8 +95,6 @@ func newServiceTester(t *testing.T, opts serviceTesterOpts) *serviceTester {
 	}
 
 	ctx, ctxCancel := test.NewTestContext()
-	t.Cleanup(ctxCancel)
-
 	require := require.New(t)
 
 	st := &serviceTester{
@@ -103,17 +107,20 @@ func newServiceTester(t *testing.T, opts serviceTesterOpts) *serviceTester {
 		opts:      opts,
 	}
 
+	// Cleanup context on test completion even if no other cleanups are registered.
+	st.cleanup(func() {})
+
 	btc, err := crypto.NewBlockchainTestContext(
 		st.ctx,
 		crypto.TestParams{NumKeys: opts.numNodes, MineOnTx: true, AutoMine: true},
 	)
 	require.NoError(err)
 	st.btc = btc
-	t.Cleanup(st.btc.Close)
+	st.cleanup(st.btc.Close)
 
 	for i := 0; i < opts.numNodes; i++ {
 		st.nodes[i] = &testNodeRecord{}
-		st.nodes[i].listener, st.nodes[i].url = makeTestListener(t)
+		st.nodes[i].listener, st.nodes[i].url = st.makeTestListener()
 	}
 
 	st.startAutoMining()
@@ -133,7 +140,64 @@ func newServiceTester(t *testing.T, opts serviceTesterOpts) *serviceTester {
 	return st
 }
 
-func (st serviceTester) CloseNode(i int) {
+// Returns a new serviceTester instance for a makeSubtest.
+//
+// The new instance shares nodes with the parent instance,
+// if parallel tests are run, node restarts or other changes should not be performed.
+func (st *serviceTester) makeSubtest(t *testing.T) *serviceTester {
+	var sub serviceTester = *st
+	sub.t = t
+	sub.ctx, sub.ctxCancel = context.WithCancel(st.ctx)
+	sub.require = require.New(t)
+
+	// Cleanup context on subtest completion even if no other cleanups are registered.
+	sub.cleanup(func() {})
+
+	return &sub
+}
+
+func (st *serviceTester) parallelSubtest(name string, test func(*serviceTester)) {
+	st.t.Run(name, func(t *testing.T) {
+		t.Parallel()
+		test(st.makeSubtest(t))
+	})
+}
+
+func (st *serviceTester) sequentialSubtest(name string, test func(*serviceTester)) {
+	st.t.Run(name, func(t *testing.T) {
+		test(st.makeSubtest(t))
+	})
+}
+
+// TODO: remove once sequentialSubtest is used
+var _ = (*serviceTester).sequentialSubtest
+
+func (st *serviceTester) cleanup(f any) {
+	st.t.Cleanup(func() {
+		st.t.Helper()
+		// On first cleanup call for current test cancel context, so relevant shutdowns are started.
+		if st.ctxCancel != nil {
+			st.ctxCancel()
+			st.ctxCancel = nil
+		}
+		switch f := f.(type) {
+		case func():
+			f()
+		case func() error:
+			_ = f()
+		default:
+			panic(fmt.Sprintf("unsupported cleanup type: %T", f))
+		}
+	})
+}
+
+func (st *serviceTester) makeTestListener() (net.Listener, string) {
+	l, url := makeTestListenerNoCleanup(st.t)
+	st.cleanup(l.Close)
+	return l, url
+}
+
+func (st *serviceTester) CloseNode(i int) {
 	if st.nodes[i] != nil {
 		st.nodes[i].Close(st.ctx, st.dbUrl)
 	}
@@ -278,13 +342,7 @@ func (st *serviceTester) startSingle(i int, opts ...startOpts) error {
 
 	var nodeRecord testNodeRecord = *st.nodes[i]
 
-	st.t.Cleanup(func() {
-		// Cancel context here: t.Cleanup calls functions in reverse order,
-		// but it's better to cancel context first.
-		// Since it's ok to cancel context multiple times, it's safe to cancel it here.
-		st.ctxCancel()
-		nodeRecord.Close(st.ctx, st.dbUrl)
-	})
+	st.cleanup(func() { nodeRecord.Close(st.ctx, st.dbUrl) })
 
 	return nil
 }

--- a/core/node/rpc/tester_test.go
+++ b/core/node/rpc/tester_test.go
@@ -169,9 +169,6 @@ func (st *serviceTester) sequentialSubtest(name string, test func(*serviceTester
 	})
 }
 
-// TODO: remove once sequentialSubtest is used
-var _ = (*serviceTester).sequentialSubtest
-
 func (st *serviceTester) cleanup(f any) {
 	st.t.Cleanup(func() {
 		st.t.Helper()

--- a/core/node/rpc/tester_test.go
+++ b/core/node/rpc/tester_test.go
@@ -175,7 +175,7 @@ var _ = (*serviceTester).sequentialSubtest
 func (st *serviceTester) cleanup(f any) {
 	st.t.Cleanup(func() {
 		st.t.Helper()
-		// On first cleanup call for current test cancel context, so relevant shutdowns are started.
+		// On first cleanup call cancel context for the current test, so relevant shutdowns are started.
 		if st.ctxCancel != nil {
 			st.ctxCancel()
 			st.ctxCancel = nil


### PR DESCRIPTION
This PR adds subtest setup & support to serviceTester (so `t`, `require` and `ctx` are correct).

It's used in notification tests, and also makes notifications tests parallel, making them significantly faster.

Additionally `Never` timeout is reduced to 1 second.