### PR TITLE
[RIVER-2085] Omit sensitive fields from notifications config

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -368,14 +368,14 @@ type APNPushNotificationsConfig struct {
 	// TeamID from developer account (View Account -> Membership)
 	TeamID string
 	// AuthKey contains the private key to authenticate the notification service with the APN service
-	AuthKey string
+	AuthKey string `json:"-" yaml:"-"` // Omit sensitive field from logging
 }
 
 type WebPushVapidNotificationConfig struct {
 	// PrivateKey is the private key of the public key that is shared with the client
 	// and used to sign push notifications that allows the client to verify the incoming
 	// notification for origin and validity.
-	PrivateKey string
+	PrivateKey string `json:"-" yaml:"-"` // Omit sensitive field from logging
 	// PublicKey as shared with the client that is used for subscribing and verifying
 	// the incoming push notification.
 	PublicKey string
@@ -385,6 +385,27 @@ type WebPushVapidNotificationConfig struct {
 
 type WebPushNotificationConfig struct {
 	Vapid WebPushVapidNotificationConfig
+}
+
+type SessionKeyConfig struct {
+	// Algorithm indicates how the session token is signed (only HS256 is supported)
+	Algorithm string
+	// Key holds the hex encoded key
+	Key string
+}
+
+type SessionTokenConfig struct {
+	// Lifetime indicates how long a session token is valid (default=30m).
+	Lifetime time.Duration
+	// Key holds the secret key that is used to sign the session token.
+	Key SessionKeyConfig `json:"-" yaml:"-"` // Omit sensitive field from logging
+}
+
+type AuthenticationConfig struct {
+	// ChallengeTimeout is the lifetime an authentication challenge is valid (default=30s).
+	ChallengeTimeout time.Duration
+	// SessionTokenKey contains the configuration for the JWT session token.
+	SessionToken SessionTokenConfig
 }
 
 type NotificationsConfig struct {
@@ -401,22 +422,7 @@ type NotificationsConfig struct {
 	Web WebPushNotificationConfig `mapstructure:"webpush"`
 
 	// Authentication holds configuration for the Client API authentication service.
-	Authentication struct {
-		// ChallengeTimeout is the lifetime an authentication challenge is valid (default=30s).
-		ChallengeTimeout time.Duration
-		// SessionTokenKey contains the configuration for the JWT session token.
-		SessionToken struct {
-			// Lifetime indicates how long a session token is valid (default=30m).
-			Lifetime time.Duration
-			// Key holds the secret key that is used to sign the session token.
-			Key struct {
-				// Algorithm indicates how the session token is signed (only HS256 is supported)
-				Algorithm string
-				// Key holds the hex encoded key
-				Key string
-			}
-		}
-	}
+	Authentication AuthenticationConfig
 }
 
 type LogConfig struct {

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -62,3 +62,70 @@ func TestTlsConfig_KeyDoesNotLog(t *testing.T) {
 	// Assert output is as expected: TLS Key is not logged, other fields included
 	require.Equal(t, expected, logOutput)
 }
+
+func TestNotificationsConfig_SensitiveKeysDontLog(t *testing.T) {
+	cfg := config.NotificationsConfig{
+		APN: config.APNPushNotificationsConfig{
+			AuthKey: "APN_AUTH_KEY",
+		},
+		Web: config.WebPushNotificationConfig{
+			Vapid: config.WebPushVapidNotificationConfig{
+				PrivateKey: "WEB_VAPID_PRIVATE_KEY",
+			},
+		},
+		Authentication: config.AuthenticationConfig{
+			SessionToken: config.SessionTokenConfig{
+				Key: config.SessionKeyConfig{
+					Algorithm: "SESSION_KEY_ALGORITHM",
+					Key:       "SESSION_KEY",
+				},
+			},
+		},
+	}
+
+	// Log cfg to buffer
+	logger, buffer := testutils.ZapJsonLogger()
+	logger.Infow("test message", "notificationsConfig", cfg)
+
+	logOutput := buffer.String()
+	require := require.New(t)
+
+	require.NotContains(logOutput, "APN_AUTH_KEY", "Expected APN_AUTH_KEY to be omitted from logOutput `%v`", logOutput)
+	require.NotContains(
+		logOutput,
+		"WEB_VAPID_PRIVATE_KEY",
+		"Expected WEB_VAPID_PRIVATE_KEY to be omitted from logOutput `%v`",
+		logOutput,
+	)
+	require.NotContains(
+		logOutput,
+		"SESSION_KEY_ALGORITHM",
+		"Expected SESSION_KEY_ALGORITHM to be omitted from logOutput `%v`",
+		logOutput,
+	)
+	require.NotContains(logOutput, "SESSION_KEY", "Expected SESSION_KEY to be omitted from logOutput `%v`", logOutput)
+}
+
+func TestConfig_ChainProvidersDoNotLog(t *testing.T) {
+	cfg := config.Config{
+		// In practice both of these fields would contain private information in key:value pairs separated
+		// by commas, but we really just don't want to see whatever the value is in the log output.
+		Chains:       "CHAINS",
+		ChainsString: "CHAINS_STRING",
+	}
+
+	// Log cfg to buffer
+	logger, buffer := testutils.ZapJsonLogger()
+	logger.Infow("test message", "config", cfg)
+
+	logOutput := buffer.String()
+	require := require.New(t)
+
+	require.NotContains(
+		logOutput,
+		"CHAINS_STRING",
+		"Expected CHAINS_STRING to be omitted from logOutput `%v`",
+		logOutput,
+	)
+	require.NotContains(logOutput, "CHAINS", "Expected CHAINS to be omitted from logOutput `%v`", logOutput)
+}


### PR DESCRIPTION
Bonus: add some test coverage for the top-level config.