### PR TITLE
Add logging metadata to help debug race conditions in replication

### DIFF
--- a/core/node/base/test/context.go
+++ b/core/node/base/test/context.go
@@ -10,24 +10,31 @@ import (
 
 func NewTestContext() (context.Context, context.CancelFunc) {
 	logLevel := os.Getenv("RIVER_TEST_LOG")
-	var handler slog.Handler
 	if logLevel == "" {
-		handler = &dlog.NullHandler{}
+		handler := &dlog.NullHandler{}
+		//lint:ignore LE0000 context.Background() used correctly
+		ctx := dlog.CtxWithLog(context.Background(), slog.New(handler))
+		return context.WithCancel(ctx)
 	} else {
-		var level slog.Level
-		err := level.UnmarshalText([]byte(logLevel))
-		if err != nil {
-			level = slog.LevelInfo
-		}
-		handler = dlog.NewPrettyTextHandler(
-			os.Stdout,
-			&dlog.PrettyHandlerOptions{
-				Level:         level,
-				PrintLongTime: false,
-				Colors:        dlog.ColorMap_Enabled,
-			},
-		)
+		return NewTestContextWithLogging(logLevel)
 	}
+}
+
+func NewTestContextWithLogging(logLevel string) (context.Context, context.CancelFunc) {
+	var level slog.Level
+	err := level.UnmarshalText([]byte(logLevel))
+	if err != nil {
+		level = slog.LevelInfo
+	}
+	handler := dlog.NewPrettyTextHandler(
+		os.Stdout,
+		&dlog.PrettyHandlerOptions{
+			Level:         level,
+			PrintLongTime: false,
+			Colors:        dlog.ColorMap_Enabled,
+		},
+	)
+
 	//lint:ignore LE0000 context.Background() used correctly
 	ctx := dlog.CtxWithLog(context.Background(), slog.New(handler))
 	return context.WithCancel(ctx)

--- a/core/node/events/miniblock_producer.go
+++ b/core/node/events/miniblock_producer.go
@@ -276,7 +276,10 @@ func (p *miniblockProducer) TestMakeMiniblock(
 
 		err = SleepWithContext(ctx, 10*time.Millisecond)
 		if err != nil {
-			return nil, err
+			return nil, AsRiverError(err, Err_INTERNAL).
+				Func("TestMakeMiniblock").
+				Message("Timed out while waiting for make_miniblock job to be scheduled").
+				Tag("streamId", streamId)
 		}
 	}
 
@@ -288,7 +291,10 @@ func (p *miniblockProducer) TestMakeMiniblock(
 
 		err = SleepWithContext(ctx, 10*time.Millisecond)
 		if err != nil {
-			return nil, err
+			return nil, AsRiverError(err, Err_INTERNAL).
+				Func("TestMakeMiniblock").
+				Message("Timed out while waiting for make_miniblock job to terminate").
+				Tag("streamId", streamId)
 		}
 	}
 
@@ -571,7 +577,13 @@ func (p *miniblockProducer) jobStart(ctx context.Context, j *mbJob, forceSnapsho
 	candidate, err := mbProduceCandidate(ctx, p.streamCache.Params(), j.stream, forceSnapshot)
 	if err != nil {
 		dlog.FromCtx(ctx).
-			Error("MiniblockProducer: jobStart: Error creating new miniblock proposal", "streamId", j.stream.streamId, "err", err)
+			Error(
+				"MiniblockProducer: jobStart: Error creating new miniblock proposal",
+				"streamId",
+				j.stream.streamId,
+				"err",
+				err,
+			)
 		p.jobDone(ctx, j)
 		return
 	}

--- a/core/node/events/stream.go
+++ b/core/node/events/stream.go
@@ -736,16 +736,20 @@ func (s *streamImpl) addEventLocked(ctx context.Context, event *ParsedEvent) err
 	// TODO: for some classes of errors, it's not clear if event was added or not
 	// for those, perhaps entire Stream structure should be scrapped and reloaded
 	if err != nil {
-		var sb strings.Builder
-		sb.WriteString("[\n")
-		for hash, event := range s.view().minipool.events.Map {
-			sb.WriteString(fmt.Sprintf("  %s %s,\n", hash, event.ShortDebugStr()))
+		eventsStr := fmt.Sprintf("[...%d events]", len(s.view().minipool.events.Map))
+		if len(s.view().minipool.events.Map) <= 16 {
+			var sb strings.Builder
+			sb.WriteString("[\n")
+			for hash, event := range s.view().minipool.events.Map {
+				sb.WriteString(fmt.Sprintf("  %s %s,\n", hash, event.ShortDebugStr()))
+			}
+			sb.WriteString("]")
+			eventsStr = sb.String()
 		}
-		sb.WriteString("]")
 
 		return AsRiverError(err, Err_DB_OPERATION_FAILURE).
 			Tag("inMemoryBlocks", len(s.view().blocks)).
-			Tag("inMemoryEvents", sb.String())
+			Tag("inMemoryEvents", eventsStr)
 	}
 
 	s.setView(newSV)

--- a/core/node/rpc/forwarder.go
+++ b/core/node/rpc/forwarder.go
@@ -192,6 +192,7 @@ func executeConnectHandler[Req, Res any](
 			Tags(
 				"nodeAddress", service.wallet.Address.Hex(),
 				"nodeUrl", service.config.Address,
+				"handler", methodName,
 				"elapsed", elapsed,
 			).
 			Func(methodName)

--- a/core/node/rpc/repl_test.go
+++ b/core/node/rpc/repl_test.go
@@ -125,10 +125,10 @@ func TestStreamReconciliationFromGenesis(t *testing.T) {
 	latestMbNum := int64(0)
 
 	mbRef := MiniblockRefFromCookie(cookie)
-	for range N {
+	for i := range N {
 		require.NoError(addUserBlockedFillerEvent(ctx, wallet, client, streamId, mbRef))
 		mbRef, err = tt.nodes[2].service.mbProducer.TestMakeMiniblock(ctx, streamId, false)
-		require.NoError(err)
+		require.NoError(err, "Failed to make miniblock on round %d", i)
 
 		if mbChain[latestMbNum] != mbRef.Hash {
 			latestMbNum = mbRef.Num

--- a/core/node/rpc/tester_test.go
+++ b/core/node/rpc/tester_test.go
@@ -109,7 +109,7 @@ func newServiceTester(t *testing.T, opts serviceTesterOpts) *serviceTester {
 	var ctx context.Context
 	var ctxCancel func()
 	if opts.printTestLogs {
-		ctx, ctxCancel = test.NewTestContextWithLogging("error")
+		ctx, ctxCancel = test.NewTestContextWithLogging("info")
 	} else {
 		ctx, ctxCancel = test.NewTestContext()
 	}

--- a/core/node/rpc/tester_test.go
+++ b/core/node/rpc/tester_test.go
@@ -79,6 +79,7 @@ type serviceTesterOpts struct {
 	replicationFactor int
 	start             bool
 	btcParams         *crypto.TestParams
+	printTestLogs     bool
 }
 
 func makeTestListenerNoCleanup(t *testing.T) (net.Listener, string) {
@@ -105,7 +106,13 @@ func newServiceTester(t *testing.T, opts serviceTesterOpts) *serviceTester {
 		opts.replicationFactor = 1
 	}
 
-	ctx, ctxCancel := test.NewTestContext()
+	var ctx context.Context
+	var ctxCancel func()
+	if opts.printTestLogs {
+		ctx, ctxCancel = test.NewTestContextWithLogging("error")
+	} else {
+		ctx, ctxCancel = test.NewTestContext()
+	}
 	require := require.New(t)
 
 	st := &serviceTester{

--- a/core/node/storage/pg_stream_store.go
+++ b/core/node/storage/pg_stream_store.go
@@ -716,9 +716,20 @@ func (s *PostgresStreamStore) writeEventTx(
 	// At this moment counter should be equal to minipoolSlot otherwise it is discrepancy of actual and expected records in minipool
 	// Keep in mind that there is service record with seqNum equal to -1
 	if counter != minipoolSlot {
+		var seqNum int
+		// Sometimes this transaction fails due to timeouts, but since we're rolling back the transaction
+		// anyway, we might as well try to add this metadata to the returned error for debugging purposes.
+		// Occasionally we see this error in local testing and there may be a race condition in our stream
+		// caching logic that is causing this inconsistency.
+		mbErr := tx.QueryRow(
+			ctx,
+			s.sqlForStream("select max(seq_num) from {{miniblocks}} where stream_id = $1", streamId),
+			streamId,
+		).Scan(&seqNum)
 		return RiverError(Err_DB_OPERATION_FAILURE, "Wrong number of records in minipool").
-			Tag("ActualRecordsNumber", counter).Tag("ExpectedRecordsNumber", minipoolSlot)
-	}
+			Tag("ActualRecordsNumber", counter).Tag("ExpectedRecordsNumber", minipoolSlot).
+			Tag("maxSeqNum", seqNum).Tag("mbErr", mbErr)
+	}	}
 
 	// All checks passed - we need to insert event into minipool
 	_, err = tx.Exec(

--- a/core/node/storage/pg_stream_store.go
+++ b/core/node/storage/pg_stream_store.go
@@ -729,7 +729,7 @@ func (s *PostgresStreamStore) writeEventTx(
 		return RiverError(Err_DB_OPERATION_FAILURE, "Wrong number of records in minipool").
 			Tag("ActualRecordsNumber", counter).Tag("ExpectedRecordsNumber", minipoolSlot).
 			Tag("maxSeqNum", seqNum).Tag("mbErr", mbErr)
-	}	}
+	}
 
 	// All checks passed - we need to insert event into minipool
 	_, err = tx.Exec(


### PR DESCRIPTION
This PR separates out some additional logging and population of error metadata in returned errors that mostly only occurs in the case of error conditions, and should not affect total log volume overly. The additional metadata has been helpful in tracking down what may be happening when searching for race conditions in the code.

It also adds a service tester configuration to enable logging for specific test cases.