### PR TITLE
fix(web3): bump `createSpace` gas limit

### DIFF
--- a/packages/web3/src/v3/SpaceDapp.ts
+++ b/packages/web3/src/v3/SpaceDapp.ts
@@ -332,25 +332,29 @@ export class SpaceDapp implements ISpaceDapp {
         txnOpts?: TransactionOpts,
     ): Promise<ContractTransaction> {
         return wrapTransaction(() => {
-            const createSpaceFunction = this.spaceRegistrar.CreateSpace.write(signer)[
-                'createSpaceWithPrepay(((string,string,string,string),((string,string,uint256,uint256,uint64,address,address,uint256,address),(bool,address[],bytes,bool),string[]),(string),(uint256)))'
-            ] as (arg: any) => Promise<ContractTransaction>
+            const createSpaceFunction =
+                this.spaceRegistrar.CreateSpace.write(signer)[
+                    'createSpaceWithPrepay(((string,string,string,string),((string,string,uint256,uint256,uint64,address,address,uint256,address),(bool,address[],bytes,bool),string[]),(string),(uint256)))'
+                ]
 
-            return createSpaceFunction({
-                channel: {
-                    metadata: params.channelName || '',
+            return createSpaceFunction(
+                {
+                    channel: {
+                        metadata: params.channelName || '',
+                    },
+                    membership: params.membership,
+                    metadata: {
+                        name: params.spaceName,
+                        uri: params.uri,
+                        longDescription: params.longDescription || '',
+                        shortDescription: params.shortDescription || '',
+                    },
+                    prepay: {
+                        supply: params.prepaySupply ?? 0,
+                    },
                 },
-                membership: params.membership,
-                metadata: {
-                    name: params.spaceName,
-                    uri: params.uri,
-                    longDescription: params.longDescription || '',
-                    shortDescription: params.shortDescription || '',
-                },
-                prepay: {
-                    supply: params.prepaySupply ?? 0,
-                },
-            })
+                { gasLimit: 50_000 },
+            )
         }, txnOpts)
     }
 


### PR DESCRIPTION
Previously, we're getting: `Transaction failed after retries: cannot estimate gas` in the playground app while trying to create a space on omega network due to the default gas limit. 

This PR bumps the gas limit to `50_000`