### PR TITLE
Group Encryption Refactor 2: Split the alogrithms into basic/group, remove goofy defines

### DIFF
--- a/packages/encryption/src/decryptionExtensions.ts
+++ b/packages/encryption/src/decryptionExtensions.ts
@@ -14,7 +14,7 @@ import {
     check,
     bin_toHexString,
 } from '@river-build/dlog'
-import { GROUP_ENCRYPTION_ALGORITHM, GroupEncryptionSession, UserDevice } from './olmLib'
+import { GroupEncryptionAlgorithmId, GroupEncryptionSession, UserDevice } from './olmLib'
 import { GroupEncryptionCrypto } from './groupEncryptionCrypto'
 
 export interface EntitlementsDelegate {
@@ -546,7 +546,7 @@ export abstract class BaseDecryptionExtensions {
                     streamId: streamId,
                     sessionId: session.sessionIds[i],
                     sessionKey: sessionKeys.keys[i],
-                    algorithm: GROUP_ENCRYPTION_ALGORITHM,
+                    algorithm: GroupEncryptionAlgorithmId.GroupEncryption,
                 } satisfies GroupEncryptionSession),
         )
         // import the sessions

--- a/packages/encryption/src/encryptionDevice.ts
+++ b/packages/encryption/src/encryptionDevice.ts
@@ -8,7 +8,7 @@ import {
     Utility,
 } from './encryptionTypes'
 import { EncryptionDelegate } from './encryptionDelegate'
-import { GROUP_ENCRYPTION_ALGORITHM, GroupEncryptionSession } from './olmLib'
+import { GroupEncryptionAlgorithmId, GroupEncryptionSession } from './olmLib'
 import { dlog } from '@river-build/dlog'
 import type { ExtendedInboundGroupSessionData, GroupSessionRecord } from './storeTypes'
 
@@ -729,7 +729,7 @@ export class EncryptionDevice {
             streamId: streamId,
             sessionId: sessionId,
             sessionKey: sessionKey,
-            algorithm: GROUP_ENCRYPTION_ALGORITHM,
+            algorithm: GroupEncryptionAlgorithmId.GroupEncryption,
         }
     }
 
@@ -757,7 +757,7 @@ export class EncryptionDevice {
                     streamId: sessionData.streamId,
                     sessionId: sessionData.sessionId,
                     sessionKey: sessionKey,
-                    algorithm: GROUP_ENCRYPTION_ALGORITHM,
+                    algorithm: GroupEncryptionAlgorithmId.GroupEncryption,
                 })
             }
         })

--- a/packages/encryption/src/groupEncryption.ts
+++ b/packages/encryption/src/groupEncryption.ts
@@ -1,7 +1,7 @@
 import { EncryptedData } from '@river-build/proto'
 import { PlainMessage } from '@bufbuild/protobuf'
 import { EncryptionAlgorithm, IEncryptionParams } from './base'
-import { GROUP_ENCRYPTION_ALGORITHM } from './olmLib'
+import { GroupEncryptionAlgorithmId } from './olmLib'
 import { dlog } from '@river-build/dlog'
 
 const log = dlog('csb:encryption:groupEncryption')
@@ -79,7 +79,7 @@ export class GroupEncryption extends EncryptionAlgorithm {
         const result = await this.device.encryptGroupMessage(payload, streamId)
 
         return new EncryptedData({
-            algorithm: GROUP_ENCRYPTION_ALGORITHM,
+            algorithm: GroupEncryptionAlgorithmId.GroupEncryption,
             senderKey: this.device.deviceCurve25519Key!,
             ciphertext: result.ciphertext,
             sessionId: result.sessionId,

--- a/packages/encryption/src/olmLib.ts
+++ b/packages/encryption/src/olmLib.ts
@@ -7,20 +7,14 @@ globalThis.OLM_OPTIONS = {}
  */
 
 // Supported algorithms
-enum Algorithm {
+export enum EncryptionAlgorithmId {
     Olm = 'r.olm.v1.curve25519-aes-sha2',
-    GroupEncryption = 'r.group-encryption.v1.aes-sha2',
 }
 
-/**
- * river algorithm tag for olm
- */
-export const OLM_ALGORITHM = Algorithm.Olm
-
-/**
- * river algorithm tag for group encryption
- */
-export const GROUP_ENCRYPTION_ALGORITHM = Algorithm.GroupEncryption
+export enum GroupEncryptionAlgorithmId {
+    // group olm encryption based on signal protocol with ratcheting
+    GroupEncryption = 'r.group-encryption.v1.aes-sha2',
+}
 
 export interface UserDevice {
     deviceKey: string
@@ -35,5 +29,5 @@ export interface GroupEncryptionSession {
     streamId: string
     sessionId: string
     sessionKey: string
-    algorithm: string
+    algorithm: GroupEncryptionAlgorithmId
 }

--- a/packages/sdk/src/tests/multi_ne/userInboxMessage.test.ts
+++ b/packages/sdk/src/tests/multi_ne/userInboxMessage.test.ts
@@ -5,7 +5,7 @@
 import { Client } from '../../client'
 import { makeDonePromise, makeTestClient, makeUniqueSpaceStreamId } from '../testUtils'
 import { dlog } from '@river-build/dlog'
-import { UserDeviceCollection } from '@river-build/encryption'
+import { GroupEncryptionAlgorithmId, UserDeviceCollection } from '@river-build/encryption'
 import { UserInboxPayload_GroupEncryptionSessions } from '@river-build/proto'
 import { makeUniqueChannelStreamId, streamIdAsString } from '../../id'
 
@@ -65,7 +65,7 @@ describe('inboxMessageTest', () => {
                         streamId: fakeStreamId,
                         sessionId: '300',
                         sessionKey: '400',
-                        algorithm: '',
+                        algorithm: GroupEncryptionAlgorithmId.GroupEncryption,
                     },
                 ],
                 recipients,


### PR DESCRIPTION
we don't need these goofy defines, just use enums