### PR TITLE
feat(contract): refactor `ProxyBatchDelegation` to include configurab…

### DIFF
--- a/contracts/src/tokens/river/mainnet/delegation/IProxyBatchDelegation.sol
+++ b/contracts/src/tokens/river/mainnet/delegation/IProxyBatchDelegation.sol
@@ -8,5 +8,6 @@ pragma solidity ^0.8.23;
 // contracts
 
 interface IProxyBatchDelegation {
-  function sendDelegators() external;
+  function sendAuthorizedClaimers(uint32 minGasLimit) external;
+  function sendDelegators(uint32 minGasLimit) external;
 }

--- a/contracts/test/fork/ForkProxyBatchDelegation.t.sol
+++ b/contracts/test/fork/ForkProxyBatchDelegation.t.sol
@@ -31,11 +31,6 @@ contract ForkProxyBatchDelegationTest is TestUtils {
 
   function test_sendAuthorizedClaimers() external onlyForked {
     vm.prank(_randomAddress());
-    proxyBatchDelegation.sendAuthorizedClaimers();
-  }
-
-  function test_removeDelegators() external onlyForked {
-    vm.prank(_randomAddress());
-    proxyBatchDelegation.removeDelegators();
+    proxyBatchDelegation.sendAuthorizedClaimers(200_000);
   }
 }

--- a/contracts/test/tokens/delegation/ProxyBatchDelegation.t.sol
+++ b/contracts/test/tokens/delegation/ProxyBatchDelegation.t.sol
@@ -102,7 +102,7 @@ contract ProxyBatchDelegationTest is BaseSetup, IMainnetDelegationBase {
 
     // Send values across the bridge to base
     vm.prank(_randomAddress());
-    proxyDelegation.sendAuthorizedClaimers();
+    proxyDelegation.sendAuthorizedClaimers(200_000);
 
     // Check if the claimer is the same on both sides
     assertEq(
@@ -118,7 +118,7 @@ contract ProxyBatchDelegationTest is BaseSetup, IMainnetDelegationBase {
     givenUsersHaveDelegatedTokens
   {
     vm.prank(_randomAddress());
-    proxyDelegation.sendDelegators();
+    proxyDelegation.sendDelegators(5_000_000);
 
     address randomUser = _getRandomValue(_users);
 
@@ -131,52 +131,6 @@ contract ProxyBatchDelegationTest is BaseSetup, IMainnetDelegationBase {
       authorizedClaimers.getAuthorizedClaimer(randomUser),
       delegation.getAuthorizedClaimer(randomUser)
     );
-  }
-
-  function test_removeDelegators() external {
-    address operator = 0x09285F179a9bA06CEBA12DeCd1755Ac6942A8cf4;
-
-    address[] memory delegators = new address[](2);
-    delegators[0] = 0x204f1aA5B666d0eAc07228D3065a461e92AC399c;
-    delegators[1] = 0x3541F646d321CACbc0fF4A7cCcB583E8B6E413da;
-
-    // given delegators have tokens
-    vm.startPrank(vault);
-    rvr.transfer(delegators[0], tokens);
-    rvr.transfer(delegators[1], tokens);
-    vm.stopPrank();
-
-    setOperator(operator);
-
-    // given delegators have delegated tokens
-    vm.prank(delegators[0]);
-    rvr.delegate(operator);
-
-    vm.prank(delegators[1]);
-    rvr.delegate(operator);
-
-    vm.prank(_randomAddress());
-    proxyDelegation.sendDelegators();
-
-    Delegation memory delegator = delegation.getDelegationByDelegator(
-      delegators[0]
-    );
-
-    assertEq(rvr.delegates(delegators[0]), delegator.operator);
-
-    vm.prank(_randomAddress());
-    proxyDelegation.removeDelegators();
-
-    delegator = delegation.getDelegationByDelegator(delegators[0]);
-
-    assertEq(delegator.operator, address(0));
-    assertEq(delegator.quantity, 0);
-    assertEq(delegator.delegator, address(0));
-
-    Delegation[] memory mainneDelegators = delegation
-      .getMainnetDelegationsByOperator(operator);
-
-    assertEq(mainneDelegators.length, 0);
   }
 
   function _getRandomValue(


### PR DESCRIPTION
…le gas limit

Replaced hardcoded gas limits with a `minGasLimit` parameter for `sendAuthorizedClaimers` and `sendDelegators` to enhance configurability. Removed the `removeDelegators` function and associated tests as part of cleanup. Optimized loops and introduced `SafeTransferLib` for improved balance retrieval.