### PR TITLE
Boot stream node from local persistent stream storage

### DIFF
--- a/core/node/events/stream_sync_task.go
+++ b/core/node/events/stream_sync_task.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gammazero/workerpool"
-
 	. "github.com/river-build/river/core/node/base"
 	"github.com/river-build/river/core/node/dlog"
 	. "github.com/river-build/river/core/node/protocol"

--- a/core/node/storage/migrations/000007_create_streams_metadata_table.down.sql
+++ b/core/node/storage/migrations/000007_create_streams_metadata_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS streams_metadata;

--- a/core/node/storage/migrations/000007_create_streams_metadata_table.up.sql
+++ b/core/node/storage/migrations/000007_create_streams_metadata_table.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS streams_metadata (
+    stream_id CHAR(64) NOT NULL,
+    riverblock_num BIGINT NOT NULL,
+    riverblock_log_index BIGINT NOT NULL,
+    nodes CHAR(20)[] NOT NULL,
+    miniblock_hash CHAR(64) NOT NULL,
+    miniblock_num BIGINT NOT NULL,
+    is_sealed BOOL NOT NULL,
+    PRIMARY KEY (stream_id)
+);


### PR DESCRIPTION
As part of the stream node boot cycli it reads streams from the streams registry and initialises its internal stream cache. Nodes read all streams and filters out streams it is not participating in before loading them into the stream cache. In test environments nodes are able to load ~15K streams/s.

At the moment omega has 1534869 streams. Under the assumption that performance is similar it takes over 100s just to load the streams. When the number of streams increase the time to retrieve will increase proportionally. With the number of nodes increasing the percentage of streams a node is participating in will decrease causing the node to ignore relatively more and more streams wasting resources.

This PR uses a different approach and tracks stream data from the streams registry into its local database. On boot it fetches the streams from the database and applies changes. Fetching changes can be done by retrieving logs and is more efficient than fetching all streams. This reduces boot time and scales better over time when the number of streams and nodes increases.

