### PR TITLE
fix parameters for tip linked wallet check

### DIFF
--- a/core/node/rules/can_add_event.go
+++ b/core/node/rules/can_add_event.go
@@ -865,8 +865,8 @@ func (ru *aeBlockchainTransactionRules) blockchainTransaction_ChainAuth() (*auth
 		// tips can be sent through a bundler, verify the tip sender
 		// as specified in the tip content and verified against the logs in blockchainTransaction_CheckReceiptMetadata
 		return auth.NewChainAuthArgsForIsWalletLinked(
+			ru.params.parsedEvent.Event.CreatorAddress,
 			content.Tip.GetSender(),
-			ru.transaction.Receipt.From,
 		), nil
 	default:
 		return nil, RiverError(


### PR DESCRIPTION
creator to sender, not from to sender, oops
couldn’t figure out how to test this locally