### PR TITLE
[BUGFIX] - Fix crash-looping archiver and log panic

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -495,7 +495,7 @@ func (ac *ArchiveConfig) GetWorkerPoolSize() int {
 
 func (ac *ArchiveConfig) GetStreamsContractCallPageSize() int64 {
 	if ac.StreamsContractCallPageSize <= 0 {
-		return 5000
+		return 1000
 	}
 	return ac.StreamsContractCallPageSize
 }

--- a/core/node/crypto/client.go
+++ b/core/node/crypto/client.go
@@ -166,16 +166,18 @@ func (ic *otelEthClient) BlockByNumber(ctx context.Context, number *big.Int) (*t
 // "fail" for other types of errors.
 func extractCallErrorStatus(err error) string {
 	if de, ok := err.(rpc.DataError); ok {
-		hexStr := de.ErrorData().(string)
-		hexStr = strings.TrimPrefix(hexStr, "0x")
-		revert, e := hex.DecodeString(hexStr)
-		if e == nil {
-			reason, e := abi.UnpackRevert(revert)
+		hexStr, ok := de.ErrorData().(string)
+		if ok {
+			hexStr = strings.TrimPrefix(hexStr, "0x")
+			revert, e := hex.DecodeString(hexStr)
 			if e == nil {
-				return reason
+				reason, e := abi.UnpackRevert(revert)
+				if e == nil {
+					return reason
+				}
 			}
+			return "revert"
 		}
-		return "revert"
 	}
 	return "fail"
 }

--- a/core/node/crypto/config.go
+++ b/core/node/crypto/config.go
@@ -585,7 +585,11 @@ func ABIDecodeString(data []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return args[0].(string), nil
+	str, ok := args[0].(string)
+	if !ok {
+		return "", fmt.Errorf("AbiDecodeString: argument does not resolve to string")
+	}
+	return str, nil
 }
 
 func abiBytesToTypeDecoder(ctx context.Context) mapstructure.DecodeHookFuncValue {

--- a/core/node/crypto/config.go
+++ b/core/node/crypto/config.go
@@ -585,11 +585,7 @@ func ABIDecodeString(data []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	str, ok := args[0].(string)
-	if !ok {
-		return "", fmt.Errorf("AbiDecodeString: argument does not resolve to string")
-	}
-	return str, nil
+	return args[0].(string), nil
 }
 
 func abiBytesToTypeDecoder(ctx context.Context) mapstructure.DecodeHookFuncValue {

--- a/core/node/rpc/archiver.go
+++ b/core/node/rpc/archiver.go
@@ -469,7 +469,10 @@ func (a *Archiver) startImpl(ctx context.Context, once bool, metrics infra.Metri
 				"pageSize",
 				pageSize,
 			)
-			SleepWithContext(ctx, 500*time.Millisecond)
+			err = SleepWithContext(ctx, 500*time.Millisecond)
+			if err != nil {
+				return err
+			}
 		}
 
 		if err != nil {

--- a/core/node/rpc/archiver.go
+++ b/core/node/rpc/archiver.go
@@ -445,6 +445,10 @@ func (a *Archiver) startImpl(ctx context.Context, once bool, metrics infra.Metri
 		"totalCount",
 		totalCount,
 	)
+
+	// Copy page size to the river registry contract for implicit use with ForAllStreams
+	a.contract.Settings.PageSize = int(a.config.GetStreamsContractCallPageSize())
+
 	if err := a.contract.ForAllStreams(
 		ctx,
 		blockNum,

--- a/core/node/rpc/archiver.go
+++ b/core/node/rpc/archiver.go
@@ -423,6 +423,7 @@ func (a *Archiver) startImpl(ctx context.Context, once bool, metrics infra.Metri
 	if once {
 		a.tasksWG = &sync.WaitGroup{}
 	} else if metrics != nil {
+		dlog.FromCtx(ctx).Info("Setting up metrics")
 		a.setupStatisticsMetrics(metrics)
 	}
 


### PR DESCRIPTION
The archive nodes were becoming unhealthy after reporting a panic in the logs:

```
panic: interface conversion: interface {} is nil, not string
```

This error turned out to arise from a method to convert blockchain errors into readable strings. After fixing it, we get

```
Error: archiver.start: (56:CANNOT_CALL_CONTRACT) Contract Returned Error | StreamRegistry.GetPaginatedStreamsGetPaginatedStreams smart contract call failed base_error: request timed out
```

This issue was arising when the start go routine encountered an error while reading paginated streams from the registry. if this call fails, the archiver will shut down. To fix, I reduced the default page size to 1k and added retries on the GetPaginatedStream call.