### PR TITLE
Fixes for new getMiniblocks function

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1924,7 +1924,7 @@ export class Client
 
         return {
             terminus: terminus,
-            miniblocks: [...cachedMiniblocks, ...miniblocks],
+            miniblocks: [...miniblocks, ...cachedMiniblocks],
         }
     }
 

--- a/packages/sdk/src/makeStreamRpcClient.ts
+++ b/packages/sdk/src/makeStreamRpcClient.ts
@@ -95,13 +95,18 @@ export async function getMiniblocks(
         )
 
         allMiniblocks.push(...miniblocks)
-        currentFromInclusive = nextFromInclusive
 
         // Set the terminus to true if we got at least one response with reached terminus
         // The behaviour around this flag is not implemented yet
         if (terminus && !reachedTerminus) {
             reachedTerminus = true
         }
+
+        if (currentFromInclusive === nextFromInclusive) {
+            break
+        }
+
+        currentFromInclusive = nextFromInclusive
     }
 
     return {


### PR DESCRIPTION
we're seeing a perf regression on towns, not sure if this is it, but it could be a problem.

the cached and non-cached blocks were getting inserted in the wrong order, original order here  https://github.com/river-build/river/commit/ecefe239ca21a1e383c975e634a8f7f5578cdb8f

if for some reason the node didn’t return any streams, the client could get stuck in a while loop