### PR TITLE
fix hypothetical mem free issue

### DIFF
--- a/core/node/mls_service/mls_service.go
+++ b/core/node/mls_service/mls_service.go
@@ -36,14 +36,13 @@ func makeMlsRequest(request *mls_tools.MlsRequest) ([]byte, error) {
 		&outputLen,
 	)
 
-	defer C.free_bytes(outputPtr, outputLen)
-
 	if retCode != 0 {
 		return nil, fmt.Errorf("error calling Rust function: %d", retCode)
 	}
 
 	// Convert the result to a Go slice
 	output := C.GoBytes(unsafe.Pointer(outputPtr), C.int(outputLen))
+	C.free_bytes(outputPtr, outputLen)
 	return output, nil
 }
 


### PR DESCRIPTION
I believe weird things can happen if `retCode != 0`. While we may have bigger issues if that happens, let's not make weird crashes one of those issues.

as a side note; the Go []byte returned by C.GoBytes is a _copy_ of the C memory content, `output` should be safe to use from the caller's perspective even if `C.free_bytes` was called on `outputPtr`.