### PR TITLE
Part 2 - Encryption: Add version to EncryptedData and switch to binary channel payload encoding

### DIFF
--- a/packages/encryption/src/base.ts
+++ b/packages/encryption/src/base.ts
@@ -46,7 +46,8 @@ export abstract class EncryptionAlgorithm implements IEncryptionParams {
         opts?: { awaitInitialShareSession: boolean },
     ): Promise<void>
 
-    abstract encrypt(streamId: string, payload: string): Promise<EncryptedData>
+    abstract encrypt_deprecated_v0(streamId: string, payload: string): Promise<EncryptedData>
+    abstract encrypt(streamId: string, payload: Uint8Array): Promise<EncryptedData>
 }
 
 /**

--- a/packages/encryption/src/decryptionExtensions.ts
+++ b/packages/encryption/src/decryptionExtensions.ts
@@ -713,6 +713,7 @@ export abstract class BaseDecryptionExtensions {
             return
         }
 
+        // todo split this up by algorithm so that we can send all the new hybrid keys
         knownSessionIds.sort()
         const requestedSessionIds = new Set(item.solicitation.sessionIds.sort())
         const replySessionIds = item.solicitation.isNewDevice

--- a/packages/encryption/src/groupEncryptionCrypto.ts
+++ b/packages/encryption/src/groupEncryptionCrypto.ts
@@ -161,10 +161,23 @@ export class GroupEncryptionCrypto {
      */
     public async encryptGroupEvent(
         streamId: string,
-        payload: string,
+        payload: Uint8Array,
         algorithm: GroupEncryptionAlgorithmId,
     ): Promise<EncryptedData> {
         return this.groupEncryption[algorithm].encrypt(streamId, payload)
+    }
+    /**
+     * Deprecated uses v0 encryption version
+     *
+     * @returns Promise which resolves when the event has been
+     *     encrypted, or null if nothing was needed
+     */
+    public async encryptGroupEvent_deprecated_v0(
+        streamId: string,
+        payload: string,
+        algorithm: GroupEncryptionAlgorithmId,
+    ): Promise<EncryptedData> {
+        return this.groupEncryption[algorithm].encrypt_deprecated_v0(streamId, payload)
     }
     /**
      * Decrypt a received event using group encryption algorithm

--- a/packages/encryption/src/tests/decryptionExtensions.test.ts
+++ b/packages/encryption/src/tests/decryptionExtensions.test.ts
@@ -62,6 +62,11 @@ describe.concurrent('TestDecryptionExtensions', () => {
             // bob encrypts a message
             const encryptedData = await bobCrypto.encryptGroupEvent(
                 streamId,
+                new TextEncoder().encode(bobsPlaintext),
+                algorithm,
+            )
+            const encryptedData_V0 = await bobCrypto.encryptGroupEvent_deprecated_v0(
+                streamId,
                 bobsPlaintext,
                 algorithm,
             )
@@ -89,9 +94,13 @@ describe.concurrent('TestDecryptionExtensions', () => {
 
             // try to decrypt the message
             const decrypted = await aliceDex.crypto.decryptGroupEvent(streamId, encryptedData)
+            const decrypted_V0 = await aliceDex.crypto.decryptGroupEvent(streamId, encryptedData_V0)
 
-            if (typeof decrypted !== 'string') {
+            if (typeof decrypted === 'string') {
                 throw new Error('decrypted is a string') // v1 should be bytes
+            }
+            if (typeof decrypted_V0 !== 'string') {
+                throw new Error('decrypted_V0 is a string') // v0 should be bytes
             }
 
             // stop the decryption extensions
@@ -99,7 +108,8 @@ describe.concurrent('TestDecryptionExtensions', () => {
             await aliceDex.stop()
 
             // assert
-            expect(decrypted).toBe(bobsPlaintext)
+            expect(new TextDecoder().decode(decrypted)).toBe(bobsPlaintext)
+            expect(decrypted_V0).toBe(bobsPlaintext)
             expect(bobDex.seenStates).toContain(DecryptionStatus.respondingToKeyRequests)
             expect(aliceDex.seenStates).toContain(DecryptionStatus.processingNewGroupSessions)
         },
@@ -131,6 +141,11 @@ describe.concurrent('TestDecryptionExtensions', () => {
             // bob encrypts a message
             const encryptedData = await bobCrypto.encryptGroupEvent(
                 streamId,
+                new TextEncoder().encode(bobsPlaintext),
+                algorithm,
+            )
+            const encryptedData_V0 = await bobCrypto.encryptGroupEvent_deprecated_v0(
+                streamId,
                 bobsPlaintext,
                 algorithm,
             )
@@ -145,12 +160,23 @@ describe.concurrent('TestDecryptionExtensions', () => {
             // try to decrypt the message
             const decrypted = await aliceDex.crypto.decryptGroupEvent(streamId, encryptedData)
 
+            if (typeof decrypted === 'string') {
+                throw new Error('decrypted is a string') // v1 should be bytes
+            }
+
+            const decrypted_V0 = await aliceDex.crypto.decryptGroupEvent(streamId, encryptedData_V0)
+
+            if (typeof decrypted_V0 !== 'string') {
+                throw new Error('decrypted_V0 is a string') // v0 should be bytes
+            }
+
             // stop the decryption extensions
             await bobDex.stop()
             await aliceDex.stop()
 
             // assert
-            expect(decrypted).toBe(bobsPlaintext)
+            expect(new TextDecoder().decode(decrypted)).toBe(bobsPlaintext)
+            expect(decrypted_V0).toBe(bobsPlaintext)
         },
     )
 })

--- a/packages/sdk/src/mls/coordinator/coordinator.ts
+++ b/packages/sdk/src/mls/coordinator/coordinator.ts
@@ -40,17 +40,6 @@ type MlsEncryptedContentItem = {
     encryptedData: EncryptedData
 }
 
-const encoder = new TextEncoder()
-const decoder = new TextDecoder()
-
-function encode(text: string): Uint8Array {
-    return encoder.encode(text)
-}
-
-function decode(bytes: Uint8Array): string {
-    return decoder.decode(bytes)
-}
-
 export interface ICoordinator {
     // Commands
     joinOrCreateGroup(streamId: string): Promise<void>
@@ -164,10 +153,9 @@ export class Coordinator implements ICoordinator {
             }
         }
 
-        const plaintext_ = event.toJsonString()
-        const plaintext = encode(plaintext_)
+        const plainbytes = event.toBinary()
 
-        return this.epochSecretService.encryptMessage(epochSecret, plaintext)
+        return this.epochSecretService.encryptMessage(epochSecret, plainbytes)
     }
 
     // TODO: Maybe this could be refactored into a separate class
@@ -187,11 +175,7 @@ export class Coordinator implements ICoordinator {
         // check cache
         let cleartext = await this.persistenceStore.getCleartext(eventId)
         if (cleartext === undefined) {
-            const cleartext_ = await this.epochSecretService.decryptMessage(
-                epochSecret,
-                encryptedData,
-            )
-            cleartext = decode(cleartext_)
+            cleartext = await this.epochSecretService.decryptMessage(epochSecret, encryptedData)
         }
         const decryptedContent = toDecryptedContent(kind, encryptedData.version, cleartext)
 

--- a/packages/sdk/src/mls/epoch/epochSecretService.ts
+++ b/packages/sdk/src/mls/epoch/epochSecretService.ts
@@ -7,7 +7,11 @@ import {
 } from '@river-build/mls-rs-wasm'
 import { bin_toHexString, dlog, DLogger, shortenHexString } from '@river-build/dlog'
 import { DerivedKeys, EpochSecret, EpochSecretId, epochSecretId } from './epochSecret'
-import { EncryptedData, MemberPayload_Mls_EpochSecrets } from '@river-build/proto'
+import {
+    EncryptedData,
+    EncryptedDataVersion,
+    MemberPayload_Mls_EpochSecrets,
+} from '@river-build/proto'
 import { IEpochSecretStore } from './epochSecretStore'
 import { PlainMessage } from '@bufbuild/protobuf'
 import { MLS_ALGORITHM } from '../constants'
@@ -213,6 +217,7 @@ export class EpochSecretService {
                 epoch: epochSecret.epoch,
                 ciphertext,
             },
+            version: EncryptedDataVersion.ENCRYPTED_DATA_VERSION_1,
         })
     }
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -6,7 +6,6 @@ import {
     UserMetadataPayload_Inception,
     UserPayload_Inception,
     SpacePayload_Inception,
-    ChannelProperties,
     ChannelPayload_Inception,
     UserSettingsPayload_Inception,
     SpacePayload_ChannelUpdate,
@@ -456,13 +455,6 @@ export const make_ChannelMessage_Redaction = (
             },
         },
     })
-}
-
-export const make_ChannelProperties = (
-    channelName: string,
-    channelTopic: string,
-): ChannelProperties => {
-    return new ChannelProperties({ name: channelName, topic: channelTopic })
 }
 
 export const make_ChannelPayload_Inception = (


### PR DESCRIPTION
this ended up being a large change - but mostly to just get the persistence layer changed over.

Olm still encrypts and decrypts strings…

For new encrypted data code where `version > 0`
- accept bytes to encode, use bin_toHex to convert to string before encrypting
- after decrypting, convert back to bytes with bin_fromHex before returning

For old data
- after decrypting, return string
