### PR TITLE
Add mls-rs-wasm as dependency and fix WASM packaging

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -65,6 +65,7 @@
         "vite": "^5.3.1",
         "vite-plugin-checker": "^0.8.0",
         "vite-plugin-replace": "^0.1.1",
+        "vite-plugin-wasm": "^3.3.0",
         "vite-tsconfig-paths": "^5.1.3"
     }
 }

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -4,6 +4,7 @@ import { default as checker } from 'vite-plugin-checker'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import { replaceCodePlugin } from 'vite-plugin-replace'
 import tsconfigPaths from 'vite-tsconfig-paths'
+import wasm from 'vite-plugin-wasm'
 import path from 'path'
 
 // https://vitejs.dev/config/
@@ -19,6 +20,7 @@ export default ({ mode }: { mode: string }) => {
             exclude: ['@connectrpc/connect-node'],
         },
         plugins: [
+            wasm(),
             tsconfigPaths(),
             replaceCodePlugin({
                 replacements: [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -29,6 +29,7 @@
         "@ethereumjs/util": "^8.0.1",
         "@river-build/dlog": "workspace:^",
         "@river-build/encryption": "workspace:^",
+        "@river-build/mls-rs-wasm": "^0.0.4",
         "@river-build/proto": "workspace:^",
         "@river-build/web3": "workspace:^",
         "browser-or-node": "^3.0.0",

--- a/packages/stress/esbuild.config.mjs
+++ b/packages/stress/esbuild.config.mjs
@@ -3,10 +3,10 @@ import esbuildPluginPino from "esbuild-plugin-pino";
 
 build({
   entryPoints: {
-      'start': './src/start.ts',
-      'demo': './src/demo.ts',
-      // NOTE: For some reason esbuild is not picking it up
-      'mls_rs_wasm_bg': '@river-build/mls-rs-wasm-node/mls_rs_wasm_bg.wasm'
+    start: "./src/start.ts",
+    demo: "./src/demo.ts",
+    // NOTE: For some reason esbuild is not picking it up
+    mls_rs_wasm_bg: "@river-build/mls-rs-wasm-node/mls_rs_wasm_bg.wasm",
   },
   bundle: true,
   sourcemap: "inline",
@@ -17,7 +17,7 @@ build({
   outExtension: { ".js": ".cjs" },
   plugins: [esbuildPluginPino({ transports: ["pino-pretty"] })],
   alias: {
-      '@river-build/mls-rs-wasm': '@river-build/mls-rs-wasm-node'
+    "@river-build/mls-rs-wasm": "@river-build/mls-rs-wasm-node",
   },
   ignoreAnnotations: true,
   assetNames: "[name]",

--- a/packages/stress/esbuild.config.mjs
+++ b/packages/stress/esbuild.config.mjs
@@ -1,9 +1,13 @@
 import { build } from "esbuild";
-import { wasmLoader } from "esbuild-plugin-wasm";
 import esbuildPluginPino from "esbuild-plugin-pino";
 
 build({
-  entryPoints: ["./src/start.ts", "./src/demo.ts"],
+  entryPoints: {
+      'start': './src/start.ts',
+      'demo': './src/demo.ts',
+      // NOTE: For some reason esbuild is not picking it up
+      'mls_rs_wasm_bg': '@river-build/mls-rs-wasm-node/mls_rs_wasm_bg.wasm'
+  },
   bundle: true,
   sourcemap: "inline",
   platform: "node",
@@ -11,8 +15,10 @@ build({
   format: "cjs",
   outdir: "dist",
   outExtension: { ".js": ".cjs" },
-  plugins: [wasmLoader(), esbuildPluginPino({ transports: ["pino-pretty"] })],
-
+  plugins: [esbuildPluginPino({ transports: ["pino-pretty"] })],
+  alias: {
+      '@river-build/mls-rs-wasm': '@river-build/mls-rs-wasm-node'
+  },
   ignoreAnnotations: true,
   assetNames: "[name]",
   loader: {

--- a/packages/stress/package.json
+++ b/packages/stress/package.json
@@ -29,13 +29,13 @@
         "pino-pretty": "^10.2.3"
     },
     "devDependencies": {
+        "@river-build/mls-rs-wasm-node": "^0.0.4",
         "@types/debug": "^4.1.8",
         "@types/lodash": "^4.14.186",
         "@types/node": "^20.5.0",
         "@typescript-eslint/eslint-plugin": "^6.10.0",
         "@typescript-eslint/parser": "^7.14.1",
         "esbuild": "^0.21.5",
-        "esbuild-plugin-wasm": "^1.1.0",
         "eslint": "^8.53.0",
         "eslint-import-resolver-typescript": "^3.5.5",
         "eslint-plugin-import": "^2.27.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6530,6 +6530,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@river-build/mls-rs-wasm-node@npm:^0.0.4":
+  version: 0.0.4
+  resolution: "@river-build/mls-rs-wasm-node@npm:0.0.4"
+  checksum: 11983d654e4b48f3f5c61a3c662717e9697b72e986e41b19e26876c8f96136ee896e5eaf9ed166273f220d46ed63d41c7a0d55be4af0dbd2571be23c73a835c4
+  languageName: node
+  linkType: hard
+
 "@river-build/mls-rs-wasm@npm:^0.0.4":
   version: 0.0.4
   resolution: "@river-build/mls-rs-wasm@npm:0.0.4"
@@ -6756,6 +6763,7 @@ __metadata:
     "@bufbuild/protobuf": ^1.9.0
     "@river-build/dlog": "workspace:^"
     "@river-build/encryption": "workspace:^"
+    "@river-build/mls-rs-wasm-node": ^0.0.4
     "@river-build/proto": "workspace:^"
     "@river-build/sdk": "workspace:^"
     "@river-build/web3": "workspace:^"
@@ -6766,7 +6774,6 @@ __metadata:
     "@typescript-eslint/parser": ^7.14.1
     esbuild: ^0.21.5
     esbuild-plugin-pino: ^2.2.0
-    esbuild-plugin-wasm: ^1.1.0
     eslint: ^8.53.0
     eslint-import-resolver-typescript: ^3.5.5
     eslint-plugin-import: ^2.27.5
@@ -13863,13 +13870,6 @@ __metadata:
   peerDependencies:
     esbuild: ^0.17.1 || ^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0
   checksum: 7dace40169cfeb583c493ef6d82db7892598502d1717a9d02a5f7b1025068003c4d8c1c9f72cc0a4962414f9a4ecc0889f62ed3624136203d56d4f175e6cc8c5
-  languageName: node
-  linkType: hard
-
-"esbuild-plugin-wasm@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "esbuild-plugin-wasm@npm:1.1.0"
-  checksum: 382df12ecb92634d0f526cad4792b0ac5dc8016cdf63e23d9ee099f0f2c530855463cc45045c4a6ec10a6a1bd2ff59b5c4b24e6314a361fa70cc57645caf602b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6530,6 +6530,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@river-build/mls-rs-wasm@npm:^0.0.4":
+  version: 0.0.4
+  resolution: "@river-build/mls-rs-wasm@npm:0.0.4"
+  checksum: 9cb4cca4222bc260ae880395441b21b75a79486b07aeb0cdc39342ad510e836bd4ec87f93b5fd483da8827f2460cbe588c1e2703d7542be25acffe10f6d78eaa
+  languageName: node
+  linkType: hard
+
 "@river-build/playground@workspace:packages/playground":
   version: 0.0.0-use.local
   resolution: "@river-build/playground@workspace:packages/playground"
@@ -6665,6 +6672,7 @@ __metadata:
     "@ethereumjs/util": ^8.0.1
     "@river-build/dlog": "workspace:^"
     "@river-build/encryption": "workspace:^"
+    "@river-build/mls-rs-wasm": ^0.0.4
     "@river-build/proto": "workspace:^"
     "@river-build/web3": "workspace:^"
     "@testing-library/react": ^14.2.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -6599,6 +6599,7 @@ __metadata:
     vite-plugin-checker: ^0.8.0
     vite-plugin-node-polyfills: ^0.22.0
     vite-plugin-replace: ^0.1.1
+    vite-plugin-wasm: ^3.3.0
     vite-tsconfig-paths: ^5.1.3
     wagmi: ^2.13.0
     zod: ^3.21.4
@@ -29844,6 +29845,15 @@ __metadata:
   peerDependencies:
     vite: ^2
   checksum: 247ccdc61605f0a2e097e25fd31cc3528ecb8682dc691fdb5944cc67e427f2ca66864f3bdb21cfb80f835f62366fec8d86f38a2e427f11e016acdbc51219a117
+  languageName: node
+  linkType: hard
+
+"vite-plugin-wasm@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "vite-plugin-wasm@npm:3.3.0"
+  peerDependencies:
+    vite: ^2 || ^3 || ^4 || ^5
+  checksum: 844034955d6650f89988eebb543e4b3307a54d7b800365052f5b97683223d3b99640ecb22d1fd770e768239576629d975bdefc0c9545999564e206b331f0ac3b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- adds `mls-rs-wasm` as a dependency of `sdk`,
- fixes packaging for `stress`, and
- fixes packaging for `playground`.