### PR TITLE
Ignore Rust target directory

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -55,3 +55,5 @@ packages/proto/src/protocol_*.ts
 packages/workers/**/*.json
 
 mls/*
+core/mls/mls-tools/target/*
+


### PR DESCRIPTION
Running `yarn prettier:check` will give false positives if `mls-tools` was built.