### PR TITLE
Better errors and better retry timings on transactions in tests

### DIFF
--- a/packages/web3/src/v3/SpaceDapp.ts
+++ b/packages/web3/src/v3/SpaceDapp.ts
@@ -1735,7 +1735,7 @@ async function wrapTransaction(
     txFn: () => Promise<ContractTransaction>,
     txnOpts?: TransactionOpts,
 ): Promise<ContractTransaction> {
-    const retryLimit = txnOpts?.retryCount ?? isTestEnv() ? 3 : 0
+    const retryLimit = txnOpts?.retryCount ?? isTestEnv() ? 5 : 0
 
     const runTx = async () => {
         let retryCount = 0
@@ -1763,7 +1763,7 @@ async function wrapTransaction(
                 }
                 logger.error('Transaction submission failed, retrying...', { error, retryCount })
                 await new Promise((resolve) =>
-                    setTimeout(resolve, (1000 + Math.random() * 500) * retryCount),
+                    setTimeout(resolve, (750 + Math.random() * 500) * retryCount),
                 )
             }
         }

--- a/packages/web3/src/v3/SpaceDapp.ts
+++ b/packages/web3/src/v3/SpaceDapp.ts
@@ -1739,6 +1739,7 @@ async function wrapTransaction(
 
     const runTx = async () => {
         let retryCount = 0
+        const errors = []
         // eslint-disable-next-line no-constant-condition
         while (true) {
             try {
@@ -1753,11 +1754,17 @@ async function wrapTransaction(
                 return tx
             } catch (error) {
                 retryCount++
+                errors.push(error)
                 if (retryCount >= retryLimit) {
-                    throw new Error('Transaction failed after retries: ' + (error as Error).message)
+                    throw new Error(
+                        `Transaction failed after ${retryCount} tries: \n` +
+                            errors.map((e) => (e as Error).message).join('\n =============== \n'),
+                    )
                 }
                 logger.error('Transaction submission failed, retrying...', { error, retryCount })
-                await new Promise((resolve) => setTimeout(resolve, 1000))
+                await new Promise((resolve) =>
+                    setTimeout(resolve, (1000 + Math.random() * 500) * retryCount),
+                )
             }
         }
     }


### PR DESCRIPTION
https://github.com/river-build/river/actions/runs/12894046742/job/35951816490?pr=2097

looks like our chain doesn’t run as fast as it used to? We where having lots of issues with this in the past and it cleared up after we started retrying transacitons. This pr impvoves the error message and adds more time and randomness between retries.