### PR TITLE
replace river. in typeName

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -2600,7 +2600,7 @@ export class Client
         return this.cryptoBackend.encryptGroupEvent(
             streamId,
             event.toBinary(),
-            event.getType().typeName,
+            event.getType().typeName.replace('river.', ''),
             algorithm,
         )
     }

--- a/packages/sdk/src/encryptedContentTypes.ts
+++ b/packages/sdk/src/encryptedContentTypes.ts
@@ -56,12 +56,12 @@ export function toDecryptedContent(
                     kind: 'text',
                     content: new TextDecoder().decode(cleartext),
                 } satisfies DecryptedContent_Text
-            case ChannelProperties.typeName:
+            case 'ChannelProperties':
                 return {
                     kind: 'channelProperties',
                     content: ChannelProperties.fromBinary(cleartext),
                 } satisfies DecryptedContent_ChannelProperties
-            case ChannelMessage.typeName:
+            case 'ChannelMessage':
                 return {
                     kind: 'channelMessage',
                     content: ChannelMessage.fromBinary(cleartext),


### PR DESCRIPTION
I propose we change this, since `Message.getType()` isn't available on all platforms
