### PR TITLE
playground: dont use `@wagmi/core` to get ethers signer

### DIFF
--- a/packages/playground/src/components/dialog/env-switcher.tsx
+++ b/packages/playground/src/components/dialog/env-switcher.tsx
@@ -15,8 +15,7 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { getWeb3Deployment, getWeb3Deployments } from '@river-build/web3'
 import { deleteAuth, storeAuth } from '@/utils/persist-auth'
-import { getEthersSigner } from '@/utils/viem-to-ethers'
-import { wagmiConfig } from '@/config/wagmi'
+import { useEthersSigner } from '@/utils/viem-to-ethers'
 import { Button } from '../ui/button'
 import {
     Dialog,
@@ -69,6 +68,7 @@ export const RiverEnvSwitcherContent = (props: {
     const { disconnect: disconnectWallet } = useDisconnect()
     const [bearerToken, setBearerToken] = useState('')
     const navigate = useNavigate()
+    const signer = useEthersSigner()
 
     return (
         <DialogContent className="gap-6">
@@ -115,9 +115,9 @@ export const RiverEnvSwitcherContent = (props: {
                                         }
                                     } else {
                                         switchChain?.({ chainId })
-                                        const signer = await getEthersSigner(wagmiConfig, {
-                                            chainId,
-                                        })
+                                        if (!signer) {
+                                            return
+                                        }
                                         await connect(signer, {
                                             riverConfig,
                                         }).then((sync) => {

--- a/packages/playground/src/components/form/channel/create.tsx
+++ b/packages/playground/src/components/form/channel/create.tsx
@@ -2,8 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { useCreateChannel } from '@river-build/react-sdk'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
-import { getEthersSigner } from '@/utils/viem-to-ethers'
-import { wagmiConfig } from '@/config/wagmi'
+import { useEthersSigner } from '@/utils/viem-to-ethers'
 import {
     Form,
     FormControl,
@@ -25,6 +24,7 @@ export const CreateChannel = (props: {
 }) => {
     const { onChannelCreated, spaceId } = props
     const { createChannel, isPending } = useCreateChannel(spaceId)
+    const signer = useEthersSigner()
     const form = useForm<z.infer<typeof formSchema>>({
         resolver: zodResolver(formSchema),
         defaultValues: { channelName: '' },
@@ -35,7 +35,9 @@ export const CreateChannel = (props: {
             <form
                 className="space-y-3"
                 onSubmit={form.handleSubmit(async ({ channelName }) => {
-                    const signer = await getEthersSigner(wagmiConfig)
+                    if (!signer) {
+                        return
+                    }
                     const channelId = await createChannel(channelName, signer)
                     onChannelCreated(channelId)
                 })}

--- a/packages/playground/src/components/form/space/create.tsx
+++ b/packages/playground/src/components/form/space/create.tsx
@@ -13,8 +13,7 @@ import {
 } from '@/components/ui/form'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { getEthersSigner } from '@/utils/viem-to-ethers'
-import { wagmiConfig } from '@/config/wagmi'
+import { useEthersSigner } from '@/utils/viem-to-ethers'
 
 const createSpaceFormSchema = z.object({
     spaceName: z.string().min(1, { message: 'Space name is required' }),
@@ -23,7 +22,7 @@ const createSpaceFormSchema = z.object({
 export const CreateSpace = (props: { onCreateSpace: (spaceId: string) => void }) => {
     const { onCreateSpace } = props
     const { createSpace, isPending } = useCreateSpace()
-
+    const signer = useEthersSigner()
     const form = useForm<z.infer<typeof createSpaceFormSchema>>({
         resolver: zodResolver(createSpaceFormSchema),
         defaultValues: { spaceName: '' },
@@ -34,7 +33,9 @@ export const CreateSpace = (props: { onCreateSpace: (spaceId: string) => void })
             <form
                 className="space-y-3"
                 onSubmit={form.handleSubmit(async ({ spaceName }) => {
-                    const signer = await getEthersSigner(wagmiConfig)
+                    if (!signer) {
+                        return
+                    }
                     const { spaceId } = await createSpace({ spaceName }, signer)
                     onCreateSpace(spaceId)
                 })}

--- a/packages/playground/src/components/form/space/join.tsx
+++ b/packages/playground/src/components/form/space/join.tsx
@@ -2,7 +2,7 @@ import { useJoinSpace } from '@river-build/react-sdk'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
-import { getEthersSigner } from '@/utils/viem-to-ethers'
+import { useEthersSigner } from '@/utils/viem-to-ethers'
 import {
     Form,
     FormControl,
@@ -13,7 +13,6 @@ import {
 } from '@/components/ui/form'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { wagmiConfig } from '@/config/wagmi'
 
 const joinSpaceFormSchema = z.object({
     spaceId: z.string().min(1, { message: 'Space Id is required' }),
@@ -22,7 +21,7 @@ const joinSpaceFormSchema = z.object({
 export const JoinSpace = (props: { onJoinSpace: (spaceId: string) => void }) => {
     const { onJoinSpace } = props
     const { joinSpace, isPending } = useJoinSpace()
-
+    const signer = useEthersSigner()
     const form = useForm<z.infer<typeof joinSpaceFormSchema>>({
         resolver: zodResolver(joinSpaceFormSchema),
         defaultValues: { spaceId: '' },
@@ -33,7 +32,9 @@ export const JoinSpace = (props: { onJoinSpace: (spaceId: string) => void }) => 
             <form
                 className="space-y-4"
                 onSubmit={form.handleSubmit(async ({ spaceId }) => {
-                    const signer = await getEthersSigner(wagmiConfig)
+                    if (!signer) {
+                        return
+                    }
                     joinSpace(spaceId, signer).then(() => {
                         onJoinSpace(spaceId)
                     })

--- a/packages/playground/src/utils/viem-to-ethers.ts
+++ b/packages/playground/src/utils/viem-to-ethers.ts
@@ -1,7 +1,8 @@
-// Copy-pasted from wagmi.sh/core/guides/ethers
-import { Config, getConnectorClient } from '@wagmi/core'
+// Copy-pasted from wagmi.sh/react/guides/ethers
 import { providers } from 'ethers'
+import { useMemo } from 'react'
 import type { Account, Chain, Client, Transport } from 'viem'
+import { Config, useConnectorClient } from 'wagmi'
 
 export function clientToSigner(client: Client<Transport, Chain, Account>) {
     const { account, chain, transport } = client
@@ -15,8 +16,8 @@ export function clientToSigner(client: Client<Transport, Chain, Account>) {
     return signer
 }
 
-/** Action to convert a Viem Client to an ethers.js Signer. */
-export async function getEthersSigner(config: Config, { chainId }: { chainId?: number } = {}) {
-    const client = await getConnectorClient(config, { chainId })
-    return clientToSigner(client)
+/** Hook to convert a Viem Client to an ethers.js Signer. */
+export function useEthersSigner({ chainId }: { chainId?: number } = {}) {
+    const { data: client } = useConnectorClient<Config>({ chainId })
+    return useMemo(() => (client ? clientToSigner(client) : undefined), [client])
 }

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -18,14 +18,14 @@ yarn add @river-build/react-sdk
 Wrap your app with `RiverSyncProvider` and use the `useAgentConnection` hook to connect to River.
 
 > [!NOTE]
-> You'll need to use `getEthersSigner` to get the signer from viem wallet client.
+> You'll need to use `useEthersSigner` to get the signer from viem wallet client.
 > You can get the hook from [wagmi docs](https://wagmi.sh/react/guides/ethers#usage-1).
 
 ```tsx
 import { RiverSyncProvider, useAgentConnection } from "@river-build/react-sdk";
 import { makeRiverConfig } from "@river-build/sdk";
 import { WagmiProvider } from "wagmi";
-import { getEthersSigner } from "./utils/viem-to-ethers";
+import { useEthersSigner } from "./utils/viem-to-ethers";
 import { wagmiConfig } from "./config/wagmi";
 
 const riverConfig = makeRiverConfig("gamma");
@@ -40,12 +40,15 @@ const App = ({ children }: { children: React.ReactNode }) => {
 
 const ConnectRiver = () => {
   const { connect, isConnecting, isConnected } = useAgentConnection();
+  const signer = useEthersSigner();
 
   return (
     <>
       <button
         onClick={async () => {
-          const signer = await getEthersSigner(wagmiConfig);
+          if (!signer) {
+            return;
+          }
           connect(signer, { riverConfig });
         }}
       >

--- a/packages/react-sdk/src/useAgentConnection.ts
+++ b/packages/react-sdk/src/useAgentConnection.ts
@@ -38,22 +38,25 @@ type AgentConnectConfig = Omit<SyncAgentConfig, 'context' | 'onTokenExpired'>
  *
  * ### Signer
  *
- * If you're using Wagmi and Viem, you can use the [`getEthersSigner`](https://wagmi.sh/react/guides/ethers#usage-1) hook to get an ethers.js v5 Signer from a Viem Wallet Client.
+ * If you're using Wagmi and Viem, you can use the [`useEthersSigner`](https://wagmi.sh/react/guides/ethers#usage-1) hook to get an ethers.js v5 Signer from a Viem Wallet Client.
  *
  * ```tsx
  * import { useAgentConnection } from '@river-build/react-sdk'
  * import { makeRiverConfig } from '@river-build/sdk'
- * import { getEthersSigner } from './utils/viem-to-ethers'
+ * import { useEthersSigner } from './utils/viem-to-ethers'
  *
  * const riverConfig = makeRiverConfig('gamma')
  *
  * const Login = () => {
  *   const { connect, isAgentConnecting, isAgentConnected } = useAgentConnection()
+ *   const signer = useEthersSigner()
  *
  *   return (
  *     <>
  *       <button onClick={async () => {
- *         const signer = await getEthersSigner(wagmiConfig)
+ *         if (!signer) {
+ *           return
+ *         }
  *         connect(signer, { riverConfig })
  *       }}>
  *         Login


### PR DESCRIPTION
in #1647 I changed `useEthersSigner` to `getEthersSigner`, moving from a hook to a action. But this introduces `@wagmi/core`, which tbh we dont want.

Moving back to the hook approach