### PR TITLE
Increase threshold for measuring entitlement evaluation times to account for CI slowness

### DIFF
--- a/core/xchain/entitlement/entitlement_test.go
+++ b/core/xchain/entitlement/entitlement_test.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	timingThreshold = 50 * time.Millisecond
+	timingThreshold = 100 * time.Millisecond
 
 	fastThresholdParams = ThresholdParams{
 		Threshold: big.NewInt(fast),


### PR DESCRIPTION
Tests were flaking due to time deltas slightly > 50ms, increase to 100ms.