### PR TITLE
fix(contract): refactor rewards claiming logic for mainnet delegation

### DIFF
--- a/contracts/src/base/registry/facets/distribution/v2/IRewardsDistribution.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/IRewardsDistribution.sol
@@ -249,8 +249,9 @@ interface IRewardsDistribution is IRewardsDistributionBase {
   function withdraw(uint256 depositId) external returns (uint96 amount);
 
   /// @notice Claims the reward for a beneficiary
-  /// @dev The beneficiary may be the caller. If not, the beneficiary must be a space or operator
-  /// while the caller must be the authorized claimer.
+  /// @dev The beneficiary may be the caller.
+  /// @dev If not, the caller may be the authorized claimer of the beneficiary.
+  /// @dev If not, the beneficiary must be a space or operator while the caller must be the authorized claimer.
   /// @param beneficiary The address of the beneficiary
   /// @param recipient The address of the recipient
   /// @return reward The amount of rewardToken that is claimed

--- a/contracts/src/base/registry/facets/distribution/v2/RewardsDistributionBase.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/RewardsDistributionBase.sol
@@ -207,7 +207,7 @@ abstract contract RewardsDistributionBase is IRewardsDistributionBase {
   }
 
   /// @dev Checks if the caller is the claimer of the operator
-  function _revertIfNotClaimer(address operator) internal view {
+  function _revertIfNotOperatorClaimer(address operator) internal view {
     NodeOperatorStorage.Layout storage nos = NodeOperatorStorage.layout();
     address claimer = nos.claimerByOperator[operator];
     if (msg.sender != claimer) {

--- a/contracts/src/tokens/river/base/delegation/IMainnetDelegation.sol
+++ b/contracts/src/tokens/river/base/delegation/IMainnetDelegation.sol
@@ -24,6 +24,7 @@ interface IMainnetDelegationBase {
   // =============================================================
   //                           Events
   // =============================================================
+
   event DelegationSet(
     address indexed delegator,
     address indexed operator,
@@ -32,9 +33,12 @@ interface IMainnetDelegationBase {
 
   event DelegationRemoved(address indexed delegator);
 
+  event ClaimerSet(address indexed delegator, address indexed claimer);
+
   // =============================================================
   //                           Errors
   // =============================================================
+
   error InvalidDelegator(address delegator);
   error InvalidOperator(address operator);
   error InvalidQuantity(uint256 quantity);

--- a/contracts/src/tokens/river/base/delegation/MainnetDelegationBase.sol
+++ b/contracts/src/tokens/river/base/delegation/MainnetDelegationBase.sol
@@ -199,6 +199,8 @@ abstract contract MainnetDelegationBase is IMainnetDelegationBase {
       if (claimer != address(0)) {
         ds.delegatorsByAuthorizedClaimer[claimer].add(delegator);
       }
+
+      emit ClaimerSet(delegator, claimer);
     }
   }
 

--- a/contracts/test/base/registry/RewardsDistributionV2.t.sol
+++ b/contracts/test/base/registry/RewardsDistributionV2.t.sol
@@ -604,7 +604,7 @@ contract RewardsDistributionV2Test is
     vm.prank(depositors[0]);
     rewardsDistributionFacet.initiateWithdraw(depositId0);
 
-    vm.warp(block.timestamp + timeLapse);
+    skip(timeLapse);
 
     // poke the second depositor
     vm.prank(depositors[1]);
@@ -701,7 +701,7 @@ contract RewardsDistributionV2Test is
       beneficiary
     );
 
-    vm.warp(block.timestamp + timeLapse);
+    skip(timeLapse);
 
     vm.expectEmit(address(rewardsDistributionFacet));
     emit InitiateWithdraw(address(this), depositId, amount);
@@ -913,7 +913,7 @@ contract RewardsDistributionV2Test is
     test_stake();
     test_fuzz_stake(depositor, amount, operator, commissionRate, beneficiary);
 
-    vm.warp(block.timestamp + timeLapse);
+    skip(timeLapse);
 
     uint256 currentReward = rewardsDistributionFacet.currentReward(beneficiary);
 
@@ -956,7 +956,7 @@ contract RewardsDistributionV2Test is
       vm.stopPrank();
     }
 
-    vm.warp(block.timestamp + timeLapse);
+    skip(timeLapse);
 
     uint256 currentReward = rewardsDistributionFacet.currentReward(beneficiary);
 
@@ -994,7 +994,7 @@ contract RewardsDistributionV2Test is
       address(this)
     );
 
-    vm.warp(block.timestamp + timeLapse);
+    skip(timeLapse);
 
     uint256 currentReward = rewardsDistributionFacet.currentReward(operator);
 
@@ -1029,7 +1029,7 @@ contract RewardsDistributionV2Test is
       address(this)
     );
 
-    vm.warp(block.timestamp + timeLapse);
+    skip(timeLapse);
 
     uint256 currentReward = rewardsDistributionFacet.currentReward(space);
 


### PR DESCRIPTION
Updated the rewards claiming logic to improve clarity and include mainnet delegation via `MainnetDelegationBase`. Adjustments were made to distinguish between authorized claimers for operators and beneficiaries, enhancing the contract's maintainability and security.