### PR TITLE
Update publish-to-npm script to include all addresses from the deployments directlry

### DIFF
--- a/scripts/publish-to-npm.sh
+++ b/scripts/publish-to-npm.sh
@@ -45,6 +45,7 @@ if [ $exit_status_yarn -ne 0 ]; then
     exit 1
 fi
 
+# generate docs
 yarn workspace @river-build/react-sdk gen
 exit_status_docgen=$?
 
@@ -56,6 +57,14 @@ fi
 git add packages/docs/
 git commit -m "docs for version ${VERSION_PREFIX}"
 
+# copy contracts
+rm -rf packages/generated/deployments
+cp -r contracts/deployments packages/generated/deployments
+
+git add packages/generated/deployments
+git commit -m "contract addresses for ${VERSION_PREFIX}"
+
+#push
 git push -u origin "${BRANCH_NAME}"
 
 # Get the new patch version from Lerna and tag it


### PR DESCRIPTION
The client uses the diamond addresses which never change, but sometimes (like for rewards distribution) we need the addresses in the sdk. This keeps these folders in sync daily without needing to worry about it.