### PR TITLE
don't send push notifications for edits/redactions

### DIFF
--- a/core/node/notifications/event_processor.go
+++ b/core/node/notifications/event_processor.go
@@ -78,15 +78,8 @@ func (p *MessageToNotificationsProcessor) OnMessageEvent(
 	}
 	l.Debug("Process event")
 
-	usersToNotify := make(map[common.Address]*types.UserPreferences)
 	kind := "new_message"
-	recipients := mapset.NewSet[common.Address]()
-	sender := common.BytesToAddress(event.Event.CreatorAddress)
 	tags := event.Event.GetTags()
-
-	if slices.Contains(tags.GetGroupMentionTypes(), GroupMentionType_GROUP_MENTION_TYPE_AT_CHANNEL) {
-		kind = "@channel"
-	}
 
 	switch tags.GetMessageInteractionType() {
 	case MessageInteractionType_MESSAGE_INTERACTION_TYPE_REPLY:
@@ -101,6 +94,14 @@ func (p *MessageToNotificationsProcessor) OnMessageEvent(
 		return
 	case MessageInteractionType_MESSAGE_INTERACTION_TYPE_REDACTION:
 		return
+	}
+
+	usersToNotify := make(map[common.Address]*types.UserPreferences)
+	recipients := mapset.NewSet[common.Address]()
+	sender := common.BytesToAddress(event.Event.CreatorAddress)
+
+	if slices.Contains(tags.GetGroupMentionTypes(), GroupMentionType_GROUP_MENTION_TYPE_AT_CHANNEL) {
+		kind = "@channel"
 	}
 
 	members.Each(func(member string) bool {


### PR DESCRIPTION
This PR stops the notification service from sending push notifications for edits and redactions.