### PR TITLE
Remove space membership check on user stream when creating channel

### DIFF
--- a/core/node/rpc/create_stream.go
+++ b/core/node/rpc/create_stream.go
@@ -64,6 +64,17 @@ func (s *Service) createStream(ctx context.Context, req *CreateStreamRequest) (*
 		return nil, err
 	}
 
+	// check that streams exist for derived events that will be added later
+	if csRules.DerivedEvents != nil {
+		for _, event := range csRules.DerivedEvents {
+			streamIdBytes := event.StreamId
+			stream, err := s.cache.GetStreamNoWait(ctx, streamIdBytes)
+			if err != nil || stream == nil {
+				return nil, RiverError(Err_PERMISSION_DENIED, "stream does not exist", "streamId", streamIdBytes)
+			}
+		}
+	}
+
 	// check that the creator satisfies the required memberships reqirements
 	if csRules.RequiredMemberships != nil {
 		// load the creator's user stream

--- a/core/node/rules/can_create_stream.go
+++ b/core/node/rules/can_create_stream.go
@@ -212,9 +212,6 @@ func (ru *csParams) canCreateStream() ruleBuilderCS {
 				ru.params.eventCountMatches(2),
 				ru.validateChannelJoinEvent,
 			).
-			requireMembership(
-				inception.SpaceId,
-			).
 			requireChainAuth(ru.getCreateChannelChainAuth).
 			requireDerivedEvent(
 				ru.derivedChannelSpaceParentEvent,


### PR DESCRIPTION
When we create a space we also imediately create a channel
In a replicated streams scenerio, it is tricky to get the membership event for the space join replicated in time in order to pass the checks for creating the channel stream

There are ways to do this, we thought about passing a block number of the user stream event with the create channel event, but this will slow down space creation event more.

Depend instead on the existing blockchain check that gates channel creation

Add new checks that make sure streams exist for any derived event that will be added after channel creation