### PR TITLE
Update publish to npm script to keep contract addresses up to date

### DIFF
--- a/scripts/publish-to-npm.sh
+++ b/scripts/publish-to-npm.sh
@@ -45,6 +45,7 @@ if [ $exit_status_yarn -ne 0 ]; then
     exit 1
 fi
 
+# build docs
 yarn workspace @river-build/react-sdk gen
 exit_status_docgen=$?
 
@@ -55,6 +56,11 @@ fi
 
 git add packages/docs/
 git commit -m "docs for version ${VERSION_PREFIX}"
+
+# copy contracts
+./packages/generated/scripts/copy-addresses.sh
+git add packages/generated/deployments
+git commit -m "deployments for version ${VERSION_PREFIX}"
 
 git push -u origin "${BRANCH_NAME}"
 


### PR DESCRIPTION
this should be a no-op, but it keeps us from making human errors and keeps this directory up to date with the source of truth