### PR TITLE
Hybrid group encryption fixes

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -2181,7 +2181,7 @@ export class Client
         check(isDefined(streamView.miniblockInfo), `stream not initialized: ${streamId}`)
         check(isDefined(streamView.prevMiniblockHash), `prevMiniblockHash not found: ${streamId}`)
         return {
-            miniblockNum: streamView.miniblockInfo.min,
+            miniblockNum: streamView.miniblockInfo.max,
             miniblockHash: streamView.prevMiniblockHash,
         }
     }


### PR DESCRIPTION
1. Use miniblockInfo.max instead of .min. this was a typo
2. Only send one key fulfillment. For the case of isNewDevice, any subsequent key fulfillment will get rejected, and this is more effecient all around.