### PR TITLE
fix: alphabetically order struct fields for foundry json parser

### DIFF
--- a/contracts/scripts/interactions/InteractRiverAlphaSparse.s.sol
+++ b/contracts/scripts/interactions/InteractRiverAlphaSparse.s.sol
@@ -9,7 +9,7 @@ import {stdJson} from "forge-std/StdJson.sol";
 import "forge-std/console.sol";
 
 // contracts
-import {AlphaHelper} from "contracts/scripts/interactions/helpers/AlphaHelper.sol";
+import {AlphaHelper, DiamondFacetData, FacetData} from "contracts/scripts/interactions/helpers/AlphaHelper.sol";
 
 import {DeployRiverRegistry} from "contracts/scripts/deployments/diamonds/DeployRiverRegistry.s.sol";
 import {IDiamondInitHelper} from "contracts/test/diamond/Diamond.t.sol";
@@ -24,18 +24,6 @@ contract InteractRiverAlphaSparse is AlphaHelper {
   string constant DEFAULT_JSON_FILE = "compiled_source_diff.json";
   string constant DEFAULT_REPORT_PATH = "/scripts/bytecode-diff/source-diffs/";
 
-  struct DiamondFacets {
-    string diamond;
-    FacetData[] facets;
-    uint256 numFacets;
-  }
-
-  struct FacetData {
-    address deployedAddress;
-    string facetName;
-    bytes32 sourceHash;
-  }
-
   string private jsonData;
 
   function readJSON(string memory jsonPath) internal {
@@ -46,28 +34,30 @@ contract InteractRiverAlphaSparse is AlphaHelper {
    * @notice Decodes diamond and facet data from a JSON file output by the bytecode-diff script
    * @dev Reads the JSON file specified by the DEFAULT_JSON_FILE constant
    *      and parses it to extract information about updated diamonds and their facets
-   * @return An array of DiamondFacets structs containing the decoded information
+   * @return An array of DiamondFacetData structs containing the decoded information
    */
 
   function decodeDiamondsFromJSON()
     internal
     view
-    returns (DiamondFacets[] memory)
+    returns (DiamondFacetData[] memory)
   {
     uint256 updatedDiamondLen = abi.decode(
       vm.parseJson(jsonData, ".numUpdated"),
       (uint256)
     );
-    DiamondFacets[] memory diamonds = new DiamondFacets[](updatedDiamondLen);
+    DiamondFacetData[] memory diamonds = new DiamondFacetData[](
+      updatedDiamondLen
+    );
 
     for (uint256 i = 0; i < updatedDiamondLen; i++) {
       // Decode diamond name and number of facets
-      DiamondFacets memory diamondData = abi.decode(
+      DiamondFacetData memory diamondData = abi.decode(
         vm.parseJson(
           jsonData,
           string.concat("$.updated[", vm.toString(i), "]")
         ),
-        (DiamondFacets)
+        (DiamondFacetData)
       );
 
       diamonds[i] = diamondData;
@@ -106,7 +96,7 @@ contract InteractRiverAlphaSparse is AlphaHelper {
 
     readJSON(jsonPath);
 
-    DiamondFacets[] memory diamonds = decodeDiamondsFromJSON();
+    DiamondFacetData[] memory diamonds = decodeDiamondsFromJSON();
 
     // Iterate over diamonds array and process each diamond
     for (uint256 i = 0; i < diamonds.length; i++) {

--- a/contracts/scripts/interactions/helpers/AlphaHelper.sol
+++ b/contracts/scripts/interactions/helpers/AlphaHelper.sol
@@ -16,6 +16,21 @@ import {DiamondHelper} from "contracts/test/diamond/Diamond.t.sol";
 // contracts
 import {Interaction} from "contracts/scripts/common/Interaction.s.sol";
 
+// note: struct fields must be in alphabetical order for the json parser to work
+// see: https://book.getfoundry.sh/cheatcodes/parse-json
+struct DiamondFacetData {
+  string chainName;
+  string diamond;
+  FacetData[] facets;
+  uint256 numFacets;
+}
+
+struct FacetData {
+  address deployedAddress;
+  string facetName;
+  bytes32 sourceHash;
+}
+
 abstract contract AlphaHelper is Interaction, DiamondHelper, IDiamondLoupeBase {
   function removeRemoteFacets(address deployer, address diamond) internal {
     Facet[] memory facets = IDiamondLoupe(diamond).facets();


### PR DESCRIPTION
Fixes bug in Interact*Sparse facet upgrade scripts. Foundry requires struct fields to be defined in solidity in alphabetical order as a BTree is constructed of the raw json file prior to parsing.
