### PR TITLE
Fix race condition in syncer_set startup

### DIFF
--- a/core/node/rpc/sync/client/syncer_set.go
+++ b/core/node/rpc/sync/client/syncer_set.go
@@ -2,10 +2,12 @@ package client
 
 import (
 	"context"
-	"github.com/river-build/river/core/node/dlog"
 	"sync"
 
+	"github.com/river-build/river/core/node/dlog"
+
 	"github.com/ethereum/go-ethereum/common"
+
 	. "github.com/river-build/river/core/node/base"
 	"github.com/river-build/river/core/node/events"
 	"github.com/river-build/river/core/node/nodes"
@@ -161,12 +163,6 @@ func NewSyncers(
 }
 
 func (ss *SyncerSet) Run() {
-	ss.muSyncers.Lock()
-	for _, syncer := range ss.syncers {
-		ss.startSyncer(syncer)
-	}
-	ss.muSyncers.Unlock()
-
 	<-ss.ctx.Done() // sync cancelled by client, client conn dropped or client send buffer full
 
 	ss.muSyncers.Lock()
@@ -177,7 +173,20 @@ func (ss *SyncerSet) Run() {
 	close(ss.messages)    // close will cause the sync operation to send the SYNC_CLOSE message to the client
 }
 
-func (ss *SyncerSet) AddStream(ctx context.Context, nodeAddress common.Address, streamID StreamId, cookie *SyncCookie) error {
+func (ss *SyncerSet) AddInitialStreams() {
+	ss.muSyncers.Lock()
+	for _, syncer := range ss.syncers {
+		ss.startSyncer(syncer)
+	}
+	ss.muSyncers.Unlock()
+}
+
+func (ss *SyncerSet) AddStream(
+	ctx context.Context,
+	nodeAddress common.Address,
+	streamID StreamId,
+	cookie *SyncCookie,
+) error {
 	ss.muSyncers.Lock()
 	defer ss.muSyncers.Unlock()
 

--- a/core/node/rpc/sync/operation.go
+++ b/core/node/rpc/sync/operation.go
@@ -103,6 +103,8 @@ func (syncOp *StreamSyncOperation) Run(
 		return err
 	}
 
+	syncers.AddInitialStreams()
+
 	go syncers.Run()
 
 	for {


### PR DESCRIPTION
seeing this in CI here: https://github.com/river-build/river/actions/runs/12148899395

A stream that is in the messages as add sync, but is not in the initial cookies will get subscribed to twice if these two calls race. Because addstream adds a new syncer to the sync map and initiates a sync - and then Run() loops over the sync map and initiates a sync… again


`go Run()`
and `select msg, ok` race…
Add stream starts a receiver for a specific stream
Then run starts all the receivers, leading to a double receive.

It fixes my issue locally, I had a 100% repro rate before.

```
==================
WARNING: DATA RACE
Write at 0x00c000d88318 by goroutine 9335:
connectrpc.com/connect.(*ServerStreamForClient[go.shape.a7910b12a1f7e21c2031c35e486da9da719560dc54d80219f7b879d3ee7e8afb]).Receive()
/Users/austinellis/go/pkg/mod/connectrpc.com/connect@v1.17.0/client_stream.go:119 +0xa4
github.com/river-build/river/core/node/rpc/sync/client.(*remoteSyncer).Run()
/Users/austinellis/hnt/river/core/node/rpc/sync/client/remote.go:107 +0x218
github.com/river-build/river/core/node/rpc/sync/client.(*SyncerSet).startSyncer.func1()
/Users/austinellis/hnt/river/core/node/rpc/sync/client/syncer_set.go:235 +0x44
Previous write at 0x00c000d88318 by goroutine 9330:
connectrpc.com/connect.(*ServerStreamForClient[go.shape.a7910b12a1f7e21c2031c35e486da9da719560dc54d80219f7b879d3ee7e8afb]).Receive()
/Users/austinellis/go/pkg/mod/connectrpc.com/connect@v1.17.0/client_stream.go:119 +0xa4
github.com/river-build/river/core/node/rpc/sync/client.(*remoteSyncer).Run()
/Users/austinellis/hnt/river/core/node/rpc/sync/client/remote.go:107 +0x218
github.com/river-build/river/core/node/rpc/sync/client.(*SyncerSet).startSyncer.func1()
/Users/austinellis/hnt/river/core/node/rpc/sync/client/syncer_set.go:235 +0x44
Goroutine 9335 (running) created at:
github.com/river-build/river/core/node/rpc/sync/client.(*SyncerSet).startSyncer()
/Users/austinellis/hnt/river/core/node/rpc/sync/client/syncer_set.go:234 +0xe0
github.com/river-build/river/core/node/rpc/sync/client.(*SyncerSet).Run()
/Users/austinellis/hnt/river/core/node/rpc/sync/client/syncer_set.go:166 +0xbc
github.com/river-build/river/core/node/rpc/sync.(*StreamSyncOperation).Run.gowrap1()
/Users/austinellis/hnt/river/core/node/rpc/sync/operation.go:106 +0x34
Goroutine 9330 (running) created at:
github.com/river-build/river/core/node/rpc/sync/client.(*SyncerSet).startSyncer()
/Users/austinellis/hnt/river/core/node/rpc/sync/client/syncer_set.go:234 +0xe0
github.com/river-build/river/core/node/rpc/sync/client.(*SyncerSet).AddStream()
/Users/austinellis/hnt/river/core/node/rpc/sync/client/syncer_set.go:226 +0x80c
github.com/river-build/river/core/node/rpc/sync.(*StreamSyncOperation).Run()
/Users/austinellis/hnt/river/core/node/rpc/sync/operation.go:141 +0x698
github.com/river-build/river/core/node/rpc/sync.(*handlerImpl).runSyncStreams()
/Users/austinellis/hnt/river/core/node/rpc/sync/handler.go:183 +0x25c
github.com/river-build/river/core/node/rpc/sync.(*handlerImpl).SyncStreams.gowrap3()
/Users/austinellis/hnt/river/core/node/rpc/sync/handler.go:125 +0x70
==================
WARNING: DATA RACE
Read at 0x00c0003e3300 by goroutine 9330:
connectrpc.com/connect.(*envelopeReader).Read()
/Users/austinellis/go/pkg/mod/connectrpc.com/connect@v1.17.0/envelope.go:314 +0xa4
connectrpc.com/connect.(*envelopeReader).Unmarshal()
/Users/austinellis/go/pkg/mod/connectrpc.com/connect@v1.17.0/envelope.go:243 +0x100
connectrpc.com/connect.(*grpcUnmarshaler).Unmarshal()
/Users/austinellis/go/pkg/mod/connectrpc.com/connect@v1.17.0/protocol_grpc.go:610 +0x48
connectrpc.com/connect.(*grpcClientConn).Receive()
/Users/austinellis/go/pkg/mod/connectrpc.com/connect@v1.17.0/protocol_grpc.go:372 +0xa0
connectrpc.com/connect.(*errorTranslatingClientConn).Receive()
/Users/austinellis/go/pkg/mod/connectrpc.com/connect@v1.17.0/protocol.go:210 +0x58
connectrpc.com/connect.(*ServerStreamForClient[go.shape.a7910b12a1f7e21c2031c35e486da9da719560dc54d80219f7b879d3ee7e8afb]).Receive()
/Users/austinellis/go/pkg/mod/connectrpc.com/connect@v1.17.0/client_stream.go:124 +0x2a4
github.com/river-build/river/core/node/rpc/sync/client.(*remoteSyncer).Run()
/Users/austinellis/hnt/river/core/node/rpc/sync/client/remote.go:107 +0x218
github.com/river-build/river/core/node/rpc/sync/client.(*SyncerSet).startSyncer.func1()
/Users/austinellis/hnt/river/core/node/rpc/sync/client/syncer_set.go:235 +0x44
Previous write at 0x00c0003e3300 by goroutine 9335:
connectrpc.com/connect.(*envelopeReader).Read()
/Users/austinellis/go/pkg/mod/connectrpc.com/connect@v1.17.0/envelope.go:314 +0xb8
connectrpc.com/connect.(*envelopeReader).Unmarshal()
/Users/austinellis/go/pkg/mod/connectrpc.com/connect@v1.17.0/envelope.go:243 +0x100
connectrpc.com/connect.(*grpcUnmarshaler).Unmarshal()
/Users/austinellis/go/pkg/mod/connectrpc.com/connect@v1.17.0/protocol_grpc.go:610 +0x48
connectrpc.com/connect.(*grpcClientConn).Receive()
/Users/austinellis/go/pkg/mod/connectrpc.com/connect@v1.17.0/protocol_grpc.go:372 +0xa0
connectrpc.com/connect.(*errorTranslatingClientConn).Receive()
/Users/austinellis/go/pkg/mod/connectrpc.com/connect@v1.17.0/protocol.go:210 +0x58
connectrpc.com/connect.(*ServerStreamForClient[go.shape.a7910b12a1f7e21c2031c35e486da9da719560dc54d80219f7b879d3ee7e8afb]).Receive()
/Users/austinellis/go/pkg/mod/connectrpc.com/connect@v1.17.0/client_stream.go:124 +0x2a4
github.com/river-build/river/core/node/rpc/sync/client.(*remoteSyncer).Run()
/Users/austinellis/hnt/river/core/node/rpc/sync/client/remote.go:107 +0x218
github.com/river-build/river/core/node/rpc/sync/client.(*SyncerSet).startSyncer.func1()
/Users/austinellis/hnt/river/core/node/rpc/sync/client/syncer_set.go:235 +0x44
Goroutine 9330 (running) created at:
github.com/river-build/river/core/node/rpc/sync/client.(*SyncerSet).startSyncer()
/Users/austinellis/hnt/river/core/node/rpc/sync/client/syncer_set.go:234 +0xe0
github.com/river-build/river/core/node/rpc/sync/client.(*SyncerSet).AddStream()
/Users/austinellis/hnt/river/core/node/rpc/sync/client/syncer_set.go:226 +0x80c
github.com/river-build/river/core/node/rpc/sync.(*StreamSyncOperation).Run()
/Users/austinellis/hnt/river/core/node/rpc/sync/operation.go:141 +0x698
github.com/river-build/river/core/node/rpc/sync.(*handlerImpl).runSyncStreams()
/Users/austinellis/hnt/river/core/node/rpc/sync/handler.go:183 +0x25c
github.com/river-build/river/core/node/rpc/sync.(*handlerImpl).SyncStreams.gowrap3()
/Users/austinellis/hnt/river/core/node/rpc/sync/handler.go:125 +0x70
Goroutine 9335 (running) created at:
github.com/river-build/river/core/node/rpc/sync/client.(*SyncerSet).startSyncer()
/Users/austinellis/hnt/river/core/node/rpc/sync/client/syncer_set.go:234 +0xe0
github.com/river-build/river/core/node/rpc/sync/client.(*SyncerSet).Run()
/Users/austinellis/hnt/river/core/node/rpc/sync/client/syncer_set.go:166 +0xbc
github.com/river-build/river/core/node/rpc/sync.(*StreamSyncOperation).Run.gowrap1()
/Users/austinellis/hnt/river/core/node/rpc/sync/operation.go:106 +0x34
```
