### PR TITLE
[BUGFIX] Logging fix for sync streams error message

### DIFF
--- a/core/node/events/stream_sync_task.go
+++ b/core/node/events/stream_sync_task.go
@@ -22,7 +22,7 @@ func (s *streamCacheImpl) submitSyncStreamTask(
 		err := s.syncStreamFromPeers(ctx, streamId, lastMbInContract)
 		if err != nil {
 			logging.FromCtx(ctx).
-				Error("Unable to sync stream from peers", "stream", streamId, "error", err, "targetMiniblockNum", lastMbInContract.Num)
+				Errorw("Unable to sync stream from peers", "stream", streamId, "error", err, "targetMiniblockNum", lastMbInContract.Num)
 		}
 	})
 }


### PR DESCRIPTION
There is an error in how the logging API is called in sync streams that is causing errors on the river node to print strangely in the logs, and may also be the source of a panic.