### PR TITLE
allow setting nil encryption algorithm

### DIFF
--- a/core/node/events/snapshot.go
+++ b/core/node/events/snapshot.go
@@ -594,9 +594,6 @@ func update_Snapshot_Member(
 		snapshot.Pins = snapPins
 		return nil
 	case *MemberPayload_EncryptionAlgorithm_:
-		if content.EncryptionAlgorithm == nil {
-			return RiverError(Err_INVALID_ARGUMENT, "member payload encryption algorithm not set")
-		}
 		snapshot.EncryptionAlgorithm = content.EncryptionAlgorithm
 		return nil
 	case *MemberPayload_MemberBlockchainTransaction_:


### PR DESCRIPTION
this PR allows nil values for MemberPayload.EncryptionAlgorithm in snapshots.

the way we unset the algorithm is that we simply set a nil value:
Client.ts
https://github.com/river-build/river/blob/main/packages/sdk/src/client.ts#L899
Types.ts
https://github.com/river-build/river/blob/main/packages/sdk/src/types.ts#L802-L804
Test:
https://github.com/river-build/river/blob/main/packages/sdk/src/tests/multi_ne/memberMetadata.test.ts#L703-L709
