### PR TITLE
Notifications service, remove channel setting when updating to unspecified

### DIFF
--- a/core/node/notifications/types/preferences.go
+++ b/core/node/notifications/types/preferences.go
@@ -283,7 +283,9 @@ func (up *UserPreferences) WantNotificationForSpaceChannelMessage(
 
 		// if there is a channel specific setting use that
 		if chanSetting, found := spacePreferences.Channels[channel]; found {
-			setting = chanSetting
+			if chanSetting != SpaceChannelSettingValue_SPACE_CHANNEL_SETTING_UNSPECIFIED {
+				setting = chanSetting
+			}
 		}
 	}
 

--- a/core/node/rpc/notification_test.go
+++ b/core/node/rpc/notification_test.go
@@ -17,6 +17,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	eth_crypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/google/go-cmp/cmp"
+	payload2 "github.com/sideshow/apns2/payload"
+	"github.com/stretchr/testify/require"
+
 	"github.com/river-build/river/core/node/crypto"
 	"github.com/river-build/river/core/node/events"
 	"github.com/river-build/river/core/node/notifications/push"
@@ -26,8 +29,6 @@ import (
 	. "github.com/river-build/river/core/node/shared"
 	"github.com/river-build/river/core/node/testutils"
 	"github.com/river-build/river/core/node/testutils/testcert"
-	payload2 "github.com/sideshow/apns2/payload"
-	"github.com/stretchr/testify/require"
 )
 
 // TestNotifications is designed in such a way that all tests are run in parallel
@@ -1587,5 +1588,9 @@ func spaceChannelSettings(
 	settings = settingsResp.Msg
 
 	space = settings.GetSpace()[0]
+	// channel2 should have been removed, only channel1 should be left
 	test.req.Equal(1, len(space.Channels))
+	// channel1 is the one that was set to messages all, make sure it's still there
+	test.req.Equal(space.Channels[0].ChannelId, channel1.ChannelId)
+	test.req.Equal(space.Channels[0].Value, SpaceChannelSettingValue_SPACE_CHANNEL_SETTING_MESSAGES_ALL)
 }

--- a/core/node/rpc/notification_test.go
+++ b/core/node/rpc/notification_test.go
@@ -1564,4 +1564,28 @@ func spaceChannelSettings(
 
 	test.req.Equal(request3.Msg.ChannelId, channel2.ChannelId)
 	test.req.Equal(request3.Msg.Value, channel2.Value)
+
+	request5 := connect.NewRequest(&SetSpaceChannelSettingsRequest{
+		ChannelId: channel2ID[:],
+		SpaceId:   test.spaceID[:],
+		Value:     SpaceChannelSettingValue_SPACE_CHANNEL_SETTING_UNSPECIFIED,
+	})
+	authorize(ctx, test.req, test.authClient, user, request5)
+
+	_, err = test.notificationClient.SetSpaceChannelSettings(ctx, request5)
+	test.req.NoError(err, "SetSpaceChannelSettings failed")
+
+	authorize(ctx, test.req, test.authClient, user, request4)
+
+	_, err = test.notificationClient.SetSpaceSettings(ctx, request4)
+	test.req.NoError(err, "SetSpaceSettings failed")
+
+	// ensure that the settings are correct applied
+	settingsResp, err = test.notificationClient.GetSettings(ctx, request1)
+	test.req.NoError(err, "GetSettings failed")
+
+	settings = settingsResp.Msg
+
+	space = settings.GetSpace()[0]
+	test.req.Equal(1, len(space.Channels))
 }

--- a/core/node/storage/pg_notification_store.go
+++ b/core/node/storage/pg_notification_store.go
@@ -343,6 +343,9 @@ func (s *PostgresNotificationStore) SetChannelSetting(
 	channelID shared.StreamId,
 	value SpaceChannelSettingValue,
 ) error {
+	if value == SpaceChannelSettingValue_SPACE_CHANNEL_SETTING_UNSPECIFIED {
+		return s.RemoveChannelSetting(ctx, userID, channelID)
+	}
 	return s.txRunner(
 		ctx,
 		"SetChannelSetting",
@@ -384,7 +387,7 @@ func (s *PostgresNotificationStore) RemoveChannelSetting(
 		"RemoveChannelSetting",
 		pgx.ReadWrite,
 		func(ctx context.Context, tx pgx.Tx) error {
-			return s.removeChannelSetting(ctx, tx, userID, channelID)
+			return s.removeChannelSettingTx(ctx, tx, userID, channelID)
 		},
 		nil,
 		"userID", userID,
@@ -392,7 +395,7 @@ func (s *PostgresNotificationStore) RemoveChannelSetting(
 	)
 }
 
-func (s *PostgresNotificationStore) removeChannelSetting(
+func (s *PostgresNotificationStore) removeChannelSettingTx(
 	ctx context.Context,
 	tx pgx.Tx,
 	userID common.Address,


### PR DESCRIPTION
I don’t have a good api to “unset” a channel setting.
The RemoveChannelSetting seems unused, wired it up to fire when i post unspecified for a channel.
Does this seem okay? Alternatively I could just keep the change in preferences.go that ignroes the unspecified channel setting.