### PR TITLE
notification service: bugfix tracking membership in new towns

### DIFF
--- a/core/node/events/notifications_stream_tracker.go
+++ b/core/node/events/notifications_stream_tracker.go
@@ -1,17 +1,13 @@
 package events
 
 import (
-	"bytes"
 	"context"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/ethereum/go-ethereum/common"
-
-	. "github.com/river-build/river/core/node/base"
 	"github.com/river-build/river/core/node/crypto"
 	. "github.com/river-build/river/core/node/protocol"
 	"github.com/river-build/river/core/node/shared"
-	"github.com/river-build/river/core/node/utils"
 )
 
 type (
@@ -90,17 +86,25 @@ func NewNotificationsStreamTrackerFromStreamAndCookie(
 	return ts, nil
 }
 
-func (ts *TrackedNotificationStreamView) HandleEvent(
+func (ts *TrackedNotificationStreamView) ApplyBlock(
+	miniblock *Miniblock,
+	cfg *crypto.OnChainSettings,
+) error {
+	mb, err := NewMiniblockInfoFromProto(miniblock, NewMiniblockInfoFromProtoOpts{ExpectedBlockNumber: -1})
+	if err != nil {
+		return err
+	}
+
+	return ts.applyBlock(mb, cfg)
+}
+
+func (ts *TrackedNotificationStreamView) ApplyEvent(
 	ctx context.Context,
 	event *Envelope,
 ) error {
 	parsedEvent, err := ParseEvent(event)
 	if err != nil {
 		return err
-	}
-
-	if parsedEvent.Event.GetMiniblockHeader() != nil { // clean up minipool
-		return ts.applyMiniblockHeader(parsedEvent)
 	}
 
 	// add event calls the message listener that send notifications when needed
@@ -111,8 +115,21 @@ func (ts *TrackedNotificationStreamView) LatestSyncCookie() *SyncCookie {
 	return ts.view.SyncCookie(common.Address{})
 }
 
+func (ts *TrackedNotificationStreamView) applyBlock(
+	miniblock *MiniblockInfo,
+	cfg *crypto.OnChainSettings,
+) error {
+	view, _, err := ts.view.copyAndApplyBlock(miniblock, cfg)
+	if err != nil {
+		return err
+	}
+
+	ts.view = view
+	return nil
+}
+
 func (ts *TrackedNotificationStreamView) addEvent(ctx context.Context, event *ParsedEvent) error {
-	if ts.view.minipool.events.Has(event.Hash) {
+	if ts.view.minipool.events.Has(event.Hash) || event.Event.GetMiniblockHeader() != nil {
 		return nil
 	}
 
@@ -147,89 +164,6 @@ func (ts *TrackedNotificationStreamView) addEvent(ctx context.Context, event *Pa
 	}
 
 	ts.listener.OnMessageEvent(ctx, ts.streamID, view.StreamParentId(), members, event)
-
-	return nil
-}
-
-func (ts *TrackedNotificationStreamView) applyMiniblockHeader(event *ParsedEvent) error {
-	lastBlock := ts.view.LastBlock()
-	header := event.Event.GetMiniblockHeader()
-
-	if header.MiniblockNum != lastBlock.Header().MiniblockNum+1 {
-		return RiverError(
-			Err_BAD_BLOCK,
-			"streamViewImpl: block number mismatch",
-			"expected",
-			lastBlock.Header().MiniblockNum+1,
-			"actual",
-			header.MiniblockNum,
-		)
-	}
-
-	if !bytes.Equal(lastBlock.headerEvent.Hash[:], header.PrevMiniblockHash) {
-		return RiverError(
-			Err_BAD_BLOCK,
-			"streamViewImpl: block hash mismatch",
-			"expected",
-			FormatHash(lastBlock.headerEvent.Hash),
-			"actual",
-			FormatHashFromBytes(header.PrevMiniblockHash),
-		)
-	}
-
-	// drop events from minipool that are included in this miniblock
-	remaining := make(map[common.Hash]*ParsedEvent, max(ts.view.minipool.events.Len()-len(header.EventHashes), 0))
-	for k, v := range ts.view.minipool.events.Map {
-		remaining[k] = v
-	}
-
-	for _, e := range header.EventHashes {
-		h := common.BytesToHash(e)
-		delete(remaining, h)
-	}
-
-	minipoolEvents := utils.NewOrderedMap[common.Hash, *ParsedEvent](len(remaining))
-	for _, e := range ts.view.minipool.events.Values {
-		if _, ok := remaining[e.Hash]; ok {
-			if !minipoolEvents.Set(e.Hash, e) {
-				panic("duplicate values in map")
-			}
-		}
-	}
-
-	var startIndex int
-	var snapshotIndex int
-	var snapshot *Snapshot
-	recencyConstraintsGenerations := int(ts.cfg.Get().RecencyConstraintsGen)
-	if header.Snapshot != nil {
-		snapshot = header.Snapshot
-		startIndex = max(0, len(ts.view.blocks)-recencyConstraintsGenerations)
-		snapshotIndex = len(ts.view.blocks) - startIndex
-	} else {
-		startIndex = 0
-		snapshot = ts.view.snapshot
-		snapshotIndex = ts.view.snapshotIndex
-	}
-
-	generation := header.MiniblockNum + 1
-	eventNumOffset := header.EventNumOffset + int64(len(header.EventHashes)) + 1 // plus one for header
-
-	miniblock := &MiniblockInfo{
-		Ref: &shared.MiniblockRef{
-			Hash: event.Hash,
-			Num:  header.MiniblockNum,
-		},
-		headerEvent: event,
-		Proto:       &Miniblock{}, // individual events are processed/tracked
-	}
-
-	ts.view = &streamViewImpl{
-		streamId:      ts.view.streamId,
-		blocks:        append(ts.view.blocks[startIndex:], miniblock),
-		minipool:      newMiniPoolInstance(minipoolEvents, generation, eventNumOffset),
-		snapshot:      snapshot,
-		snapshotIndex: snapshotIndex,
-	}
 
 	return nil
 }

--- a/core/node/notifications/sync/streams_tracker_worker_connectgo.go
+++ b/core/node/notifications/sync/streams_tracker_worker_connectgo.go
@@ -270,10 +270,15 @@ func (s *StreamTrackerConnectGo) Run(
 					continue
 				}
 
-				// apply update
+				for _, block := range update.GetStream().GetMiniblocks() {
+					if err := trackedStream.ApplyBlock(block, onChainConfig.Get()); err != nil {
+						log.Error("Unable to apply block", "stream", streamID, "err", err)
+					}
+				}
+
 				for _, event := range update.GetStream().GetEvents() {
-					if err := trackedStream.HandleEvent(syncCtx, event); err != nil {
-						log.Error("Unable to handle event", "stream", streamID, "err", err)
+					if err := trackedStream.ApplyEvent(syncCtx, event); err != nil {
+						log.Error("Unable to apply event", "stream", streamID, "err", err)
 					}
 				}
 


### PR DESCRIPTION
Currently the notification service doesn't handle sync updates that include miniblocks. The result is that once events are dropped from the minipool calculating the stream membership must be done from `snapshot + blocks + minipool` but is done from `snapshot + minipool`.

For notifications this is not an issue because these are handled immediately when the notification service receives them through a sync update. For user membership it needs to respect join/leave events in miniblocks.

This PR adds an unittest that hits the problem and introduces the `ApplyBlock` function that is called for incoming miniblocks.