### PR TITLE
Reduce histogram buckets and tune bucket range and intervals

### DIFF
--- a/core/node/crypto/chain_txpool.go
+++ b/core/node/crypto/chain_txpool.go
@@ -165,8 +165,8 @@ func newPendingTransactionPool(
 		"chain_id", "address", "status",
 	)
 
-	// 2, 6, 10, 14, 18s
-	txPoolHistogramBuckets := prometheus.LinearBuckets(2.0, 4.0, 5)
+	// 1, 3, 5, 7, 9s
+	txPoolHistogramBuckets := prometheus.LinearBuckets(1.0, 2.0, 5)
 	transactionTotalInclusionDuration := metrics.NewHistogramVecEx(
 		"txpool_tx_total_inclusion_duration_sec",
 		"How long it takes before a transaction is included in the chain since first submit",

--- a/core/node/crypto/chain_txpool.go
+++ b/core/node/crypto/chain_txpool.go
@@ -164,15 +164,18 @@ func newPendingTransactionPool(
 		"txpool_processed", "Number of submitted transactions that are included in the chain",
 		"chain_id", "address", "status",
 	)
+
+	// 2, 6, 10, 14, 18s
+	txPoolHistogramBuckets := prometheus.LinearBuckets(2.0, 4.0, 5)
 	transactionTotalInclusionDuration := metrics.NewHistogramVecEx(
 		"txpool_tx_total_inclusion_duration_sec",
 		"How long it takes before a transaction is included in the chain since first submit",
-		prometheus.LinearBuckets(1.0, 2.0, 10), "chain_id", "address",
+		txPoolHistogramBuckets, "chain_id", "address",
 	)
 	transactionInclusionDuration := metrics.NewHistogramVecEx(
 		"txpool_tx_inclusion_duration_sec",
 		"How long it takes before a transaction is included in the chain since last submit",
-		prometheus.LinearBuckets(1.0, 2.0, 10), "chain_id", "address",
+		txPoolHistogramBuckets, "chain_id", "address",
 	)
 	transactionReceiptsMissingCounter := metrics.NewCounterVecEx(
 		"txpool_missing_tx_receipts", "Number of receipts missing for submitted transactions",

--- a/core/node/infra/metrics_publisher.go
+++ b/core/node/infra/metrics_publisher.go
@@ -14,6 +14,7 @@ import (
 )
 
 // In practice, most rpc calls seem to land between 10 and 50ms, sometimes up to 100ms.
+// Entitlement calls can sometimes take up to 2s.
 var DefaultRpcDurationBucketsSeconds = []float64{
 	0.01,
 	0.05,
@@ -23,6 +24,7 @@ var DefaultRpcDurationBucketsSeconds = []float64{
 	5.0,
 }
 
+// Most db operations appear to complete in <= 60ms in practice.
 var DefaultDbTxDurationBucketsSeconds = []float64{
 	.001,
 	.003,

--- a/core/node/infra/metrics_publisher.go
+++ b/core/node/infra/metrics_publisher.go
@@ -13,6 +13,7 @@ import (
 	"github.com/river-build/river/core/node/dlog"
 )
 
+// In practice, most rpc calls seem to land between 10 and 50ms, sometimes up to 100ms.
 var DefaultRpcDurationBucketsSeconds = []float64{
 	0.01,
 	0.05,
@@ -20,7 +21,6 @@ var DefaultRpcDurationBucketsSeconds = []float64{
 	0.5,
 	1.0,
 	5.0,
-	10,
 }
 
 var DefaultDbTxDurationBucketsSeconds = []float64{

--- a/core/node/infra/metrics_publisher.go
+++ b/core/node/infra/metrics_publisher.go
@@ -13,23 +13,24 @@ import (
 	"github.com/river-build/river/core/node/dlog"
 )
 
-var DefaultDurationBucketsSeconds = []float64{
-	0.001,
-	0.002,
-	0.005,
+var DefaultRpcDurationBucketsSeconds = []float64{
 	0.01,
-	0.02,
-	0.03,
-	0.06,
-	0.12,
-	0.3,
-	0.6,
-	1.2,
-	1.8,
-	2.8,
-	3.6,
-	4.8,
+	0.05,
+	0.1,
+	0.5,
+	1.0,
+	5.0,
 	10,
+}
+
+var DefaultDbTxDurationBucketsSeconds = []float64{
+	.001,
+	.003,
+	.005,
+	.01,
+	.05,
+	.1,
+	1,
 }
 
 // MetricsPublisher both provides handler to publish metrics from the given registry

--- a/core/node/rpc/metrics_interceptor.go
+++ b/core/node/rpc/metrics_interceptor.go
@@ -33,7 +33,7 @@ func (s *Service) NewMetricsInterceptor() connect.Interceptor {
 		rpcDuration: s.metrics.NewHistogramVecEx(
 			"rpc_duration_seconds",
 			"RPC duration in seconds",
-			infra.DefaultDurationBucketsSeconds,
+			infra.DefaultRpcDurationBucketsSeconds,
 			"method",
 		),
 		unaryInflight: s.metrics.NewGaugeVecEx("grpc_unary_inflight", "gRPC unary calls in flight", "method"),

--- a/core/node/storage/pg_storage.go
+++ b/core/node/storage/pg_storage.go
@@ -516,7 +516,7 @@ func (s *PostgresEventStore) init(
 	s.txDuration = metrics.NewHistogramVecEx(
 		"dbtx_duration_seconds",
 		"PG transaction duration",
-		infra.DefaultDurationBucketsSeconds,
+		infra.DefaultDbTxDurationBucketsSeconds,
 		"name",
 	)
 

--- a/core/xchain/entitlement/evaluator.go
+++ b/core/xchain/entitlement/evaluator.go
@@ -47,7 +47,7 @@ func NewEvaluatorFromConfigWithBlockchainInfo(
 		evalHistrogram: metrics.NewHistogramVecEx(
 			"entitlement_op_duration_seconds",
 			"Duration of entitlement evaluation",
-			infra.DefaultDurationBucketsSeconds,
+			infra.DefaultRpcDurationBucketsSeconds,
 			"operation",
 		),
 		ethChainIds: config.GetEtherBasedBlockchains(

--- a/core/xchain/server/server.go
+++ b/core/xchain/server/server.go
@@ -237,7 +237,7 @@ func New(
 		callDurations: metrics.NewHistogramVecEx(
 			"call_duration_seconds",
 			"Durations of contract calls",
-			infra.DefaultDurationBucketsSeconds,
+			infra.DefaultRpcDurationBucketsSeconds,
 			"op",
 		),
 	}


### PR DESCRIPTION
I partnered with @mechanical-turk to discuss our highest cardinality metrics and to shave down cost while maintaining observability where possible. Here is a proposal to reduce the granularity of buckets for several histogram metrics.