### PR TITLE
migrate node from SetStreamLastMiniblock to SetStreamLastMiniblockBatch

### DIFF
--- a/core/node/registries/river_registry_contract.go
+++ b/core/node/registries/river_registry_contract.go
@@ -714,61 +714,6 @@ func (c *RiverRegistryContract) SetStreamLastMiniblockBatch(
 	return nil, nil, RiverError(Err_ERR_UNSPECIFIED, "SetStreamLastMiniblockBatch transaction result unknown")
 }
 
-func (c *RiverRegistryContract) SetStreamLastMiniblock(
-	ctx context.Context,
-	streamId StreamId,
-	prevMiniblockHash common.Hash,
-	lastMiniblockHash common.Hash,
-	lastMiniblockNum uint64,
-	isSealed bool,
-) error {
-	log := dlog.FromCtx(ctx)
-
-	pendingTx, err := c.Blockchain.TxPool.Submit(
-		ctx,
-		"SetStreamLastMiniblock",
-		func(opts *bind.TransactOpts) (*types.Transaction, error) {
-			tx, err := c.StreamRegistry.SetStreamLastMiniblock(
-				opts, streamId, prevMiniblockHash, lastMiniblockHash, lastMiniblockNum, isSealed)
-			if err == nil {
-				log.Debug(
-					"RiverRegistryContract: prepared transaction",
-					"name", "SetStreamLastMiniblock",
-					"streamId", streamId,
-					"prevMiniblockHash", prevMiniblockHash,
-					"lastMiniblockHash", lastMiniblockHash,
-					"lastMiniblockNum", lastMiniblockNum,
-					"isSealed", isSealed,
-					"txHash", tx.Hash(),
-				)
-			}
-			return tx, err
-		},
-	)
-	if err != nil {
-		return AsRiverError(err, Err_CANNOT_CALL_CONTRACT).
-			Func("SetStreamLastMiniblock").
-			Tags("streamId", streamId, "prevMiniblockHash", prevMiniblockHash, "lastMiniblockHash",
-				lastMiniblockHash, "lastMiniblockNum", lastMiniblockNum, "isSealed", isSealed)
-	}
-
-	receipt, err := pendingTx.Wait(ctx)
-	if err != nil {
-		return err
-	}
-
-	if receipt != nil && receipt.Status == crypto.TransactionResultSuccess {
-		return nil
-	}
-	if receipt != nil && receipt.Status != crypto.TransactionResultSuccess {
-		return RiverError(Err_ERR_UNSPECIFIED, "Set stream last mini block transaction failed").
-			Tag("tx", receipt.TxHash.Hex()).
-			Func("SetStreamLastMiniblock")
-	}
-
-	return RiverError(Err_ERR_UNSPECIFIED, "SetStreamLastMiniblock transaction result unknown")
-}
-
 type NodeRecord = river.Node
 
 func (c *RiverRegistryContract) GetAllNodes(ctx context.Context, blockNum crypto.BlockNumber) ([]NodeRecord, error) {

--- a/core/node/registries/river_registry_contract_test.go
+++ b/core/node/registries/river_registry_contract_test.go
@@ -294,15 +294,19 @@ func TestStreamEvents(t *testing.T) {
 
 	// Update last miniblock
 	newMBHash := common.HexToHash("0x456")
-	err = rr1.SetStreamLastMiniblock(
+	succeeded, failed, err := rr1.SetStreamLastMiniblockBatch(
 		ctx,
-		streamId,
-		genesisHash,
-		newMBHash,
-		1,
-		false,
+		[]river.SetMiniblock{{
+			StreamId:          streamId,
+			PrevMiniBlockHash: genesisHash,
+			LastMiniblockHash: newMBHash,
+			LastMiniblockNum:  1,
+			IsSealed:          false,
+		}},
 	)
 	require.NoError(err)
+	require.Len(succeeded, 1)
+	require.Empty(failed)
 
 	lastMB := <-lastMBC
 	require.NotNil(lastMB)
@@ -314,7 +318,7 @@ func TestStreamEvents(t *testing.T) {
 	require.Len(placementC, 0)
 
 	newMBHash2 := common.HexToHash("0x789")
-	succeeded, failed, err := rr1.SetStreamLastMiniblockBatch(
+	succeeded, failed, err = rr1.SetStreamLastMiniblockBatch(
 		ctx,
 		[]river.SetMiniblock{{
 			StreamId:          streamId,


### PR DESCRIPTION
Before `SetStreamLastMiniblock` can be dropped from the stream registry the node to migrate to the batched version. This change replaces all `SetStreamLastMiniblock` calls with `SetStreamLastMiniblockBatch`.

Follow up action, when the stream registry facet is updated the ABI + generated bindings must be upgraded. 