### PR TITLE
StreamImpl comments, method renames, cleanup

### DIFF
--- a/core/node/events/stream.go
+++ b/core/node/events/stream.go
@@ -121,16 +121,19 @@ type localStreamState struct {
 	pendingCandidates []*MiniblockRef
 }
 
+// IsLocal is thread-safe.
 func (s *streamImpl) IsLocal() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.local != nil
 }
 
+// view should be called with at least a read lock.
 func (s *streamImpl) view() *streamViewImpl {
 	return s.local.useGetterAndSetterToGetView
 }
 
+// This should be accessed under lock.
 func (s *streamImpl) setView(view *streamViewImpl) {
 	s.local.useGetterAndSetterToGetView = view
 	if view != nil && len(s.local.pendingCandidates) > 0 {
@@ -145,7 +148,7 @@ func (s *streamImpl) setView(view *streamViewImpl) {
 	}
 }
 
-// Should be called with lock held
+// loadInternal should be called with a lock held.
 func (s *streamImpl) loadInternal(ctx context.Context) error {
 	if s.view() != nil {
 		return nil
@@ -177,6 +180,7 @@ func (s *streamImpl) loadInternal(ctx context.Context) error {
 }
 
 // ApplyMiniblock applies given miniblock, updating the cached stream view and storage.
+// ApplyMiniblock is thread-safe.
 func (s *streamImpl) ApplyMiniblock(ctx context.Context, miniblock *MiniblockInfo) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -189,6 +193,7 @@ func (s *streamImpl) ApplyMiniblock(ctx context.Context, miniblock *MiniblockInf
 }
 
 // importMiniblocks imports the given miniblocks.
+// importMiniblocks is thread-safe.
 func (s *streamImpl) importMiniblocks(
 	ctx context.Context,
 	miniblocks []*MiniblockInfo,
@@ -202,6 +207,7 @@ func (s *streamImpl) importMiniblocks(
 	return s.importMiniblocksLocked(ctx, miniblocks)
 }
 
+// importMiniblocksLocked should be called with a lock held.
 func (s *streamImpl) importMiniblocksLocked(
 	ctx context.Context,
 	miniblocks []*MiniblockInfo,
@@ -278,13 +284,13 @@ func (s *streamImpl) importMiniblocksLocked(
 		return err
 	}
 
-	prevSyncCookie := originalView.SyncCookie(s.params.Wallet.Address)
 	s.setView(currentView)
 	newSyncCookie := s.view().SyncCookie(s.params.Wallet.Address)
-	s.notifySubscribers(allNewEvents, newSyncCookie, prevSyncCookie)
+	s.notifySubscribersLocked(allNewEvents, newSyncCookie)
 	return nil
 }
 
+// applyMiniblockImplLocked should be called with a lock held.
 func (s *streamImpl) applyMiniblockImplLocked(
 	ctx context.Context,
 	miniblock *MiniblockInfo,
@@ -330,21 +336,22 @@ func (s *streamImpl) applyMiniblockImplLocked(
 		return err
 	}
 
-	prevSyncCookie := s.view().SyncCookie(s.params.Wallet.Address)
 	s.setView(newSV)
 	newSyncCookie := s.view().SyncCookie(s.params.Wallet.Address)
 
 	newEvents = append(newEvents, miniblock.headerEvent.Envelope)
-	s.notifySubscribers(newEvents, newSyncCookie, prevSyncCookie)
+	s.notifySubscribersLocked(newEvents, newSyncCookie)
 	return nil
 }
 
+// promoteCandidate is thread-safe.
 func (s *streamImpl) promoteCandidate(ctx context.Context, mb *MiniblockRef) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.promoteCandidateLocked(ctx, mb)
 }
 
+// promoteCandidateLocked shouldbe called with a lock held.
 func (s *streamImpl) promoteCandidateLocked(ctx context.Context, mb *MiniblockRef) error {
 	if s.local == nil {
 		return nil
@@ -395,6 +402,7 @@ func (s *streamImpl) promoteCandidateLocked(ctx context.Context, mb *MiniblockRe
 	return s.applyMiniblockImplLocked(ctx, miniblock, miniblockBytes)
 }
 
+// schedulePromotionLocked should be called with a lock held.
 func (s *streamImpl) schedulePromotionLocked(ctx context.Context, mb *MiniblockRef) error {
 	if len(s.local.pendingCandidates) == 0 {
 		if mb.Num != s.view().LastBlock().Ref.Num+1 {
@@ -411,6 +419,7 @@ func (s *streamImpl) schedulePromotionLocked(ctx context.Context, mb *MiniblockR
 	return nil
 }
 
+// initFromGenesis is not thread-safe. It should be called with a lock held.
 func (s *streamImpl) initFromGenesis(
 	ctx context.Context,
 	genesisInfo *MiniblockInfo,
@@ -457,6 +466,7 @@ func (s *streamImpl) initFromGenesis(
 	return nil
 }
 
+// initFromBlockchain is not thread-safe. It should be called with a lock held.
 func (s *streamImpl) initFromBlockchain(ctx context.Context) error {
 	// TODO: move this call out of the lock
 	record, _, mb, blockNum, err := s.params.Registry.GetStreamWithGenesis(ctx, s.streamId)
@@ -508,6 +518,7 @@ func (s *streamImpl) initFromBlockchain(ctx context.Context) error {
 	return nil
 }
 
+// getViewIfLocal is thread-safe.
 func (s *streamImpl) getViewIfLocal(ctx context.Context) (*streamViewImpl, error) {
 	s.mu.RLock()
 	isLocal := s.local != nil
@@ -536,6 +547,7 @@ func (s *streamImpl) getViewIfLocal(ctx context.Context) (*streamViewImpl, error
 	return s.view(), nil
 }
 
+// GetView is thread-safe.
 func (s *streamImpl) GetView(ctx context.Context) (StreamView, error) {
 	view, err := s.getViewIfLocal(ctx)
 	// Return nil interface, if implementation is nil.
@@ -548,6 +560,7 @@ func (s *streamImpl) GetView(ctx context.Context) (StreamView, error) {
 	return view, nil
 }
 
+// GetViewIfLocal is thread-safe.
 func (s *streamImpl) GetViewIfLocal(ctx context.Context) (StreamView, error) {
 	view, err := s.getViewIfLocal(ctx)
 	// Return nil interface, if implementation is nil.
@@ -560,7 +573,8 @@ func (s *streamImpl) GetViewIfLocal(ctx context.Context) (StreamView, error) {
 	return view, nil
 }
 
-// Returns StreamView if it's already loaded, or nil if it's not.
+// tryGetView returns StreamView if it's already loaded, or nil if it's not.
+// tryGetView is thread-safe.
 func (s *streamImpl) tryGetView() StreamView {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -573,6 +587,9 @@ func (s *streamImpl) tryGetView() StreamView {
 	}
 }
 
+// maybeScrubLocked schedules a stream scrub if the stream is eligible based on it's
+// last scrub time.
+// maybeScrubLocked should be taken with a lock.
 func (s *streamImpl) maybeScrubLocked() {
 	if !ValidChannelStreamId(&s.streamId) {
 		return
@@ -586,6 +603,9 @@ func (s *streamImpl) maybeScrubLocked() {
 	}
 }
 
+// resetLastScrubbed reset the last scrubbed time on the stream, which is used for
+// determining when the stream is eligible for another scrub.
+// resetLastScrubbed is thread-safe.
 func (s *streamImpl) resetLastScrubbed() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -596,6 +616,7 @@ func (s *streamImpl) resetLastScrubbed() {
 
 // tryCleanup unloads its internal view when s haven't got activity within the given expiration period.
 // It returns true when the view is unloaded
+// tryCleanup is thread-safe.
 func (s *streamImpl) tryCleanup(expiration time.Duration) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -626,9 +647,11 @@ func (s *streamImpl) tryCleanup(expiration time.Duration) bool {
 	return true
 }
 
-// Returns
+// GetMiniblocks returns miniblock data directly fromn storage, bypassing the cache.
+// This is useful when we expect block data to be substantial and do not want to bust the cache.
 // miniblocks: with indexes from fromIndex inclusive, to toIndex exclusive
 // terminus: true if fromIndex is 0, or if there are no more blocks because they've been garbage collected
+// GetMiniblocks is thread-safe.
 func (s *streamImpl) GetMiniblocks(
 	ctx context.Context,
 	fromInclusive int64,
@@ -656,6 +679,8 @@ func (s *streamImpl) GetMiniblocks(
 	return miniblocks, terminus, nil
 }
 
+// AddEvent adds an event to the stream.
+// AddEvent is thread-safe.
 func (s *streamImpl) AddEvent(ctx context.Context, event *ParsedEvent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -663,11 +688,15 @@ func (s *streamImpl) AddEvent(ctx context.Context, event *ParsedEvent) error {
 		return err
 	}
 
-	return s.addEventImpl(ctx, event)
+	return s.addEventLocked(ctx, event)
 }
 
-// caller must have a RW lock on s.mu
-func (s *streamImpl) notifySubscribers(envelopes []*Envelope, newSyncCookie *SyncCookie, prevSyncCookie *SyncCookie) {
+// notifySubscribersLocked updates all callers with unseen events and the new sync cookie.
+// Callers must have a lock held.
+func (s *streamImpl) notifySubscribersLocked(
+	envelopes []*Envelope,
+	newSyncCookie *SyncCookie,
+) {
 	if s.local.receivers != nil && s.local.receivers.Cardinality() > 0 {
 		s.lastAccessedTime = time.Now()
 
@@ -681,8 +710,9 @@ func (s *streamImpl) notifySubscribers(envelopes []*Envelope, newSyncCookie *Syn
 	}
 }
 
-// Lock must be taken.
-func (s *streamImpl) addEventImpl(ctx context.Context, event *ParsedEvent) error {
+// addEventLocked is not thread-safe.
+// Callers must have a lock held.
+func (s *streamImpl) addEventLocked(ctx context.Context, event *ParsedEvent) error {
 	envelopeBytes, err := event.GetEnvelopeBytes()
 	if err != nil {
 		return err
@@ -707,15 +737,16 @@ func (s *streamImpl) addEventImpl(ctx context.Context, event *ParsedEvent) error
 		return err
 	}
 
-	prevSyncCookie := s.view().SyncCookie(s.params.Wallet.Address)
 	s.setView(newSV)
 	newSyncCookie := s.view().SyncCookie(s.params.Wallet.Address)
 
-	s.notifySubscribers([]*Envelope{event.Envelope}, newSyncCookie, prevSyncCookie)
+	s.notifySubscribersLocked([]*Envelope{event.Envelope}, newSyncCookie)
 
 	return nil
 }
 
+// Sub subscribes the reciever to the stream, sending all content between the cookie and the
+// current stream state. This method is thread-safe.
 func (s *streamImpl) Sub(ctx context.Context, cookie *SyncCookie, receiver SyncResultReceiver) error {
 	log := dlog.FromCtx(ctx)
 	if !bytes.Equal(cookie.NodeAddress, s.params.Wallet.Address.Bytes()) {
@@ -819,8 +850,9 @@ func (s *streamImpl) Sub(ctx context.Context, cookie *SyncCookie, receiver SyncR
 	}
 }
 
-// It's ok to unsub non-existing receiver.
+// Unsub unsubscribes the receiver from sync. It's ok to unsub non-existing receiver.
 // Such situation arises during ForceFlush.
+// Unsub is thread-safe.
 func (s *streamImpl) Unsub(receiver SyncResultReceiver) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -832,6 +864,7 @@ func (s *streamImpl) Unsub(receiver SyncResultReceiver) {
 // ForceFlush transitions Stream object to unloaded state.
 // All subbed receivers will receive empty response and must
 // terminate corresponding sync loop.
+// ForceFlush is thread-safe.
 func (s *streamImpl) ForceFlush(ctx context.Context) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -850,6 +883,8 @@ func (s *streamImpl) ForceFlush(ctx context.Context) {
 	s.local.receivers = nil
 }
 
+// canCreateMiniblock determines if a stream is eligible to create a miniblock.
+// canCreateMiniblock is thread-safe.
 func (s *streamImpl) canCreateMiniblock() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -868,6 +903,8 @@ type streamImplStatus struct {
 	lastAccess        time.Time
 }
 
+// getStatus returns a snapshot of useful statistics describing the stream's in-memory state.
+// getStatus is thread-safe.
 func (s *streamImpl) getStatus() *streamImplStatus {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -885,6 +922,10 @@ func (s *streamImpl) getStatus() *streamImplStatus {
 	return ret
 }
 
+// SaveMiniblockCandidate saves the miniblock candidate for the stream. If the candidate matches
+// the first block in the list of pending candidates, it will be applied. This method is thread-safe.
+// Note: saving the candidate itself, without applying it, does not modify the stream's in-memory
+// cached state at all.
 func (s *streamImpl) SaveMiniblockCandidate(ctx context.Context, mb *Miniblock) error {
 	mbInfo, err := NewMiniblockInfoFromProto(
 		mb,
@@ -916,6 +957,11 @@ func (s *streamImpl) SaveMiniblockCandidate(ctx context.Context, mb *Miniblock) 
 	)
 }
 
+// tryApplyCandidate tries to apply the miniblock candidate to the stream. It will apply iff
+// it matches the first in the list of pending candidates, and then it will apply the entire
+// list of pending candidates. It will also return a true result if this block matches the
+// last block applied to the stream.
+// tryApplyCandidate is thread-safe.
 func (s *streamImpl) tryApplyCandidate(ctx context.Context, mb *MiniblockInfo) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -927,6 +973,7 @@ func (s *streamImpl) tryApplyCandidate(ctx context.Context, mb *MiniblockInfo) (
 
 	if mb.Ref.Num <= s.view().LastBlock().Ref.Num {
 		existing, err := s.view().blockWithNum(mb.Ref.Num)
+		// Check if block is already applied
 		if err == nil && existing.Ref.Hash == mb.Ref.Hash {
 			return true, nil
 		}
@@ -966,6 +1013,8 @@ func (s *streamImpl) tryApplyCandidate(ctx context.Context, mb *MiniblockInfo) (
 	return false, nil
 }
 
+// tryReadAndApplyCandidateLocked searches for the candidate in storage and applies it if it exists.
+// tryReadAndApplyCandidateLocked is not thread-safe.
 func (s *streamImpl) tryReadAndApplyCandidateLocked(ctx context.Context, mbRef *MiniblockRef) bool {
 	miniblockBytes, err := s.params.Storage.ReadMiniblockCandidate(ctx, s.streamId, mbRef.Hash, mbRef.Num)
 	if err == nil {
@@ -987,6 +1036,7 @@ func (s *streamImpl) tryReadAndApplyCandidateLocked(ctx context.Context, mbRef *
 
 // getLastMiniblockNumSkipLoad returns the last miniblock number for the given stream from the view if loaded,
 // or from storage otherwise.
+// getLastMiniblockNumSkipLoad is thread-safe.
 func (s *streamImpl) getLastMiniblockNumSkipLoad(ctx context.Context) (int64, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -999,6 +1049,8 @@ func (s *streamImpl) getLastMiniblockNumSkipLoad(ctx context.Context) (int64, er
 	return s.params.Storage.GetLastMiniblockNumber(ctx, s.streamId)
 }
 
+// applyStreamEvents applies the list of stream events to the stream.
+// applyStreamEvents is thread-safe.
 func (s *streamImpl) applyStreamEvents(
 	ctx context.Context,
 	events []river.EventWithStreamId,
@@ -1033,22 +1085,28 @@ func (s *streamImpl) applyStreamEvents(
 		case *river.StreamPlacementUpdated:
 			err := s.nodesLocked.Update(event, s.params.Wallet.Address)
 			if err != nil {
-				dlog.FromCtx(ctx).Error("applyStreamEventsNoLock: failed to update nodes", "err", err, "streamId", s.streamId)
+				dlog.FromCtx(ctx).Error("applyStreamEvents: failed to update nodes", "err", err, "streamId", s.streamId)
 			}
 		default:
-			dlog.FromCtx(ctx).Error("applyStreamEventsNoLock: unknown event", "event", event, "streamId", s.streamId)
+			dlog.FromCtx(ctx).Error("applyStreamEvents: unknown event", "event", event, "streamId", s.streamId)
 		}
 	}
 
 	s.lastAppliedBlockNum = blockNum
 }
 
+// GetNodes returns the list of nodes this stream resides on according to the stream
+// registry. GetNodes is thread-safe.
 func (s *streamImpl) GetNodes() []common.Address {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return slices.Clone(s.nodesLocked.GetNodes())
 }
 
+// GetRemotesAndIsLocal returns
+// remotes - a list of non-local nodes on which the stream resides
+// isLocal - boolean, whether the stream is hosted on this node
+// GetRemotesAndIsLocal is thread-safe.
 func (s *streamImpl) GetRemotesAndIsLocal() ([]common.Address, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1056,12 +1114,18 @@ func (s *streamImpl) GetRemotesAndIsLocal() ([]common.Address, bool) {
 	return slices.Clone(r), l
 }
 
+// GetStickyPeer returns the peer this node typically uses to forward requests to for this
+// stream. If the node becomes unavailable, the sticky peer can be updated with AdvanceStickyPeer.
+// This method is thread-safe.
 func (s *streamImpl) GetStickyPeer() common.Address {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.nodesLocked.GetStickyPeer()
 }
 
+// AdvanceStickyPeer updates the peer used for forwarding requests for this stream. AdvanceStickyPeer
+// can be used whenever a node becomes unavailable.
+// AdvanceStickyPeer is thread-safe.
 func (s *streamImpl) AdvanceStickyPeer(currentPeer common.Address) common.Address {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
- Clarify thread-safety of each method in comments so it will show up on mouse hover in IDEs.
- rename a couple of methods for clarity
- refactor to remove unused parameters