### PR TITLE
Change forEachEvent functions to be consistant

### DIFF
--- a/core/node/events/miniblock.go
+++ b/core/node/events/miniblock.go
@@ -138,22 +138,22 @@ func (b *MiniblockInfo) asStorageMbWithData(bytes []byte) *storage.WriteMinibloc
 	}
 }
 
-func (b *MiniblockInfo) forEachEvent(op func(e *ParsedEvent, minibockNum int64, eventNum int64) (bool, error)) error {
+func (b *MiniblockInfo) forEachEvent(op func(e *ParsedEvent, minibockNum int64, eventNum int64) (bool, error)) (bool, error) {
 	blockNum := b.Header().MiniblockNum
 	eventNum := b.Header().EventNumOffset
 	for _, event := range b.events() {
 		c, err := op(event, blockNum, eventNum)
 		eventNum++
-		if !c {
-			return err
+		if err != nil || !c {
+			return false, err
 		}
 	}
 
 	c, err := op(b.headerEvent, blockNum, eventNum)
-	if !c {
-		return err
+	if err != nil || !c {
+		return false, err
 	}
-	return nil
+	return true, nil
 }
 
 func NewMiniblockInfoFromBytes(bytes []byte, expectedBlockNumber int64) (*MiniblockInfo, error) {

--- a/core/node/events/minipool.go
+++ b/core/node/events/minipool.go
@@ -41,7 +41,7 @@ func (m *minipoolInstance) forEachEvent(
 	for _, e := range m.events.Values {
 		cont, err := op(e, m.generation, eventNum)
 		eventNum++
-		if !cont {
+		if err != nil || !cont {
 			return err
 		}
 	}

--- a/core/node/events/stream_view.go
+++ b/core/node/events/stream_view.go
@@ -495,8 +495,8 @@ func (r *streamViewImpl) forEachEvent(
 	}
 
 	for i := startBlock; i < len(r.blocks); i++ {
-		err := r.blocks[i].forEachEvent(op)
-		if err != nil {
+		cont, err := r.blocks[i].forEachEvent(op)
+		if err != nil || !cont {
 			return err
 		}
 	}


### PR DESCRIPTION
I have a new case where I’d like to return early from a forEachEvent function.

I returned `false, nil` from my inner lambda, and that exited the current iteration, but then just skipped to the next miniblock.

This was not the behavior that I was expecting.

Update all loops to have the same behavior, returning error or continue=false will exit the iteration.