### PR TITLE
[BUGFIX] - Contract names fix for parameterless calls with ethCall metrics

### DIFF
--- a/core/node/crypto/client.go
+++ b/core/node/crypto/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
-	"runtime"
 	"strings"
 
 	"github.com/ethereum/go-ethereum"
@@ -21,7 +20,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/river-build/river/core/node/dlog"
 	"github.com/river-build/river/core/node/infra"
 )
 
@@ -221,15 +219,6 @@ func (ic *otelEthClient) makeEthCallWithTraceAndMetrics(
 	// If tracer was nil, we may not have computed the method name.
 	if methodName == "" {
 		methodName = getMethodName(msg.Data)
-	}
-
-	if methodName == "" {
-		log := dlog.FromCtx(ctx)
-		log.Info("Empty method name", "data", msg.Data)
-
-		buf := make([]byte, 1024)
-		n := runtime.Stack(buf, false)
-		fmt.Printf("Call stack:\n%s\n", buf[:n])
 	}
 
 	ic.ethCalls.With(

--- a/core/node/crypto/contract_names.go
+++ b/core/node/crypto/contract_names.go
@@ -11,6 +11,7 @@ import (
 	"github.com/river-build/river/core/xchain/bindings/erc1155"
 	"github.com/river-build/river/core/xchain/bindings/erc20"
 	"github.com/river-build/river/core/xchain/bindings/erc721"
+	"github.com/river-build/river/core/xchain/bindings/ierc5313"
 )
 
 // ContractNameMap maps selectors found in contract ABI code to the contract's method name.
@@ -87,6 +88,8 @@ func init() {
 	nameMap.RegisterABI("RuleEntitlementV2", abi)
 	abi, _ = base.WalletLinkMetaData.GetAbi()
 	nameMap.RegisterABI("WalletLink", abi)
+	abi, _ = ierc5313.Ierc5313MetaData.GetAbi()
+	nameMap.RegisterABI("Ierc5313", abi)
 
 	// Entitlement-related. These may also occur on other chains.
 	abi, _ = erc721.Erc721MetaData.GetAbi()


### PR DESCRIPTION
- fixed msg.Data length check to capture calls with no parameter data
- register ierc5313 contract selectors for space ownership checks