### PR TITLE
Revert changes to paginate miniblocks

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -56,7 +56,7 @@ import {
     makeSessionKeys,
     type EncryptionDeviceInitOpts,
 } from '@river-build/encryption'
-import { getMaxTimeoutMs, StreamRpcClient, getMiniblocks } from './makeStreamRpcClient'
+import { getMaxTimeoutMs, StreamRpcClient } from './makeStreamRpcClient'
 import { errorContains, getRpcErrorProperty } from './rpcInterceptors'
 import { assert, isDefined } from './check'
 import EventEmitter from 'events'
@@ -86,6 +86,7 @@ import {
     checkEventSignature,
     makeEvent,
     UnpackEnvelopeOpts,
+    unpackMiniblock,
     unpackStream,
     unpackStreamEx,
 } from './sign'
@@ -1908,23 +1909,25 @@ export class Client
             }
         }
 
-        const { miniblocks, terminus } = await getMiniblocks(
-            this.rpcClient,
-            streamId,
+        const response = await this.rpcClient.getMiniblocks({
+            streamId: streamIdAsBytes(streamId),
             fromInclusive,
             toExclusive,
-            this.unpackEnvelopeOpts,
-        )
+        })
 
+        const unpackedMiniblocks: ParsedMiniblock[] = []
+        for (const miniblock of response.miniblocks) {
+            const unpackedMiniblock = await unpackMiniblock(miniblock, this.unpackEnvelopeOpts)
+            unpackedMiniblocks.push(unpackedMiniblock)
+        }
         await this.persistenceStore.saveMiniblocks(
             streamIdAsString(streamId),
-            miniblocks,
+            unpackedMiniblocks,
             'backward',
         )
-
         return {
-            terminus: terminus,
-            miniblocks: [...cachedMiniblocks, ...miniblocks],
+            terminus: response.terminus,
+            miniblocks: [...unpackedMiniblocks, ...cachedMiniblocks],
         }
     }
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1924,7 +1924,7 @@ export class Client
 
         return {
             terminus: terminus,
-            miniblocks: [...miniblocks, ...cachedMiniblocks],
+            miniblocks: [...cachedMiniblocks, ...miniblocks],
         }
     }
 

--- a/packages/sdk/src/makeStreamRpcClient.ts
+++ b/packages/sdk/src/makeStreamRpcClient.ts
@@ -95,18 +95,13 @@ export async function getMiniblocks(
         )
 
         allMiniblocks.push(...miniblocks)
+        currentFromInclusive = nextFromInclusive
 
         // Set the terminus to true if we got at least one response with reached terminus
         // The behaviour around this flag is not implemented yet
         if (terminus && !reachedTerminus) {
             reachedTerminus = true
         }
-
-        if (currentFromInclusive === nextFromInclusive) {
-            break
-        }
-
-        currentFromInclusive = nextFromInclusive
     }
 
     return {


### PR DESCRIPTION
We're seeing the route return 0 for the response.fromInclusive when it shouldn't be...

Revert "Updated SDK to paginate miniblocks (#1790)"

This reverts commit ecefe239ca21a1e383c975e634a8f7f5578cdb8f.


Revert "Fixes for new getMiniblocks function (#1840)"

This reverts commit cd79d8d922d4eed424afd7e87737f7f95b4753a7.