### PR TITLE
fix just file “run-go” command for new mls requirements

### DIFF
--- a/core/justfile
+++ b/core/justfile
@@ -195,6 +195,7 @@ run-go *args: _require_run_env
     source ${ENV_FILE}
     cd ${RUN_BASE}
     mkdir -p logs
+    CGO_LDFLAGS="-L./bin" \
     go run ../../river_node/main.go \
         --config common.yaml \
         --config config.yaml \


### PR DESCRIPTION
fixes
```
ld: library not found for -lmls_lib
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```