### PR TITLE
[RIVER-2049] Add sampling for archiver logs

### DIFF
--- a/core/cmd/archive_cmd.go
+++ b/core/cmd/archive_cmd.go
@@ -4,13 +4,19 @@ import (
 	"context"
 
 	"github.com/river-build/river/core/config"
+	"github.com/river-build/river/core/node/logging"
 	"github.com/river-build/river/core/node/rpc"
+	"go.uber.org/zap"
 
 	"github.com/spf13/cobra"
 )
 
 func runArchive(cfg *config.Config, once bool) error {
 	err := setupProfiler("archive-node", cfg)
+
+	// Enable sampling for archiver logs.
+	zap.ReplaceGlobals(logging.SampledLogger(zap.L()))
+
 	if err != nil {
 		return err
 	}

--- a/core/node/logging/sampling.go
+++ b/core/node/logging/sampling.go
@@ -1,0 +1,23 @@
+package logging
+
+import (
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// SampledLogger returns a modified version of the input log that samples the logs
+// using zap's sampling algorithm, which drops logs with identical messages within
+// a time period after a threshold of identical logs is met. The sampling here is
+// configured to drop 95% of logs after 10 of the same log message is seen in 10
+// seconds.
+func SampledLogger(log *zap.Logger) *zap.Logger {
+	return log.WithOptions(
+		zap.WrapCore(
+			func(core zapcore.Core) zapcore.Core {
+				return zapcore.NewSamplerWithOptions(core, 10*time.Second, 10, 20)
+			},
+		),
+	)
+}


### PR DESCRIPTION
This sampler will drop 95% of logs after a threshold of 10 logs of the same message has been met within a 10 second interval. Note that the sampler disregards context keys, e.g. two logs with the same message and different fields count towards the same threshold.

@mechanical-turk let me know if this looks reasonable, I can tune these numbers. The goal is to not filter on datadog because we want to guarantee we're seeing all of the errors.

I tested this locally by printing 50 log messages from the archiver on start, I see exactly what I expect. Sampling appears to work!

```
{"level":"INFO","timestamp":"2025-01-17T15:28:58.674-0800","msg":"Is this log message filtered?","instanceId":"bDlEpM3hKR0T","mode":"archive","nodeType":"stream","i":0}
{"level":"INFO","timestamp":"2025-01-17T15:28:58.674-0800","msg":"Is this log message filtered?","instanceId":"bDlEpM3hKR0T","mode":"archive","nodeType":"stream","i":1}
{"level":"INFO","timestamp":"2025-01-17T15:28:58.674-0800","msg":"Is this log message filtered?","instanceId":"bDlEpM3hKR0T","mode":"archive","nodeType":"stream","i":2}
{"level":"INFO","timestamp":"2025-01-17T15:28:58.674-0800","msg":"Is this log message filtered?","instanceId":"bDlEpM3hKR0T","mode":"archive","nodeType":"stream","i":3}
{"level":"INFO","timestamp":"2025-01-17T15:28:58.674-0800","msg":"Is this log message filtered?","instanceId":"bDlEpM3hKR0T","mode":"archive","nodeType":"stream","i":4}
{"level":"INFO","timestamp":"2025-01-17T15:28:58.674-0800","msg":"Is this log message filtered?","instanceId":"bDlEpM3hKR0T","mode":"archive","nodeType":"stream","i":5}
{"level":"INFO","timestamp":"2025-01-17T15:28:58.674-0800","msg":"Is this log message filtered?","instanceId":"bDlEpM3hKR0T","mode":"archive","nodeType":"stream","i":6}
{"level":"INFO","timestamp":"2025-01-17T15:28:58.674-0800","msg":"Is this log message filtered?","instanceId":"bDlEpM3hKR0T","mode":"archive","nodeType":"stream","i":7}
{"level":"INFO","timestamp":"2025-01-17T15:28:58.674-0800","msg":"Is this log message filtered?","instanceId":"bDlEpM3hKR0T","mode":"archive","nodeType":"stream","i":8}
{"level":"INFO","timestamp":"2025-01-17T15:28:58.674-0800","msg":"Is this log message filtered?","instanceId":"bDlEpM3hKR0T","mode":"archive","nodeType":"stream","i":9}
{"level":"INFO","timestamp":"2025-01-17T15:28:58.674-0800","msg":"Is this log message filtered?","instanceId":"bDlEpM3hKR0T","mode":"archive","nodeType":"stream","i":29}
{"level":"INFO","timestamp":"2025-01-17T15:28:58.674-0800","msg":"Is this log message filtered?","instanceId":"bDlEpM3hKR0T","mode":"archive","nodeType":"stream","i":49}
{"level":"INFO","timestamp":"2025-01-17T15:28:58.674-0800","msg":"Server started","instanceId":"bDlEpM3hKR0T","mode":"archive","nodeType":"stream","port":4040,"https":false,"url":"http://localhost:4040/debug/multi"}
```