### PR TITLE
[RIVER-1950] Stream debug endpoint

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -64,6 +64,7 @@ func GetDefaultConfig() *Config {
 			PProf:                 false,
 			Stacks:                true,
 			StacksMaxSizeKb:       5 * 1024,
+			Stream:                true,
 			TxPool:                true,
 			EnableStorageEndpoint: true,
 		},
@@ -445,6 +446,7 @@ type DebugEndpointsConfig struct {
 	PProf           bool
 	Stacks          bool
 	StacksMaxSizeKb int
+	Stream          bool
 	TxPool          bool
 
 	// Make storage statistics available via debug endpoints. This may involve running queries

--- a/core/node/rpc/debug.go
+++ b/core/node/rpc/debug.go
@@ -71,7 +71,7 @@ func (s *Service) registerDebugHandlers(enableDebugEndpoints bool, cfg config.De
 	handler.HandleFunc(mux, "/debug/multi/json", s.handleDebugMultiJson)
 	handler.Handle(mux, "/debug/config", &onChainConfigHandler{onChainConfig: s.chainConfig})
 
-	if enableDebugEndpoints && cfg.EnableStorageEndpoint {
+	if cfg.EnableStorageEndpoint || enableDebugEndpoints {
 		handler.HandleFunc(mux, "/debug/storage", s.handleDebugStorage)
 	}
 
@@ -100,7 +100,7 @@ func (s *Service) registerDebugHandlers(enableDebugEndpoints bool, cfg config.De
 		handler.Handle(mux, "/debug/txpool", &txpoolHandler{riverTxPool: s.riverChain.TxPool})
 	}
 
-	if enableDebugEndpoints {
+	if cfg.Stream || enableDebugEndpoints {
 		handler.Handle(mux, "/debug/stream/{streamIdStr}", &streamHandler{store: s.storage})
 	}
 }
@@ -170,7 +170,7 @@ func (s *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			err,
 			"streamIdString",
 			streamIdStr)
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("Stream id is not parsable: `%v`", err), http.StatusInternalServerError)
 		return
 	}
 

--- a/core/node/rpc/render/templates/debug/stream.template.html
+++ b/core/node/rpc/render/templates/debug/stream.template.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Stream Summary</title>
+    <style>
+      body {
+        font-family: monospace;
+      }
+
+      table,
+      th,
+      td {
+        border: none;
+        border-collapse: collapse;
+        vertical-align: text-top;
+      }
+
+      table tr td:nth-child(1) {
+        font-weight: bolder;
+        text-align: right;
+      }
+
+      table table tr td:nth-child(1) {
+        font-weight: normal;
+        text-align: center;
+      }
+
+      th,
+      td {
+        padding: 8px;
+        text-align: center;
+      }
+
+      table tr th {
+        text-align: left;
+      }
+    </style>
+  </head>
+  <!-- prettier-ignore -->
+
+  <body>
+    <table>
+      <tr><th colspan="2"><h2>Stream Summary</h2></th></tr>
+      <tr><td>Stream Id:</td><td>{{.Result.StreamId}}</td></tr>
+      <tr><td>Num Minipool Events:</td><td>{{.Result.NumMinipoolEvents}}</td></tr>
+      <tr><td>Latest Snapshot Miniblock Num:</td><td>{{.Result.LatestSnapshotMiniblockNum}}</td></tr>
+      <tr><td>Lastest Miniblock Number:</td><td>{{.Result.LatestMiniblockNum}}</td></tr>
+      <tr><td>Current Miniblock Candidates:</td>
+        <td>
+          <table>
+            <tr><th>BlockNum</th><th>Hash</th></tr>
+            {{ range $i, $mc := .Result.CurrentMiniblockCandidates }}
+            <tr><td>{{$mc.BlockNum}}</td><td>{{$mc.Hash}}</td></tr>
+            {{end}}
+          </table>
+      </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/core/node/rpc/render/types.go
+++ b/core/node/rpc/render/types.go
@@ -8,8 +8,16 @@ import (
 
 // RenderableData is the interface for all data that can be rendered
 type RenderableData interface {
-	*AvailableDebugHandlersData | *CacheData | *TransactionPoolData | *OnChainConfigData |
-		*GoRoutineData | *SystemStatsData | *InfoIndexData | *DebugMultiData | *StorageData
+	*AvailableDebugHandlersData |
+		*CacheData |
+		*TransactionPoolData |
+		*OnChainConfigData |
+		*GoRoutineData |
+		*SystemStatsData |
+		*InfoIndexData |
+		*DebugMultiData |
+		*StorageData |
+		*StreamSummaryData
 
 	// TemplateName returns the name of the template to be used for rendering
 	TemplateName() string
@@ -53,6 +61,14 @@ type TransactionPoolData struct {
 		ReplacementTransactionsCount int64
 		LastReplacementTransaction   string
 	}
+}
+
+type StreamSummaryData struct {
+	Result storage.DebugReadStreamStatisticsResult
+}
+
+func (d StreamSummaryData) TemplateName() string {
+	return "templates/debug/stream.template.html"
 }
 
 func (d TransactionPoolData) TemplateName() string {

--- a/core/node/storage/pg_stream_store.go
+++ b/core/node/storage/pg_stream_store.go
@@ -1603,7 +1603,7 @@ func (s *PostgresStreamStore) DebugReadStreamData(
 		pgx.ReadWrite,
 		func(ctx context.Context, tx pgx.Tx) error {
 			var err error
-			ret, err = s.debugReadStreamData(ctx, tx, streamId)
+			ret, err = s.debugReadStreamDataTx(ctx, tx, streamId)
 			return err
 		},
 		nil,
@@ -1615,7 +1615,7 @@ func (s *PostgresStreamStore) DebugReadStreamData(
 	return ret, nil
 }
 
-func (s *PostgresStreamStore) debugReadStreamData(
+func (s *PostgresStreamStore) debugReadStreamDataTx(
 	ctx context.Context,
 	tx pgx.Tx,
 	streamId StreamId,
@@ -1692,8 +1692,7 @@ func (s *PostgresStreamStore) debugReadStreamData(
 		var num int64
 		var hashStr string
 		var data []byte
-		err = candRows.Scan(&num, &hashStr, &data)
-		if err != nil {
+		if err = candRows.Scan(&num, &hashStr, &data); err != nil {
 			return nil, err
 		}
 		result.MbCandidates = append(result.MbCandidates, MiniblockDescriptor{
@@ -1701,6 +1700,91 @@ func (s *PostgresStreamStore) debugReadStreamData(
 			Data:            data,
 			Hash:            common.HexToHash(hashStr),
 		})
+	}
+
+	return result, nil
+}
+
+func (s *PostgresStreamStore) DebugReadStreamStatistics(
+	ctx context.Context,
+	streamId StreamId,
+) (*DebugReadStreamStatisticsResult, error) {
+	var ret *DebugReadStreamStatisticsResult
+	err := s.txRunnerWithUUIDCheck(
+		ctx,
+		"DebugReadStreamStatistics",
+		pgx.ReadWrite,
+		func(ctx context.Context, tx pgx.Tx) error {
+			var err error
+			ret, err = s.debugReadStreamStatisticsTx(ctx, tx, streamId)
+			return err
+		},
+		nil,
+		"streamId", streamId,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (s *PostgresStreamStore) debugReadStreamStatisticsTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	streamId StreamId,
+) (*DebugReadStreamStatisticsResult, error) {
+	lastSnapshotMiniblock, err := s.lockStream(ctx, tx, streamId, false)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &DebugReadStreamStatisticsResult{
+		StreamId:                   streamId.String(),
+		LatestSnapshotMiniblockNum: lastSnapshotMiniblock,
+	}
+
+	if err = tx.QueryRow(
+		ctx,
+		s.sqlForStream(
+			"SELECT MAX(seq_num) from {{miniblocks}} WHERE stream_id = $1",
+			streamId,
+		),
+		streamId,
+	).Scan(&result.LatestMiniblockNum); err != nil {
+		return nil, AsRiverError(err, Err_DB_OPERATION_FAILURE).Tag("query", "latest_block")
+	}
+
+	if err = tx.QueryRow(
+		ctx,
+		s.sqlForStream(
+			"SELECT count(*) FROM {{minipools}} WHERE stream_id = $1 AND slot_num <> -1",
+			streamId,
+		),
+		streamId,
+	).Scan(&result.NumMinipoolEvents); err != nil {
+		return nil, AsRiverError(err, Err_DB_OPERATION_FAILURE).Tag("query", "minipool_size")
+	}
+
+	candRows, err := tx.Query(
+		ctx,
+		s.sqlForStream(
+			"SELECT seq_num, block_hash FROM {{miniblock_candidates}} WHERE stream_id = $1 ORDER BY seq_num, block_hash",
+			streamId,
+		),
+		streamId,
+	)
+	if err != nil {
+		return nil, AsRiverError(err, Err_DB_OPERATION_FAILURE).Tag("query", "candidates")
+	}
+	defer candRows.Close()
+
+	for candRows.Next() {
+		var candidate MiniblockCandidateStatisticsResult
+		if err = candRows.Scan(&candidate.BlockNum, &candidate.Hash); err != nil {
+			return nil, err
+		}
+
+		result.CurrentMiniblockCandidates = append(result.CurrentMiniblockCandidates, candidate)
 	}
 
 	return result, nil

--- a/core/node/storage/storage.go
+++ b/core/node/storage/storage.go
@@ -118,6 +118,11 @@ type StreamStorage interface {
 		streamId StreamId,
 	) (*DebugReadStreamDataResult, error)
 
+	DebugReadStreamStatistics(
+		ctx context.Context,
+		streamId StreamId,
+	) (*DebugReadStreamStatisticsResult, error)
+
 	// GetLastMiniblockNumber returns the last miniblock number for the given stream from storage.
 	GetLastMiniblockNumber(ctx context.Context, streamID StreamId) (int64, error)
 
@@ -155,4 +160,17 @@ type DebugReadStreamDataResult struct {
 	Miniblocks                 []MiniblockDescriptor
 	Events                     []EventDescriptor
 	MbCandidates               []MiniblockDescriptor
+}
+
+type MiniblockCandidateStatisticsResult struct {
+	Hash     string
+	BlockNum int64
+}
+
+type DebugReadStreamStatisticsResult struct {
+	StreamId                   string
+	LatestMiniblockNum         int64
+	CurrentMiniblockCandidates []MiniblockCandidateStatisticsResult
+	NumMinipoolEvents          int64
+	LatestSnapshotMiniblockNum int64
 }


### PR DESCRIPTION
Add a debug endpoint for printing stream debug statistics:
- latest miniblock number
- last snapshot block number
- minipool length
- candidate hashes and block numbers

## Example with MB Candidates
![Screenshot 2025-01-02 at 6 14 03 PM](https://github.com/user-attachments/assets/b85b06d2-b1f7-4ab7-b156-fa8d6d8f99c0)

## Example, No MB Candidates
![Screenshot 2025-01-02 at 6 23 04 PM](https://github.com/user-attachments/assets/62d5efe7-e284-4687-8c67-d8921d441ff7)

## Stream Not Found (404)
![Screenshot 2025-01-02 at 6 25 10 PM](https://github.com/user-attachments/assets/b8eeb5d4-20e5-42e1-9449-486aaf0e3f36)

## Cannot parse stream id
![Screenshot 2025-01-02 at 6 27 51 PM](https://github.com/user-attachments/assets/45945495-2977-41f4-8e7f-0053bb8832a2)
