### PR TITLE
Small fixes to the new returned event refs

### DIFF
--- a/core/node/rpc/add_event.go
+++ b/core/node/rpc/add_event.go
@@ -95,7 +95,7 @@ func (s *Service) addParsedEvent(
 		}
 		// If no chainAuthArgs grant entitlement, execute the OnChainAuthFailure side effect.
 		if !isEntitled {
-			var newEvents []*EventRef
+			var newEvents []*EventRef = nil
 			if sideEffects.OnChainAuthFailure != nil {
 				newEvents, err = s.AddEventPayload(
 					ctx,
@@ -203,5 +203,9 @@ func (s *Service) AddEventPayload(
 		return nil, err
 	}
 
-	return resp.Msg.NewEvents, nil
+	if resp.Msg != nil {
+		return resp.Msg.NewEvents, nil
+	}
+
+	return nil, nil
 }

--- a/core/node/rpc/create_stream.go
+++ b/core/node/rpc/create_stream.go
@@ -138,7 +138,7 @@ func (s *Service) createStream(ctx context.Context, req *CreateStreamRequest) (*
 
 	// add derived events
 	if csRules.DerivedEvents != nil {
-		derivedEvents = make([]*EventRef, 0, len(csRules.DerivedEvents))
+		derivedEvents = make([]*EventRef, 0)
 		for _, de := range csRules.DerivedEvents {
 			newEvents, err := s.AddEventPayload(ctx, de.StreamId, de.Payload, de.Tags)
 			derivedEvents = append(derivedEvents, newEvents...)


### PR DESCRIPTION
1) follow convention when creating new pointers to slices
2) check for nil on the returned Msg payload (i already checked for error)
3) don’t pre allocate the derived events slice, i don’t actually know how big it will be