### PR TITLE
unittest: fix flaky notifications test

### DIFF
--- a/core/node/notifications/sync/streams_tracker.go
+++ b/core/node/notifications/sync/streams_tracker.go
@@ -168,7 +168,7 @@ func (tracker *StreamsTracker) Run(ctx context.Context) error {
 				go func() {
 					st := StreamTrackerConnectGo{}
 					idx := rand.Int63n(int64(len(tracker.nodeRegistries)))
-					st.Run(ctx, stream, tracker.nodeRegistries[idx], workerPool, tracker.onChainConfig,
+					st.Run(ctx, stream, false, tracker.nodeRegistries[idx], workerPool, tracker.onChainConfig,
 						tracker.listener, tracker.storage, tracker.metrics,
 					)
 				}()
@@ -232,7 +232,7 @@ func (tracker *StreamsTracker) OnStreamAllocated(
 			}
 
 			idx := rand.Int63n(int64(len(tracker.nodeRegistries)))
-			st.Run(ctx, stream, tracker.nodeRegistries[idx], workerPool,
+			st.Run(ctx, stream, true, tracker.nodeRegistries[idx], workerPool,
 				tracker.onChainConfig, tracker.listener, tracker.storage, tracker.metrics)
 		}()
 	}

--- a/core/node/rpc/notification_test.go
+++ b/core/node/rpc/notification_test.go
@@ -429,7 +429,7 @@ func testDMMessageWithDefaultUserNotificationsPreferences(
 
 		return cmp.Equal(webNotifications, expectedUsersToReceiveNotification) &&
 			cmp.Equal(apnNotifications, expectedUsersToReceiveNotification)
-	}, notificationDeliveryDelay, 100*time.Millisecond, "Didn't receive expected notifications for stream %s", test.dmStreamID[:])
+	}, notificationDeliveryDelay, 100*time.Millisecond, "Didn't receive expected notifications for stream %s", test.dmStreamID)
 
 	// Wait a bit to ensure that no more notifications come in
 	test.req.Never(func() bool {
@@ -443,7 +443,7 @@ func testDMMessageWithDefaultUserNotificationsPreferences(
 
 		return webCount != len(expectedUsersToReceiveNotification) ||
 			apnCount != len(expectedUsersToReceiveNotification)
-	}, time.Second, 100*time.Millisecond, "Received unexpected notifications")
+	}, 3*time.Second, 100*time.Millisecond, "Received unexpected notifications")
 }
 
 func testDMMessageWithBlockedUser(


### PR DESCRIPTION
```
--- FAIL: TestNotifications (0.74s)
    --- FAIL: TestNotifications/DMNotifications (35.77s)
        --- FAIL: TestNotifications/DMNotifications/MessageWithDefaultUserNotificationsPreferences (30.80s)
```

Not able to reproduce the issue locally but a possible scenario is:

- Notification service listens for StreamAllocated event. This is done by polling the chain for these events and can take some time. After it got the event it subscribes for sync updates and ignores all miniblocks/events that it got from the sync reset and starts only processing new incoming updates/events for notifications. This is to prevent sending duplicate notifications for events.
- During test initialisation a new stream is allocated and immediately events are sent to it. The test starts listening for notification for these events. Sometimes these notifications are not received. Possible issue is that these events are so fast and included in the sync reset the notification service receives as first update and ignores.

This change distinguishes between streams that the notification service will track between streams that already exists for a while and streams that are just allocated. For just allocated streams the notification service will process events in miniblocks/minipool that it got in the sync reset when subscribing. For streams that already exists it will ignore these to prevent sending notifications multiple times for the same stream.




