### PR TITLE
river stream registry: delete genesis when stream advanced

### DIFF
--- a/contracts/src/river/registry/facets/stream/StreamRegistry.sol
+++ b/contracts/src/river/registry/facets/stream/StreamRegistry.sol
@@ -114,10 +114,8 @@ contract StreamRegistry is IStreamRegistry, RegistryModifiers {
       revert(RiverRegistryErrors.BAD_ARG);
     }
 
-    // Delete genesis miniblock if `stream` still contains the genesis block after `stream` has advanced since genesis.
-    if (stream.lastMiniblockNum == 0) {
-      delete ds.genesisMiniblockByStreamId[streamId];
-    }
+    // Delete genesis miniblock
+    delete ds.genesisMiniblockByStreamId[streamId];
 
     // Update the stream information
     stream.lastMiniblockHash = lastMiniblockHash;

--- a/contracts/src/river/registry/facets/stream/StreamRegistry.sol
+++ b/contracts/src/river/registry/facets/stream/StreamRegistry.sol
@@ -114,6 +114,11 @@ contract StreamRegistry is IStreamRegistry, RegistryModifiers {
       revert(RiverRegistryErrors.BAD_ARG);
     }
 
+    // Delete genesis miniblock if `stream` still contains the genesis block after `stream` has advanced since genesis.
+    if (stream.lastMiniblockNum == 0) {
+      delete ds.genesisMiniblockByStreamId[streamId];
+    }
+
     // Update the stream information
     stream.lastMiniblockHash = lastMiniblockHash;
     stream.lastMiniblockNum = lastMiniblockNum;
@@ -121,11 +126,6 @@ contract StreamRegistry is IStreamRegistry, RegistryModifiers {
     // Set the sealed flag if requested
     if (isSealed) {
       stream.flags |= StreamFlags.SEALED;
-    }
-
-    // Delete genesis miniblock if `stream` still contains the genesis block after `stream` has advanced since genesis.
-    if (stream.lastMiniblockNum == 0) {
-      delete ds.genesisMiniblockByStreamId[streamId];
     }
 
     emit StreamLastMiniblockUpdated(


### PR DESCRIPTION
With https://github.com/river-build/river/pull/1923/commits/1c63faedffe99c6574a75645c1b9ecb79c406fae the genesis block is never removed because `stream.lastMiniblockNum` is updated before the check it's `0`. Do this check and deletion before the update.