### PR TITLE
Update event tags to allow tag forwarding

### DIFF
--- a/core/node/rpc/add_event.go
+++ b/core/node/rpc/add_event.go
@@ -98,6 +98,7 @@ func (s *Service) addParsedEvent(
 					ctx,
 					sideEffects.OnChainAuthFailure.StreamId,
 					sideEffects.OnChainAuthFailure.Payload,
+					sideEffects.OnChainAuthFailure.Tags,
 				)
 				if err != nil {
 					return err
@@ -128,7 +129,12 @@ func (s *Service) addParsedEvent(
 	}
 
 	if sideEffects.RequiredParentEvent != nil {
-		err := s.AddEventPayload(ctx, sideEffects.RequiredParentEvent.StreamId, sideEffects.RequiredParentEvent.Payload)
+		err := s.AddEventPayload(
+			ctx,
+			sideEffects.RequiredParentEvent.StreamId,
+			sideEffects.RequiredParentEvent.Payload,
+			sideEffects.RequiredParentEvent.Tags,
+		)
 		if err != nil {
 			return err
 		}
@@ -149,7 +155,12 @@ func (s *Service) addParsedEvent(
 	return nil
 }
 
-func (s *Service) AddEventPayload(ctx context.Context, streamId StreamId, payload IsStreamEvent_Payload) error {
+func (s *Service) AddEventPayload(
+	ctx context.Context,
+	streamId StreamId,
+	payload IsStreamEvent_Payload,
+	tags *Tags,
+) error {
 	hashRequest := &GetLastMiniblockHashRequest{
 		StreamId: streamId[:],
 	}
@@ -157,10 +168,10 @@ func (s *Service) AddEventPayload(ctx context.Context, streamId StreamId, payloa
 	if err != nil {
 		return err
 	}
-	envelope, err := MakeEnvelopeWithPayload(s.wallet, payload, &MiniblockRef{
+	envelope, err := MakeEnvelopeWithPayloadAndTags(s.wallet, payload, &MiniblockRef{
 		Hash: common.BytesToHash(hashResponse.Msg.Hash),
 		Num:  hashResponse.Msg.MiniblockNum,
-	})
+	}, tags)
 	if err != nil {
 		return err
 	}

--- a/core/node/rpc/create_stream.go
+++ b/core/node/rpc/create_stream.go
@@ -136,7 +136,7 @@ func (s *Service) createStream(ctx context.Context, req *CreateStreamRequest) (*
 	// add derived events
 	if csRules.DerivedEvents != nil {
 		for _, de := range csRules.DerivedEvents {
-			err := s.AddEventPayload(ctx, de.StreamId, de.Payload)
+			err := s.AddEventPayload(ctx, de.StreamId, de.Payload, de.Tags)
 			if err != nil {
 				return nil, RiverError(Err_INTERNAL, "failed to add derived event", "err", err)
 			}

--- a/core/node/rpc/membership_scrub_test.go
+++ b/core/node/rpc/membership_scrub_test.go
@@ -155,8 +155,9 @@ func (o *ObservingEventAdder) AddEventPayload(
 	ctx context.Context,
 	streamId StreamId,
 	payload IsStreamEvent_Payload,
+	tags *Tags,
 ) error {
-	err := o.adder.AddEventPayload(ctx, streamId, payload)
+	err := o.adder.AddEventPayload(ctx, streamId, payload, tags)
 	if err != nil {
 		return err
 	}

--- a/core/node/rules/rule_builder.go
+++ b/core/node/rules/rule_builder.go
@@ -14,6 +14,7 @@ import (
 type DerivedEvent struct {
 	Payload  IsStreamEvent_Payload
 	StreamId shared.StreamId
+	Tags     *Tags
 }
 
 func unknownPayloadType(payload any) error {

--- a/core/node/scrub/stream_membership_scrub_task.go
+++ b/core/node/scrub/stream_membership_scrub_task.go
@@ -21,7 +21,7 @@ import (
 )
 
 type EventAdder interface {
-	AddEventPayload(ctx context.Context, streamId StreamId, payload IsStreamEvent_Payload) error
+	AddEventPayload(ctx context.Context, streamId StreamId, payload IsStreamEvent_Payload, tags *Tags) error
 }
 
 type streamMembershipScrubTaskProcessorImpl struct {
@@ -163,6 +163,7 @@ func (tp *streamMembershipScrubTaskProcessorImpl) processMemberImpl(
 				&member,
 				spaceId[:],
 			),
+			nil,
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
Tags allow us to signal to the notification service to deliver notifications.
In the case of tips, we add an event to the user stream, which adds an event to the recipient's stream, which adds an event to the channel
I will update the derived events created by the rules to forward the tags so that the notification server can properly deliver notifications