### PR TITLE
pass encryption emitter to onConfirmedEvent

### DIFF
--- a/packages/sdk/src/streamStateView.ts
+++ b/packages/sdk/src/streamStateView.ts
@@ -422,12 +422,12 @@ export class StreamStateView implements IStreamStateView {
             check(isConfirmedEvent(event), `Event is not confirmed ${eventId}`)
             switch (event.remoteEvent.event.payload.case) {
                 case 'memberPayload':
-                    this.membershipContent.onConfirmedEvent(event, stateEmitter)
+                    this.membershipContent.onConfirmedEvent(event, stateEmitter, encryptionEmitter)
                     break
                 case undefined:
                     break
                 default:
-                    this.getContent().onConfirmedEvent(event, stateEmitter)
+                    this.getContent().onConfirmedEvent(event, stateEmitter, encryptionEmitter)
             }
             confirmed.push(event)
         }

--- a/packages/sdk/src/streamStateView_AbstractContent.ts
+++ b/packages/sdk/src/streamStateView_AbstractContent.ts
@@ -41,6 +41,7 @@ export abstract class StreamStateView_AbstractContent {
     onConfirmedEvent(
         _event: ConfirmedTimelineEvent,
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
+        _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ): void {
         //
     }

--- a/packages/sdk/src/streamStateView_DMChannel.ts
+++ b/packages/sdk/src/streamStateView_DMChannel.ts
@@ -107,8 +107,9 @@ export class StreamStateView_DMChannel extends StreamStateView_AbstractContent {
     onConfirmedEvent(
         event: ConfirmedTimelineEvent,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
+        encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ): void {
-        super.onConfirmedEvent(event, stateEmitter)
+        super.onConfirmedEvent(event, stateEmitter, encryptionEmitter)
     }
     onAppendLocalEvent(
         event: StreamTimelineEvent,

--- a/packages/sdk/src/streamStateView_GDMChannel.ts
+++ b/packages/sdk/src/streamStateView_GDMChannel.ts
@@ -117,8 +117,9 @@ export class StreamStateView_GDMChannel extends StreamStateView_AbstractContent 
     onConfirmedEvent(
         event: ConfirmedTimelineEvent,
         emitter: TypedEmitter<StreamEvents> | undefined,
+        encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ): void {
-        super.onConfirmedEvent(event, emitter)
+        super.onConfirmedEvent(event, emitter, encryptionEmitter)
     }
 
     onAppendLocalEvent(

--- a/packages/sdk/src/streamStateView_Members.ts
+++ b/packages/sdk/src/streamStateView_Members.ts
@@ -370,6 +370,7 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
     onConfirmedEvent(
         event: ConfirmedTimelineEvent,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
+        encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ): void {
         check(event.remoteEvent.event.payload.case === 'memberPayload')
         const payload: MemberPayload = event.remoteEvent.event.payload.value
@@ -412,6 +413,7 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
             case 'memberBlockchainTransaction':
                 break
             case 'mls':
+                this.mls.onConfirmedEvent(event, stateEmitter, encryptionEmitter)
                 break
             case 'encryptionAlgorithm':
                 break

--- a/packages/sdk/src/streamStateView_Mls.ts
+++ b/packages/sdk/src/streamStateView_Mls.ts
@@ -1,6 +1,6 @@
 import { StreamStateView_AbstractContent } from './streamStateView_AbstractContent'
 import TypedEmitter from 'typed-emitter'
-import { RemoteTimelineEvent } from './types'
+import { ConfirmedTimelineEvent, RemoteTimelineEvent } from './types'
 import { StreamEncryptionEvents, StreamStateEvents } from './streamEvents'
 import { MemberPayload_Snapshot_Mls, MemberPayload_Snapshot_Mls_Member } from '@river-build/proto'
 import { check } from '@river-build/dlog'
@@ -73,5 +73,13 @@ export class StreamStateView_Mls extends StreamStateView_AbstractContent {
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
         //
+    }
+
+    onConfirmedEvent(
+        event: ConfirmedTimelineEvent,
+        stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
+        encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
+    ): void {
+        super.onConfirmedEvent(event, stateEmitter, encryptionEmitter)
     }
 }

--- a/packages/sdk/src/streamStateView_UserInbox.ts
+++ b/packages/sdk/src/streamStateView_UserInbox.ts
@@ -39,8 +39,9 @@ export class StreamStateView_UserInbox extends StreamStateView_AbstractContent {
     onConfirmedEvent(
         event: ConfirmedTimelineEvent,
         emitter: TypedEmitter<StreamStateEvents> | undefined,
+        encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ): void {
-        super.onConfirmedEvent(event, emitter)
+        super.onConfirmedEvent(event, emitter, encryptionEmitter)
         const eventId = event.hashStr
         const payload = this.pendingGroupSessions[eventId]
         if (payload) {


### PR DESCRIPTION
MLS will require us to act on confirmed events, let's include the encryption emitter in the `onConfirmedEvent` function call.