### PR TITLE
remove operator + node address from prometheus labels

### DIFF
--- a/packages/metrics-discovery/src/metrics-discovery.ts
+++ b/packages/metrics-discovery/src/metrics-discovery.ts
@@ -40,8 +40,6 @@ export class MetricsDiscovery {
         const host = url.hostname
         return {
             labels: {
-                node_address: node.nodeAddress,
-                operator: node.operator,
                 node_url: node.url,
                 env: this.env,
             },


### PR DESCRIPTION
we don't use these, and they increase our cardinality and thus metrics bills