### PR TITLE
react-sdk: useRedact should call `sendChannelMessage_Redaction`

### DIFF
--- a/packages/playground/src/components/blocks/timeline.tsx
+++ b/packages/playground/src/components/blocks/timeline.tsx
@@ -31,7 +31,7 @@ const useMessageReaction = (streamId: string, eventId: string) => {
     const { data: reactionMap } = useReactions(streamId)
     const reactions = reactionMap?.[eventId]
     const { sendReaction } = useSendReaction(streamId)
-    const { redactEvent } = useRedact(streamId)
+    const { redact } = useRedact(streamId)
     const onReact = useCallback(
         (
             params:
@@ -47,10 +47,10 @@ const useMessageReaction = (streamId: string, eventId: string) => {
             if (params.type === 'add') {
                 sendReaction(eventId, params.reaction)
             } else {
-                redactEvent(params.refEventId)
+                redact(params.refEventId)
             }
         },
-        [sendReaction, redactEvent, eventId],
+        [sendReaction, redact, eventId],
     )
 
     return {
@@ -154,7 +154,7 @@ const Message = ({
     const prettyDisplayName = displayName || username
     const isMyMessage = event.sender.id === sync.userId
     const { reactions, onReact } = useMessageReaction(streamId, event.eventId)
-    const { redactEvent } = useRedact(streamId)
+    const { redact } = useRedact(streamId)
 
     return (
         <div className="flex w-full gap-3.5">
@@ -187,7 +187,7 @@ const Message = ({
                         👍
                     </Button>
                     {isMyMessage && (
-                        <Button variant="ghost" onClick={() => redactEvent(event.eventId)}>
+                        <Button variant="ghost" onClick={() => redact(event.eventId)}>
                             ❌
                         </Button>
                     )}

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -3,6 +3,7 @@
  **************************************************************************/
 export * from './RiverSyncProvider'
 export * from './connectRiver'
+export * from './useAdminRedact'
 export * from './useAgentConnection'
 export * from './useChannel'
 export * from './useCreateChannel'

--- a/packages/react-sdk/src/useAdminRedact.ts
+++ b/packages/react-sdk/src/useAdminRedact.ts
@@ -1,22 +1,22 @@
 'use client'
 
-import { type Channel, Space, assert } from '@river-build/sdk'
+import { Channel, Space, assert } from '@river-build/sdk'
 import { type ActionConfig, useAction } from './internals/useAction'
 import { useSyncAgent } from './useSyncAgent'
 import { getRoom } from './utils'
 
 /**
- * Hook to redact your own message in a channel stream.
+ * Hook to redact any message in a channel if you're an admin.
  * @example
  *
  * ### Redact a message
  *
- * You can use `redact` to redact a message in a stream.
+ * You can use `adminRedact` to redact a message in a stream.
  * ```ts
- * import { useRedact } from '@river-build/react-sdk'
+ * import { useAdminRedact } from '@river-build/react-sdk'
  *
- * const { redact } = useRedact(streamId)
- * redact({ eventId: messageEventId })
+ * const { adminRedact } = useAdminRedact(streamId)
+ * adminRedact({ eventId: messageEventId })
  * ```
  *
  * ### Redact a message reaction
@@ -32,14 +32,14 @@ import { getRoom } from './utils'
  * @param config - Configuration options for the action.
  * @returns The `redact` action and its loading state.
  */
-export const useRedact = (streamId: string, config?: ActionConfig<Channel['redact']>) => {
+export const useAdminRedact = (streamId: string, config?: ActionConfig<Channel['adminRedact']>) => {
     const sync = useSyncAgent()
     const room = getRoom(sync, streamId)
-    assert(!(room instanceof Space), 'Space does not have reactions')
-    const { action: redact, ...rest } = useAction(room, 'redact', config)
+    assert(!(room instanceof Space), 'Spaces dont have timeline to redact')
+    const { action: adminRedact, ...rest } = useAction(room, 'adminRedact', config)
 
     return {
-        redact,
+        adminRedact,
         ...rest,
     }
 }

--- a/packages/sdk/src/sync-agent/dms/models/dm.ts
+++ b/packages/sdk/src/sync-agent/dms/models/dm.ts
@@ -107,7 +107,34 @@ export class Dm extends PersistedObservable<DmModel> {
         return eventId
     }
 
-    async redactEvent(eventId: string) {
+    /** Redacts your own event.
+     * @param eventId - The event id of the message to redact
+     * @param reason - The reason for the redaction
+     */
+    async redact(eventId: string, reason?: string) {
+        const channelId = this.data.id
+        const result = await this.riverConnection.withStream(channelId).call((client, stream) => {
+            const event = stream.view.events.get(eventId)
+            if (!event) {
+                throw new Error(`ref event not found: ${eventId}`)
+            }
+            if (event.remoteEvent?.creatorUserId !== this.riverConnection.userId) {
+                throw new Error(
+                    `You can only redact your own messages: ${eventId} - userId: ${this.riverConnection.userId}`,
+                )
+            }
+            return client.sendChannelMessage_Redaction(channelId, {
+                refEventId: eventId,
+                reason,
+            })
+        })
+        return result
+    }
+
+    /** Redacts any message as an admin.
+     * @param eventId - The event id of the message to redact
+     */
+    async adminRedact(eventId: string) {
         const channelId = this.data.id
         const result = await this.riverConnection
             .withStream(channelId)

--- a/packages/sdk/src/sync-agent/spaces/models/channel.ts
+++ b/packages/sdk/src/sync-agent/spaces/models/channel.ts
@@ -155,7 +155,34 @@ export class Channel extends PersistedObservable<ChannelModel> {
         return eventId
     }
 
-    async redactEvent(eventId: string) {
+    /** Redacts your own event.
+     * @param eventId - The event id of the message to redact
+     * @param reason - The reason for the redaction
+     */
+    async redact(eventId: string, reason?: string) {
+        const channelId = this.data.id
+        const result = await this.riverConnection.withStream(channelId).call((client, stream) => {
+            const event = stream.view.events.get(eventId)
+            if (!event) {
+                throw new Error(`ref event not found: ${eventId}`)
+            }
+            if (event.creatorUserId !== this.riverConnection.userId) {
+                throw new Error(
+                    `You can only redact your own messages. Message creator: ${event.creatorUserId} - Your id: ${this.riverConnection.userId}`,
+                )
+            }
+            return client.sendChannelMessage_Redaction(channelId, {
+                refEventId: eventId,
+                reason,
+            })
+        })
+        return result
+    }
+
+    /** Redacts any message as an admin.
+     * @param eventId - The event id of the message to redact
+     */
+    async adminRedact(eventId: string) {
         const channelId = this.data.id
         const result = await this.riverConnection
             .withStream(channelId)

--- a/packages/sdk/src/sync-agent/timeline/timeline.test.ts
+++ b/packages/sdk/src/sync-agent/timeline/timeline.test.ts
@@ -194,7 +194,7 @@ describe('timeline.test.ts', () => {
             expect(reaction?.['👍'][alice.userId].eventId).toEqual(reactionEventId)
         })
         // alice deletes the reaction
-        await aliceChannel.redactEvent(reactionEventId)
+        await aliceChannel.redact(reactionEventId)
         // wait for bob to no longer see the reaction
         await waitFor(() => {
             const reaction = bobChannel.timeline.reactions.get(messageEvent!.eventId)
@@ -268,7 +268,7 @@ describe('timeline.test.ts', () => {
                 ).toBeTruthy()
             })
             // alice deletes the first reply
-            await aliceChannel.redactEvent(firstReply.eventId)
+            await aliceChannel.redact(firstReply.eventId)
             // bob should no longer see the first reply
             await waitFor(() => {
                 const thread = bobChannel.timeline.threads.get(event.eventId)!


### PR DESCRIPTION
Example of admin redact will be add later - we need to have an example of what is an admin and how you can add someone as an admin (aka permissions - future priority)