### PR TITLE
Fix river errors with missing info in %T

### DIFF
--- a/core/node/events/snapshot.go
+++ b/core/node/events/snapshot.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"bytes"
+	"fmt"
 	"slices"
 
 	"google.golang.org/protobuf/proto"
@@ -113,7 +114,7 @@ func make_SnapshotContent(iInception IsInceptionPayload) (IsSnapshot_Content, er
 			},
 		}, nil
 	default:
-		return nil, RiverError(Err_INVALID_ARGUMENT, "unknown inception type %T", iInception)
+		return nil, RiverError(Err_INVALID_ARGUMENT, fmt.Sprintf("unknown inception type %T", iInception))
 	}
 }
 
@@ -179,7 +180,7 @@ func Update_Snapshot(iSnapshot *Snapshot, event *ParsedEvent, miniblockNum int64
 	case *StreamEvent_MediaPayload:
 		return RiverError(Err_BAD_PAYLOAD, "Media payload snapshots are not supported")
 	default:
-		return RiverError(Err_INVALID_ARGUMENT, "unknown payload type %T", event.Event.Payload)
+		return RiverError(Err_INVALID_ARGUMENT, fmt.Sprintf("unknown payload type %T", event.Event.Payload))
 	}
 }
 
@@ -247,7 +248,7 @@ func update_Snapshot_Space(
 		}
 		return nil
 	default:
-		return RiverError(Err_INVALID_ARGUMENT, "unknown space payload type %T", spacePayload.Content)
+		return RiverError(Err_INVALID_ARGUMENT, fmt.Sprintf("unknown space payload type %T", spacePayload.Content))
 	}
 }
 
@@ -263,7 +264,7 @@ func update_Snapshot_Channel(iSnapshot *Snapshot, channelPayload *ChannelPayload
 	case *ChannelPayload_Message:
 		return nil
 	default:
-		return RiverError(Err_INVALID_ARGUMENT, "unknown channel payload type %T", content)
+		return RiverError(Err_INVALID_ARGUMENT, fmt.Sprintf("unknown channel payload type %T", content))
 	}
 }
 
@@ -281,7 +282,7 @@ func update_Snapshot_DmChannel(
 	case *DmChannelPayload_Message:
 		return nil
 	default:
-		return RiverError(Err_INVALID_ARGUMENT, "unknown dm channel payload type %T", content)
+		return RiverError(Err_INVALID_ARGUMENT, fmt.Sprintf("unknown dm channel payload type %T", content))
 	}
 }
 
@@ -305,7 +306,7 @@ func update_Snapshot_GdmChannel(
 	case *GdmChannelPayload_Message:
 		return nil
 	default:
-		return RiverError(Err_INVALID_ARGUMENT, "unknown channel payload type %T", channelPayload.Content)
+		return RiverError(Err_INVALID_ARGUMENT, fmt.Sprintf("unknown channel payload type %T", channelPayload.Content))
 	}
 }
 
@@ -323,7 +324,7 @@ func update_Snapshot_User(iSnapshot *Snapshot, userPayload *UserPayload) error {
 	case *UserPayload_UserMembershipAction_:
 		return nil
 	default:
-		return RiverError(Err_INVALID_ARGUMENT, "unknown user payload type %T", userPayload.Content)
+		return RiverError(Err_INVALID_ARGUMENT, fmt.Sprintf("unknown user payload type %T", userPayload.Content))
 	}
 }
 
@@ -342,7 +343,7 @@ func update_Snapshot_UserSettings(iSnapshot *Snapshot, userSettingsPayload *User
 		snapshot.UserSettingsContent.UserBlocksList = insertUserBlock(snapshot.UserSettingsContent.UserBlocksList, content.UserBlock)
 		return nil
 	default:
-		return RiverError(Err_INVALID_ARGUMENT, "unknown user settings payload type %T", userSettingsPayload.Content)
+		return RiverError(Err_INVALID_ARGUMENT, fmt.Sprintf("unknown user settings payload type %T", userSettingsPayload.Content))
 	}
 }
 
@@ -388,7 +389,7 @@ func update_Snapshot_UserMetadata(
 		snapshot.UserMetadataContent.Bio = &WrappedEncryptedData{Data: content.Bio, EventNum: eventNum, EventHash: eventHash}
 		return nil
 	default:
-		return RiverError(Err_INVALID_ARGUMENT, "unknown user metadata payload type %T", userMetadataPayload.Content)
+		return RiverError(Err_INVALID_ARGUMENT, fmt.Sprintf("unknown user metadata payload type %T", userMetadataPayload.Content))
 	}
 }
 
@@ -438,7 +439,7 @@ func update_Snapshot_UserInbox(
 		cleanup_Snapshot_UserInbox(snapshot, miniblockNum)
 		return nil
 	default:
-		return RiverError(Err_INVALID_ARGUMENT, "unknown user to device payload type %T", userInboxPayload.Content)
+		return RiverError(Err_INVALID_ARGUMENT, fmt.Sprintf("unknown user to device payload type %T", userInboxPayload.Content))
 	}
 }
 
@@ -549,7 +550,7 @@ func update_Snapshot_Member(
 		snapshot.EncryptionAlgorithm.Algorithm = content.EncryptionAlgorithm.Algorithm
 		return nil
 	default:
-		return RiverError(Err_INVALID_ARGUMENT, "unknown membership payload type %T", memberPayload.Content)
+		return RiverError(Err_INVALID_ARGUMENT, fmt.Sprintf("unknown membership payload type %T", memberPayload.Content))
 	}
 }
 

--- a/core/node/rules/rule_builder.go
+++ b/core/node/rules/rule_builder.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"fmt"
 	"time"
 
 	. "github.com/river-build/river/core/node/base"
@@ -16,15 +17,15 @@ type DerivedEvent struct {
 }
 
 func unknownPayloadType(payload any) error {
-	return RiverError(Err_INVALID_ARGUMENT, "unknown payload type %T", payload)
+	return RiverError(Err_INVALID_ARGUMENT, fmt.Sprintf("unknown payload type %T", payload))
 }
 
 func unknownContentType(content any) error {
-	return RiverError(Err_INVALID_ARGUMENT, "unknown content type %T", content)
+	return RiverError(Err_INVALID_ARGUMENT, fmt.Sprintf("unknown content type %T", content))
 }
 
 func invalidContentType(content any) error {
-	return RiverError(Err_INVALID_ARGUMENT, "invalid contemt type %T", content)
+	return RiverError(Err_INVALID_ARGUMENT, fmt.Sprintf("invalid contemt type %T", content))
 }
 
 func isPastExpiry(currentTime time.Time, expiryEpochMs int64) bool {


### PR DESCRIPTION
when i converted these from `fmt.Errorf` it didn’t pick up the formatting. just putting the content in the log doesn’t do what i want.