### PR TITLE
chore: add `BASE_RPC_URL` environment variable to unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,8 @@ jobs:
             - name: Unit Tests
               if: ${{ !cancelled() && steps.setup_success.outcome == 'success' && steps.ts_build.outcome == 'success' }}
               run: yarn test:unit
+              env:
+                  BASE_RPC_URL: ${{ secrets.BASE_RPC_URL }}
     Multinode:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_multinode


### PR DESCRIPTION
This update ensures that the BASE_RPC_URL secret is available during the execution of unit tests in the CI workflow. Including this environment variable is necessary for tests that depend on a specific RPC endpoint configuration.