### PR TITLE
Fixes and better errors for tests

### DIFF
--- a/packages/web3/src/v3/SpaceDapp.ts
+++ b/packages/web3/src/v3/SpaceDapp.ts
@@ -1780,7 +1780,7 @@ async function wrapTransaction(
                     (error as { code: unknown }).code === 'CALL_EXCEPTION'
                 ) {
                     logger.error('Transaction failed', { tx, errorCount, error })
-                    throw new Error('Transaction confirmed but failed')
+                    throw error
                 }
 
                 // If the transaction receipt is not available yet, the error may be thrown


### PR DESCRIPTION
Seeing new flakyness in the sdk tests. Seems like the build machine is either faster or slower.
The timeline test fails locally for me, forcing some miniblocks makes scrollback more preditable
The space is failing to mint in some instances, i feel like this will give us a better error message