### PR TITLE
Fix CGO so that testing from VSCode work

### DIFF
--- a/core/node/mls_service/mls_service.go
+++ b/core/node/mls_service/mls_service.go
@@ -1,7 +1,7 @@
 package mls_service
 
 /*
-#cgo LDFLAGS: -lmls_lib
+#cgo LDFLAGS: -L${SRCDIR}/../../mls/mls-tools/target/release -lmls_lib
 #include <stdlib.h>
 #include <stdint.h>
 


### PR DESCRIPTION
Remember to build Rust library using `just build`.