### PR TITLE
Media stream optimization: Added checks to AddMediaEvent endpoint

### DIFF
--- a/core/node/storage/storage.go
+++ b/core/node/storage/storage.go
@@ -49,9 +49,6 @@ type StreamStorage interface {
 		onEachMb func(blockdata []byte, seqNum int) error,
 	) error
 
-	// ReadGenesisMiniblock reads genesis miniblock of the stream.
-	ReadGenesisMiniblock(ctx context.Context, streamId StreamId) ([]byte, error)
-
 	// WriteEvent adds event to the given minipool.
 	// Current generation of minipool should match minipoolGeneration,
 	// and there should be exactly minipoolSlot events in the minipool.


### PR DESCRIPTION
- Only media stream creator address can add media events
- Chunk index must be within the range 
- Chunk data but not exceed the configured max limit 