### PR TITLE
Revert "Revert changes to paginate miniblocks (#1844)" & Update logic to be backwards compatible

### DIFF
--- a/packages/sdk/src/makeStreamRpcClient.ts
+++ b/packages/sdk/src/makeStreamRpcClient.ts
@@ -115,17 +115,13 @@ export async function getMiniblocks(
     }
 }
 
-export async function fetchMiniblocksFromRpc(
+async function fetchMiniblocksFromRpc(
     client: StreamRpcClient,
     streamId: string | Uint8Array,
     fromInclusive: bigint,
     toExclusive: bigint,
     unpackEnvelopeOpts: UnpackEnvelopeOpts | undefined,
-): Promise<{
-    miniblocks: ParsedMiniblock[]
-    terminus: boolean
-    nextFromInclusive: bigint
-}> {
+) {
     const response = await client.getMiniblocks({
         streamId: streamIdAsBytes(streamId),
         fromInclusive,
@@ -138,9 +134,12 @@ export async function fetchMiniblocksFromRpc(
         miniblocks.push(unpackedMiniblock)
     }
 
+    const respondedFromInclusive =
+        miniblocks.length > 0 ? miniblocks[0].header.miniblockNum : fromInclusive
+
     return {
         miniblocks: miniblocks,
         terminus: response.terminus,
-        nextFromInclusive: response.fromInclusive + BigInt(response.miniblocks.length),
+        nextFromInclusive: respondedFromInclusive + BigInt(response.miniblocks.length),
     }
 }

--- a/packages/sdk/src/makeStreamRpcClient.ts
+++ b/packages/sdk/src/makeStreamRpcClient.ts
@@ -10,7 +10,10 @@ import {
     retryInterceptor,
     type RetryParams,
 } from './rpcInterceptors'
+import { UnpackEnvelopeOpts, unpackMiniblock } from './sign'
 import { RpcOptions, createHttp2ConnectTransport } from './rpcCommon'
+import { streamIdAsBytes } from './id'
+import { ParsedMiniblock } from './types'
 
 const logInfo = dlog('csb:rpc:info')
 let nextRpcClientNum = 0
@@ -69,4 +72,75 @@ export function getMaxTimeoutMs(opts: StreamRpcClientOptions): number {
             opts.retryParams.defaultTimeoutMs ?? 0 + getRetryDelayMs(i, opts.retryParams)
     }
     return maxTimeoutMs
+}
+
+export async function getMiniblocks(
+    client: StreamRpcClient,
+    streamId: string | Uint8Array,
+    fromInclusive: bigint,
+    toExclusive: bigint,
+    unpackEnvelopeOpts: UnpackEnvelopeOpts | undefined,
+): Promise<{ miniblocks: ParsedMiniblock[]; terminus: boolean }> {
+    const allMiniblocks: ParsedMiniblock[] = []
+    let currentFromInclusive = fromInclusive
+    let reachedTerminus = false
+
+    while (currentFromInclusive < toExclusive) {
+        const { miniblocks, terminus, nextFromInclusive } = await fetchMiniblocksFromRpc(
+            client,
+            streamId,
+            currentFromInclusive,
+            toExclusive,
+            unpackEnvelopeOpts,
+        )
+
+        allMiniblocks.push(...miniblocks)
+
+        // Set the terminus to true if we got at least one response with reached terminus
+        // The behaviour around this flag is not implemented yet
+        if (terminus && !reachedTerminus) {
+            reachedTerminus = true
+        }
+
+        if (currentFromInclusive === nextFromInclusive) {
+            break
+        }
+
+        currentFromInclusive = nextFromInclusive
+    }
+
+    return {
+        miniblocks: allMiniblocks,
+        terminus: reachedTerminus,
+    }
+}
+
+export async function fetchMiniblocksFromRpc(
+    client: StreamRpcClient,
+    streamId: string | Uint8Array,
+    fromInclusive: bigint,
+    toExclusive: bigint,
+    unpackEnvelopeOpts: UnpackEnvelopeOpts | undefined,
+): Promise<{
+    miniblocks: ParsedMiniblock[]
+    terminus: boolean
+    nextFromInclusive: bigint
+}> {
+    const response = await client.getMiniblocks({
+        streamId: streamIdAsBytes(streamId),
+        fromInclusive,
+        toExclusive,
+    })
+
+    const miniblocks: ParsedMiniblock[] = []
+    for (const miniblock of response.miniblocks) {
+        const unpackedMiniblock = await unpackMiniblock(miniblock, unpackEnvelopeOpts)
+        miniblocks.push(unpackedMiniblock)
+    }
+
+    return {
+        miniblocks: miniblocks,
+        terminus: response.terminus,
+        nextFromInclusive: response.fromInclusive + BigInt(response.miniblocks.length),
+    }
 }

--- a/packages/sdk/src/unauthenticatedClient.ts
+++ b/packages/sdk/src/unauthenticatedClient.ts
@@ -1,8 +1,8 @@
 import debug from 'debug'
 import { DLogger, check, dlog, dlogError } from '@river-build/dlog'
 import { hasElements, isDefined } from './check'
-import { StreamRpcClient } from './makeStreamRpcClient'
-import { UnpackEnvelopeOpts, unpackMiniblock, unpackStream } from './sign'
+import { StreamRpcClient, getMiniblocks } from './makeStreamRpcClient'
+import { UnpackEnvelopeOpts, unpackStream } from './sign'
 import { StreamStateView } from './streamStateView'
 import { ParsedMiniblock, StreamTimelineEvent } from './types'
 import { streamIdAsString, streamIdAsBytes, userIdFromAddress, makeUserStreamId } from './id'
@@ -204,20 +204,17 @@ export class UnauthenticatedClient {
             }
         }
 
-        const response = await this.rpcClient.getMiniblocks({
-            streamId: streamIdAsBytes(streamId),
+        const { miniblocks, terminus } = await getMiniblocks(
+            this.rpcClient,
+            streamId,
             fromInclusive,
             toExclusive,
-        })
+            this.unpackEnvelopeOpts,
+        )
 
-        const unpackedMiniblocks: ParsedMiniblock[] = []
-        for (const miniblock of response.miniblocks) {
-            const unpackedMiniblock = await unpackMiniblock(miniblock, this.unpackEnvelopeOpts)
-            unpackedMiniblocks.push(unpackedMiniblock)
-        }
         return {
-            terminus: response.terminus,
-            miniblocks: unpackedMiniblocks,
+            terminus: terminus,
+            miniblocks: miniblocks,
         }
     }
 


### PR DESCRIPTION
This reverts commit accb4bdf8f50abfa1ebd40e96284947e3bb4339c.

And, use the miniblock num of the first miniblock
Roman suggested this initially

until the api change is deployed to the nodes, the fromInclusive will always be 0
after, we can continue to ignore it, it's duplicate info, but useful to have so that we can parallelize miniblock unpacking in the future.