### PR TITLE
for GetMiniblocks there should be on-chain setting limiting number of blocks fetchable at once

### DIFF
--- a/core/env/local/multi_ne/on_chain.csv
+++ b/core/env/local/multi_ne/on_chain.csv
@@ -13,3 +13,4 @@
 "stream.cacheExpirationMs",0,300000
 "stream.cacheExpirationPollIntervalMs",0,30000
 "xchain.blockchains",0,"31337,31338,84532,11155111"
+"stream.miniblocksListLimit",0,100

--- a/core/justfile
+++ b/core/justfile
@@ -302,7 +302,7 @@ _run-node $INSTANCE_NUM $INSTANCE_DIR:
         --config ../contracts.env \
         --config ../config.yaml \
         --config config/config.env \
-        ${RUN_ARGS} --log_level debug \
+        ${RUN_ARGS} \
         > ./logs/tty.stdout.log 2> ./logs/tty.stderr.log &
 
 _stop-node $INSTANCE_NUM $INSTANCE_DIR:

--- a/core/justfile
+++ b/core/justfile
@@ -302,7 +302,7 @@ _run-node $INSTANCE_NUM $INSTANCE_DIR:
         --config ../contracts.env \
         --config ../config.yaml \
         --config config/config.env \
-        ${RUN_ARGS} \
+        ${RUN_ARGS} --log_level debug \
         > ./logs/tty.stdout.log 2> ./logs/tty.stderr.log &
 
 _stop-node $INSTANCE_NUM $INSTANCE_DIR:

--- a/core/node/crypto/config.go
+++ b/core/node/crypto/config.go
@@ -95,6 +95,8 @@ type OnChainSettings struct {
 	StreamCacheExpiration    time.Duration `mapstructure:"stream.cacheExpirationMs"`
 	StreamCachePollIntterval time.Duration `mapstructure:"stream.cacheExpirationPollIntervalMs"`
 
+	MbsListLimit uint64 `mapstructure:"stream.miniblocksListLimit"`
+
 	MembershipLimits MembershipLimitsSettings `mapstructure:",squash"`
 
 	XChain XChainSettings `mapstructure:",squash"`
@@ -163,6 +165,8 @@ func DefaultOnChainSettings() *OnChainSettings {
 
 		StreamCacheExpiration:    5 * time.Minute,
 		StreamCachePollIntterval: 30 * time.Second,
+
+		MbsListLimit: 100,
 
 		MembershipLimits: MembershipLimitsSettings{
 			GDM: 48,

--- a/core/node/rpc/forwarder.go
+++ b/core/node/rpc/forwarder.go
@@ -340,6 +340,14 @@ func (s *Service) getMiniblocksImpl(
 	ctx context.Context,
 	req *connect.Request[GetMiniblocksRequest],
 ) (*connect.Response[GetMiniblocksResponse], error) {
+	count := uint64(req.Msg.ToExclusive - req.Msg.FromInclusive)
+	if limit := s.chainConfig.Get().MbsListLimit; limit > 0 && count > limit {
+		return nil, RiverError(Err_INVALID_ARGUMENT, "Requested miniblock count exceeds limit").
+			Func("getMiniblocksImpl").
+			Tag("count", count).
+			Tag("limit", limit)
+	}
+
 	streamId, err := shared.StreamIdFromBytes(req.Msg.StreamId)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
https://github.com/river-build/river/issues/518