### PR TITLE
SpaceDapp: change tip to receive tokenId instead of receiver address

### DIFF
--- a/packages/web3/src/ISpaceDapp.ts
+++ b/packages/web3/src/ISpaceDapp.ts
@@ -349,7 +349,7 @@ export interface ISpaceDapp {
     tip: (
         args: {
             spaceId: string
-            receiver: string
+            tokenId: string
             currency: string
             amount: bigint
             messageId: string
@@ -357,4 +357,6 @@ export interface ISpaceDapp {
         },
         signer: SignerType,
     ) => Promise<TransactionType>
+    getLinkedWallets: (wallet: string) => Promise<string[]>
+    getTokenIdOfOwner: (spaceId: string, owner: string) => Promise<string | undefined>
 }

--- a/packages/web3/src/v3/Space.ts
+++ b/packages/web3/src/v3/Space.ts
@@ -473,9 +473,12 @@ export class Space {
         }
     }
 
-    public async getTokenIdsOfOwner(ownerAddress: string): Promise<string[]> {
-        const tokens = await this.erc721AQueryable.read.tokensOfOwner(ownerAddress)
-        return tokens.map((token) => token.toString())
+    public async getTokenIdsOfOwner(linkedWallets: string[]): Promise<string[]> {
+        const tokenPromises = linkedWallets.map((wallet) =>
+            this.erc721AQueryable.read.tokensOfOwner(wallet),
+        )
+        const allTokenArrays = await Promise.all(tokenPromises)
+        return allTokenArrays.flat().map((token) => token.toString())
     }
 
     /**

--- a/packages/web3/src/v3/SpaceDapp.ts
+++ b/packages/web3/src/v3/SpaceDapp.ts
@@ -1646,10 +1646,39 @@ export class SpaceDapp implements ISpaceDapp {
         return space.Membership.listenForMembershipToken(receiver, abortController)
     }
 
+    /**
+     * Get the token id for the owner
+     * Returns the first token id matched from the linked wallets of the owner
+     * @param spaceId - The space id
+     * @param owner - The owner
+     * @returns The token id
+     */
+    public async getTokenIdOfOwner(spaceId: string, owner: string): Promise<string | undefined> {
+        const space = this.getSpace(spaceId)
+        if (!space) {
+            throw new Error(`Space with spaceId "${spaceId}" is not found.`)
+        }
+        const linkedWallets = await this.getLinkedWallets(owner)
+        const tokenIds = await space.getTokenIdsOfOwner(linkedWallets)
+        return tokenIds[0]
+    }
+
+    /**
+     * Tip a user
+     * @param args
+     * @param args.spaceId - The space id
+     * @param args.tokenId - The token id to tip. Obtainable from getTokenIdOfOwner
+     * @param args.currency - The currency to tip - address or 0xEeeeeeeeee... for native currency
+     * @param args.amount - The amount to tip
+     * @param args.messageId - The message id - needs to be hex encoded to 64 characters
+     * @param args.channelId - The channel id - needs to be hex encoded to 64 characters
+     * @param signer - The signer to use for the tip
+     * @returns The transaction
+     */
     public async tip(
         args: {
             spaceId: string
-            receiver: string
+            tokenId: string
             currency: string
             amount: bigint
             messageId: string
@@ -1657,15 +1686,12 @@ export class SpaceDapp implements ISpaceDapp {
         },
         signer: ethers.Signer,
     ): Promise<ContractTransaction> {
-        const { spaceId, receiver, currency, amount, messageId, channelId } = args
+        const { spaceId, tokenId, currency, amount, messageId, channelId } = args
         const space = this.getSpace(spaceId)
         if (!space) {
             throw new Error(`Space with spaceId "${spaceId}" is not found.`)
         }
-        const tokenId = (await space.getTokenIdsOfOwner(receiver))[0]
-        if (!tokenId) {
-            throw new Error(`TokenId for receiver "${receiver}" is not found.`)
-        }
+
         return space.Tipping.write(signer).tip(
             {
                 tokenId,


### PR DESCRIPTION
I thought it made more sense to be able to pass receiver here. But after writing some tests, I realized the membership nft could be in any linked wallet - and that is where the tip is going to go.

It's confusing to have a parameter called receiver, then internally fetch linked wallets, and have the tip go potentially to another address. So instead callers can pass the tokenId using getTokenIdOfOwner