### PR TITLE
feat(contract): add period reward amount to `RewardsDistribution`

### DIFF
--- a/contracts/scripts/deployments/facets/DeployRewardsDistributionV2.s.sol
+++ b/contracts/scripts/deployments/facets/DeployRewardsDistributionV2.s.sol
@@ -14,6 +14,7 @@ contract DeployRewardsDistributionV2 is Deployer, FacetHelper {
   constructor() {
     addSelector(RewardsDistribution.upgradeDelegationProxy.selector);
     addSelector(RewardsDistribution.setRewardNotifier.selector);
+    addSelector(RewardsDistribution.setPeriodRewardAmount.selector);
     addSelector(RewardsDistribution.stake.selector);
     addSelector(RewardsDistribution.permitAndStake.selector);
     addSelector(RewardsDistribution.stakeOnBehalf.selector);
@@ -36,6 +37,7 @@ contract DeployRewardsDistributionV2 is Deployer, FacetHelper {
     addSelector(RewardsDistribution.currentReward.selector);
     addSelector(RewardsDistribution.currentSpaceDelegationReward.selector);
     addSelector(RewardsDistribution.implementation.selector);
+    addSelector(RewardsDistribution.getPeriodRewardAmount.selector);
   }
 
   function initializer() public pure override returns (bytes4) {

--- a/contracts/src/base/registry/facets/distribution/v2/IRewardsDistribution.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/IRewardsDistribution.sol
@@ -69,6 +69,10 @@ interface IRewardsDistributionBase {
   /// @param enabled The whitelist status
   event RewardNotifierSet(address indexed notifier, bool enabled);
 
+  /// @notice Emitted when the reward amount for a period is set
+  /// @param amount The amount of rewardToken to distribute
+  event PeriodRewardAmountSet(uint256 amount);
+
   /// @notice Emitted when a deposit is staked
   /// @param owner The address of the depositor
   /// @param delegatee The address of the delegatee
@@ -159,6 +163,11 @@ interface IRewardsDistribution is IRewardsDistributionBase {
   /// @param notifier The address of the notifier
   /// @param enabled The whitelist status
   function setRewardNotifier(address notifier, bool enabled) external;
+
+  /// @notice Sets the reward amount for a period
+  /// @dev Only the owner can call this function
+  /// @param amount The amount of rewardToken to distribute
+  function setPeriodRewardAmount(uint256 amount) external;
 
   /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
   /*                       STATE MUTATING                       */
@@ -352,4 +361,7 @@ interface IRewardsDistribution is IRewardsDistributionBase {
 
   /// @notice Returns the implementation stored in the beacon
   function implementation() external view returns (address);
+
+  /// @notice Returns the period reward amount
+  function getPeriodRewardAmount() external view returns (uint256);
 }

--- a/contracts/src/base/registry/facets/distribution/v2/RewardsDistribution.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/RewardsDistribution.sol
@@ -85,6 +85,13 @@ contract RewardsDistribution is
     emit RewardNotifierSet(notifier, enabled);
   }
 
+  /// @inheritdoc IRewardsDistribution
+  function setPeriodRewardAmount(uint256 amount) external onlyOwner {
+    RewardsDistributionStorage.layout().periodRewardAmount = amount;
+
+    emit PeriodRewardAmountSet(amount);
+  }
+
   /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
   /*                       STATE MUTATING                       */
   /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
@@ -473,5 +480,10 @@ contract RewardsDistribution is
     assembly {
       result := sload(_UPGRADEABLE_BEACON_IMPLEMENTATION_SLOT)
     }
+  }
+
+  /// @inheritdoc IRewardsDistribution
+  function getPeriodRewardAmount() external view returns (uint256) {
+    return RewardsDistributionStorage.layout().periodRewardAmount;
   }
 }

--- a/contracts/src/base/registry/facets/distribution/v2/RewardsDistributionStorage.sol
+++ b/contracts/src/base/registry/facets/distribution/v2/RewardsDistributionStorage.sol
@@ -24,6 +24,7 @@ library RewardsDistributionStorage {
     mapping(uint256 depositId => address proxy) proxyById;
     mapping(address rewardNotifier => bool) isRewardNotifier;
     mapping(address depositor => EnumerableSet.UintSet) depositsByDepositor;
+    uint256 periodRewardAmount;
   }
 
   function layout() internal pure returns (Layout storage s) {

--- a/contracts/test/base/registry/RewardsDistributionV2.t.sol
+++ b/contracts/test/base/registry/RewardsDistributionV2.t.sol
@@ -42,6 +42,45 @@ contract RewardsDistributionV2Test is
   }
 
   /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+  /*                       ADMIN FUNCTIONS                      */
+  /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+  function test_setRewardNotifier_revertIf_notOwner() public {
+    address caller = _randomAddress();
+    vm.prank(caller);
+    vm.expectRevert(abi.encodeWithSelector(Ownable__NotOwner.selector, caller));
+    rewardsDistributionFacet.setRewardNotifier(caller, true);
+  }
+
+  function test_fuzz_setRewardNotifier(
+    address notifier,
+    bool isRewardNotifier
+  ) public {
+    vm.expectEmit(address(rewardsDistributionFacet));
+    emit RewardNotifierSet(notifier, isRewardNotifier);
+
+    vm.prank(deployer);
+    rewardsDistributionFacet.setRewardNotifier(notifier, isRewardNotifier);
+  }
+
+  function test_setPeriodRewardAmount_revertIf_notOwner() public {
+    address caller = _randomAddress();
+    vm.prank(caller);
+    vm.expectRevert(abi.encodeWithSelector(Ownable__NotOwner.selector, caller));
+    rewardsDistributionFacet.setPeriodRewardAmount(1);
+  }
+
+  function test_fuzz_setPeriodRewardAmount(uint256 reward) public {
+    vm.expectEmit(address(rewardsDistributionFacet));
+    emit PeriodRewardAmountSet(reward);
+
+    vm.prank(deployer);
+    rewardsDistributionFacet.setPeriodRewardAmount(reward);
+
+    assertEq(rewardsDistributionFacet.getPeriodRewardAmount(), reward);
+  }
+
+  /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
   /*                      DELEGATION PROXY                      */
   /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
@@ -53,7 +92,7 @@ contract RewardsDistributionV2Test is
   }
 
   function test_fuzz_upgradeDelegationProxy(address newImplementation) public {
-    vm.assume(uint160(newImplementation) > 10);
+    assumeNotPrecompile(newImplementation);
     vm.assume(newImplementation.code.length == 0);
     vm.etch(newImplementation, type(DelegationProxy).runtimeCode);
 


### PR DESCRIPTION
Introduced functions to set and retrieve the period reward amount in the `RewardsDistributionFacet`. Updated related storage, events, and deployment script to support the new functionality, along with corresponding tests for validation.