### PR TITLE
Part 1: Decryption - Add version to EncryptedData and switch to binary channel payload encoding

### DIFF
--- a/packages/encryption/src/base.ts
+++ b/packages/encryption/src/base.ts
@@ -59,7 +59,7 @@ export abstract class DecryptionAlgorithm implements IDecryptionParams {
         this.device = params.device
     }
 
-    abstract decrypt(streamId: string, content: EncryptedData): Promise<string>
+    abstract decrypt(streamId: string, content: EncryptedData): Promise<Uint8Array | string>
 
     abstract importStreamKey(streamId: string, session: GroupEncryptionSession): Promise<void>
 

--- a/packages/encryption/src/groupDecryption.ts
+++ b/packages/encryption/src/groupDecryption.ts
@@ -2,8 +2,8 @@ import type { GroupSessionExtraData } from './encryptionDevice'
 
 import { DecryptionAlgorithm, DecryptionError, IDecryptionParams } from './base'
 import { GroupEncryptionAlgorithmId, GroupEncryptionSession } from './olmLib'
-import { EncryptedData } from '@river-build/proto'
-import { dlog } from '@river-build/dlog'
+import { EncryptedData, EncryptedDataVersion } from '@river-build/proto'
+import { bin_fromBase64, dlog } from '@river-build/dlog'
 
 const log = dlog('csb:encryption:groupDecryption')
 
@@ -24,7 +24,7 @@ export class GroupDecryption extends DecryptionAlgorithm {
      * decrypting, or rejects with an `algorithms.DecryptionError` if there is a
      * problem decrypting the event.
      */
-    public async decrypt(streamId: string, content: EncryptedData): Promise<string> {
+    public async decrypt(streamId: string, content: EncryptedData): Promise<Uint8Array | string> {
         if (!content.senderKey || !content.sessionId || !content.ciphertext) {
             throw new DecryptionError('GROUP_DECRYPTION_MISSING_FIELDS', 'Missing fields in input')
         }
@@ -35,8 +35,18 @@ export class GroupDecryption extends DecryptionAlgorithm {
             throw new Error('Session not found')
         }
 
+        // for historical reasons, we return the plaintext as a string
         const result = session.decrypt(content.ciphertext)
-        return result.plaintext
+
+        switch (content.version) {
+            case EncryptedDataVersion.ENCRYPTED_DATA_VERSION_0:
+                return result.plaintext
+            case EncryptedDataVersion.ENCRYPTED_DATA_VERSION_1:
+                return bin_fromBase64(result.plaintext)
+
+            default:
+                throw new DecryptionError('GROUP_DECRYPTION_INVALID_VERSION', 'Unsupported version')
+        }
     }
 
     /**

--- a/packages/encryption/src/hybridGroupDecryption.ts
+++ b/packages/encryption/src/hybridGroupDecryption.ts
@@ -1,6 +1,6 @@
 import { DecryptionAlgorithm, DecryptionError, IDecryptionParams } from './base'
 import { GroupEncryptionAlgorithmId, GroupEncryptionSession } from './olmLib'
-import { EncryptedData, HybridGroupSessionKey } from '@river-build/proto'
+import { EncryptedData, EncryptedDataVersion, HybridGroupSessionKey } from '@river-build/proto'
 import { bin_toHexString, dlog } from '@river-build/dlog'
 import { decryptAesGcm, importAesGsmKeyBytes } from './cryptoAesGcm'
 
@@ -23,7 +23,7 @@ export class HybridGroupDecryption extends DecryptionAlgorithm {
      * decrypting, or rejects with an `algorithms.DecryptionError` if there is a
      * problem decrypting the event.
      */
-    public async decrypt(streamId: string, content: EncryptedData): Promise<string> {
+    public async decrypt(streamId: string, content: EncryptedData): Promise<Uint8Array | string> {
         if (
             !content.senderKey ||
             !content.sessionIdBytes ||
@@ -45,7 +45,15 @@ export class HybridGroupDecryption extends DecryptionAlgorithm {
 
         const key = await importAesGsmKeyBytes(session.key)
         const result = await decryptAesGcm(key, content.ciphertextBytes, content.ivBytes)
-        return new TextDecoder().decode(result) // TODO: what kind of string is actually expected here? TODO: convert to Uint8Array
+
+        switch (content.version) {
+            case EncryptedDataVersion.ENCRYPTED_DATA_VERSION_0:
+                return new TextDecoder().decode(result)
+            case EncryptedDataVersion.ENCRYPTED_DATA_VERSION_1:
+                return result
+            default:
+                throw new DecryptionError('GROUP_DECRYPTION_INVALID_VERSION', 'Unsupported version')
+        }
     }
 
     /**

--- a/packages/encryption/src/tests/decryptionExtensions.test.ts
+++ b/packages/encryption/src/tests/decryptionExtensions.test.ts
@@ -90,6 +90,10 @@ describe.concurrent('TestDecryptionExtensions', () => {
             // try to decrypt the message
             const decrypted = await aliceDex.crypto.decryptGroupEvent(streamId, encryptedData)
 
+            if (typeof decrypted !== 'string') {
+                throw new Error('decrypted is a string') // v1 should be bytes
+            }
+
             // stop the decryption extensions
             await bobDex.stop()
             await aliceDex.stop()

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -2572,7 +2572,7 @@ export class Client
         check(isDefined(stream), 'stream not found')
         check(isEncryptedContentKind(kind), `invalid kind ${kind}`)
         const cleartext = await this.cleartextForGroupEvent(streamId, eventId, encryptedData)
-        const decryptedContent = toDecryptedContent(kind, cleartext)
+        const decryptedContent = toDecryptedContent(kind, encryptedData.version, cleartext)
         stream.updateDecryptedContent(eventId, decryptedContent)
     }
 
@@ -2580,7 +2580,7 @@ export class Client
         streamId: string,
         eventId: string,
         encryptedData: EncryptedData,
-    ): Promise<string> {
+    ): Promise<Uint8Array | string> {
         const cached = await this.persistenceStore.getCleartext(eventId)
         if (cached) {
             this.logDebug('Cache hit for cleartext', eventId)

--- a/packages/sdk/src/memberMetadata_DisplayNames.ts
+++ b/packages/sdk/src/memberMetadata_DisplayNames.ts
@@ -7,6 +7,8 @@ import { StreamEncryptionEvents, StreamStateEvents } from './streamEvents'
 // temporary until we move encrypted user and display names to the user metadata stream
 const MAX_DECRYPTED_NAMES_PER_STREAM = 50
 
+const textDecoder = new TextDecoder()
+
 export class MemberMetadata_DisplayNames {
     log = dlog('csb:streams:displaynames')
     private decryptionDispatchCount = 0
@@ -27,7 +29,7 @@ export class MemberMetadata_DisplayNames {
         encryptedData: EncryptedData,
         userId: string,
         pending: boolean = true,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ) {
@@ -35,7 +37,10 @@ export class MemberMetadata_DisplayNames {
         this.addEventForUserId(userId, eventId, encryptedData, pending)
 
         if (cleartext) {
-            this.plaintextDisplayNames.set(userId, cleartext)
+            this.plaintextDisplayNames.set(
+                userId,
+                typeof cleartext === 'string' ? cleartext : textDecoder.decode(cleartext),
+            )
         } else if (this.decryptionDispatchCount < MAX_DECRYPTED_NAMES_PER_STREAM) {
             this.decryptionDispatchCount++
             // Clear the plaintext display name for this user on name change

--- a/packages/sdk/src/mls/coordinator/coordinator.ts
+++ b/packages/sdk/src/mls/coordinator/coordinator.ts
@@ -193,7 +193,7 @@ export class Coordinator implements ICoordinator {
             )
             cleartext = decode(cleartext_)
         }
-        const decryptedContent = toDecryptedContent(kind, cleartext)
+        const decryptedContent = toDecryptedContent(kind, encryptedData.version, cleartext)
 
         stream.updateDecryptedContent(eventId, decryptedContent)
     }

--- a/packages/sdk/src/persistenceStore.ts
+++ b/packages/sdk/src/persistenceStore.ts
@@ -64,9 +64,9 @@ async function fnReadRetryer<T>(
 }
 
 export interface IPersistenceStore {
-    saveCleartext(eventId: string, cleartext: string): Promise<void>
-    getCleartext(eventId: string): Promise<string | undefined>
-    getCleartexts(eventIds: string[]): Promise<Record<string, string> | undefined>
+    saveCleartext(eventId: string, cleartext: Uint8Array | string): Promise<void>
+    getCleartext(eventId: string): Promise<Uint8Array | string | undefined>
+    getCleartexts(eventIds: string[]): Promise<Record<string, Uint8Array | string> | undefined>
     getSyncedStream(streamId: string): Promise<
         | {
               syncCookie: SyncCookie
@@ -92,7 +92,7 @@ export interface IPersistenceStore {
 }
 
 export class PersistenceStore extends Dexie implements IPersistenceStore {
-    cleartexts!: Table<{ cleartext: string; eventId: string }>
+    cleartexts!: Table<{ cleartext: Uint8Array | string; eventId: string }>
     syncedStreams!: Table<{ streamId: string; data: Uint8Array }>
     miniblocks!: Table<{ streamId: string; miniblockNum: string; data: Uint8Array }>
 
@@ -115,11 +115,16 @@ export class PersistenceStore extends Dexie implements IPersistenceStore {
             return tx.table('syncedStreams').toCollection().delete()
         })
 
+        // Version 4: added a option to have a data_type field to the encrypted data, drop all saved cleartexts
+        this.version(4).upgrade((tx) => {
+            return tx.table('cleartexts').toCollection().delete()
+        })
+
         this.requestPersistentStorage()
         this.logPersistenceStats()
     }
 
-    async saveCleartext(eventId: string, cleartext: string) {
+    async saveCleartext(eventId: string, cleartext: Uint8Array | string) {
         await this.cleartexts.put({ eventId, cleartext })
     }
 
@@ -138,7 +143,7 @@ export class PersistenceStore extends Dexie implements IPersistenceStore {
                           acc[record.eventId] = record.cleartext
                       }
                       return acc
-                  }, {} as Record<string, string>)
+                  }, {} as Record<string, Uint8Array | string>)
         }, DEFAULT_RETRY_COUNT)
     }
 
@@ -256,7 +261,7 @@ export class PersistenceStore extends Dexie implements IPersistenceStore {
 //Linting below is disable as this is a stub class which is used for testing and just follows the interface
 /* eslint-disable @typescript-eslint/no-unused-vars */
 export class StubPersistenceStore implements IPersistenceStore {
-    async saveCleartext(eventId: string, cleartext: string) {
+    async saveCleartext(eventId: string, cleartext: Uint8Array) {
         return Promise.resolve()
     }
 

--- a/packages/sdk/src/stream.ts
+++ b/packages/sdk/src/stream.ts
@@ -50,7 +50,7 @@ export class Stream extends (EventEmitter as new () => TypedEmitter<StreamEvents
         miniblocks: ParsedMiniblock[],
         prependedMiniblocks: ParsedMiniblock[],
         prevSnapshotMiniblockNum: bigint,
-        cleartexts: Record<string, string> | undefined,
+        cleartexts: Record<string, Uint8Array | string> | undefined,
     ): void {
         // grab any local events from the previous view that haven't been processed
         const localEvents = this._view.timeline
@@ -78,14 +78,14 @@ export class Stream extends (EventEmitter as new () => TypedEmitter<StreamEvents
     async appendEvents(
         events: ParsedEvent[],
         nextSyncCookie: SyncCookie,
-        cleartexts: Record<string, string> | undefined,
+        cleartexts: Record<string, Uint8Array | string> | undefined,
     ): Promise<void> {
         this._view.appendEvents(events, nextSyncCookie, cleartexts, this)
     }
 
     prependEvents(
         miniblocks: ParsedMiniblock[],
-        cleartexts: Record<string, string> | undefined,
+        cleartexts: Record<string, Uint8Array | string> | undefined,
         terminus: boolean,
     ) {
         this._view.prependEvents(miniblocks, cleartexts, terminus, this, this)

--- a/packages/sdk/src/streamStateView.ts
+++ b/packages/sdk/src/streamStateView.ts
@@ -225,7 +225,7 @@ export class StreamStateView implements IStreamStateView {
     private applySnapshot(
         eventHash: string,
         inSnapshot: Snapshot,
-        cleartexts: Record<string, string> | undefined,
+        cleartexts: Record<string, Uint8Array | string> | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ) {
         const snapshot = migrateSnapshot(inSnapshot)
@@ -299,7 +299,7 @@ export class StreamStateView implements IStreamStateView {
     private appendStreamAndCookie(
         nextSyncCookie: SyncCookie,
         minipoolEvents: ParsedEvent[],
-        cleartexts: Record<string, string> | undefined,
+        cleartexts: Record<string, Uint8Array | string> | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): {
@@ -341,7 +341,7 @@ export class StreamStateView implements IStreamStateView {
 
     private processAppendedEvent(
         timelineEvent: RemoteTimelineEvent,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): ConfirmedTimelineEvent[] | undefined {
@@ -436,7 +436,7 @@ export class StreamStateView implements IStreamStateView {
 
     private processPrependedEvent(
         timelineEvent: RemoteTimelineEvent,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
@@ -552,7 +552,7 @@ export class StreamStateView implements IStreamStateView {
         miniblocks: ParsedMiniblock[],
         prependedMiniblocks: ParsedMiniblock[],
         prevSnapshotMiniblockNum: bigint,
-        cleartexts: Record<string, string> | undefined,
+        cleartexts: Record<string, Uint8Array | string> | undefined,
         localEvents: LocalTimelineEvent[],
         emitter: TypedEmitter<StreamEvents> | undefined,
     ): void {
@@ -629,7 +629,7 @@ export class StreamStateView implements IStreamStateView {
     appendEvents(
         events: ParsedEvent[],
         nextSyncCookie: SyncCookie,
-        cleartexts: Record<string, string> | undefined,
+        cleartexts: Record<string, Uint8Array | string> | undefined,
         emitter: TypedEmitter<StreamEvents>,
     ) {
         const { appended, updated, confirmed } = this.appendStreamAndCookie(
@@ -648,7 +648,7 @@ export class StreamStateView implements IStreamStateView {
 
     prependEvents(
         miniblocks: ParsedMiniblock[],
-        cleartexts: Record<string, string> | undefined,
+        cleartexts: Record<string, Uint8Array | string> | undefined,
         terminus: boolean,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,

--- a/packages/sdk/src/streamStateView_AbstractContent.ts
+++ b/packages/sdk/src/streamStateView_AbstractContent.ts
@@ -11,13 +11,13 @@ export abstract class StreamStateView_AbstractContent {
     abstract readonly streamId: string
     abstract prependEvent(
         event: RemoteTimelineEvent,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void
     abstract appendEvent(
         event: RemoteTimelineEvent,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void
@@ -26,11 +26,11 @@ export abstract class StreamStateView_AbstractContent {
         kind: EncryptedContent['kind'],
         event: RemoteTimelineEvent,
         content: EncryptedData,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ) {
         if (cleartext) {
-            event.decryptedContent = toDecryptedContent(kind, cleartext)
+            event.decryptedContent = toDecryptedContent(kind, content.version, cleartext)
         } else {
             switch (content.algorithm) {
                 case MLS_ALGORITHM:

--- a/packages/sdk/src/streamStateView_Channel.ts
+++ b/packages/sdk/src/streamStateView_Channel.ts
@@ -29,7 +29,7 @@ export class StreamStateView_Channel extends StreamStateView_AbstractContent {
     applySnapshot(
         snapshot: Snapshot,
         content: ChannelPayload_Snapshot,
-        _cleartexts: Record<string, string> | undefined,
+        _cleartexts: Record<string, Uint8Array | string> | undefined,
         _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ): void {
         this.spaceId = streamIdFromBytes(content.inception?.spaceId ?? Uint8Array.from([]))
@@ -37,7 +37,7 @@ export class StreamStateView_Channel extends StreamStateView_AbstractContent {
 
     prependEvent(
         event: RemoteTimelineEvent,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
@@ -70,7 +70,7 @@ export class StreamStateView_Channel extends StreamStateView_AbstractContent {
 
     appendEvent(
         event: RemoteTimelineEvent,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {

--- a/packages/sdk/src/streamStateView_ChannelMetadata.ts
+++ b/packages/sdk/src/streamStateView_ChannelMetadata.ts
@@ -17,7 +17,7 @@ export class StreamStateView_ChannelMetadata {
 
     applySnapshot(
         encryptedChannelProperties: WrappedEncryptedData,
-        cleartexts: Record<string, string> | undefined,
+        cleartexts: Record<string, Uint8Array | string> | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ): void {
         if (!encryptedChannelProperties.data) {
@@ -37,11 +37,15 @@ export class StreamStateView_ChannelMetadata {
     private decryptPayload(
         payload: EncryptedData,
         eventId: string,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ) {
         if (cleartext) {
-            const decryptedContent = toDecryptedContent('channelProperties', cleartext)
+            const decryptedContent = toDecryptedContent(
+                'channelProperties',
+                payload.version,
+                cleartext,
+            )
             this.handleDecryptedContent(decryptedContent, encryptionEmitter)
         } else {
             encryptionEmitter?.emit('newEncryptedContent', this.streamId, eventId, {
@@ -65,7 +69,7 @@ export class StreamStateView_ChannelMetadata {
 
     appendEvent(
         event: RemoteTimelineEvent,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         emitter: TypedEmitter<StreamEvents> | undefined,
     ): void {
         check(event.remoteEvent.event.payload.case === 'gdmChannelPayload')
@@ -76,7 +80,7 @@ export class StreamStateView_ChannelMetadata {
 
     prependEvent(
         _event: RemoteTimelineEvent,
-        _cleartext: string | undefined,
+        _cleartext: Uint8Array | string | undefined,
         _emitter: TypedEmitter<StreamEvents> | undefined,
     ): void {
         // conveyed in snapshot

--- a/packages/sdk/src/streamStateView_DMChannel.ts
+++ b/packages/sdk/src/streamStateView_DMChannel.ts
@@ -27,7 +27,7 @@ export class StreamStateView_DMChannel extends StreamStateView_AbstractContent {
     applySnapshot(
         snapshot: Snapshot,
         content: DmChannelPayload_Snapshot,
-        _cleartexts: Record<string, string> | undefined,
+        _cleartexts: Record<string, Uint8Array | string> | undefined,
         _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ): void {
         if (content.inception) {
@@ -38,7 +38,7 @@ export class StreamStateView_DMChannel extends StreamStateView_AbstractContent {
 
     appendEvent(
         event: RemoteTimelineEvent,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
@@ -69,7 +69,7 @@ export class StreamStateView_DMChannel extends StreamStateView_AbstractContent {
 
     prependEvent(
         event: RemoteTimelineEvent,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {

--- a/packages/sdk/src/streamStateView_GDMChannel.ts
+++ b/packages/sdk/src/streamStateView_GDMChannel.ts
@@ -28,7 +28,7 @@ export class StreamStateView_GDMChannel extends StreamStateView_AbstractContent 
     applySnapshot(
         snapshot: Snapshot,
         content: GdmChannelPayload_Snapshot,
-        cleartexts: Record<string, string> | undefined,
+        cleartexts: Record<string, Uint8Array | string> | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ): void {
         if (content.channelProperties) {
@@ -42,7 +42,7 @@ export class StreamStateView_GDMChannel extends StreamStateView_AbstractContent 
 
     prependEvent(
         event: RemoteTimelineEvent,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
@@ -74,7 +74,7 @@ export class StreamStateView_GDMChannel extends StreamStateView_AbstractContent 
 
     appendEvent(
         event: RemoteTimelineEvent,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {

--- a/packages/sdk/src/streamStateView_Media.ts
+++ b/packages/sdk/src/streamStateView_Media.ts
@@ -48,7 +48,7 @@ export class StreamStateView_Media extends StreamStateView_AbstractContent {
 
     appendEvent(
         event: RemoteTimelineEvent,
-        _cleartext: string | undefined,
+        _cleartext: Uint8Array | string | undefined,
         _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
@@ -78,7 +78,7 @@ export class StreamStateView_Media extends StreamStateView_AbstractContent {
 
     prependEvent(
         event: RemoteTimelineEvent,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {

--- a/packages/sdk/src/streamStateView_MemberMetadata.ts
+++ b/packages/sdk/src/streamStateView_MemberMetadata.ts
@@ -44,7 +44,7 @@ export class StreamStateView_MemberMetadata {
         displayNames: { userId: string; wrappedEncryptedData: WrappedEncryptedData }[],
         ensAddresses: { userId: string; ensAddress: Uint8Array }[],
         nfts: { userId: string; nft: MemberPayload_Nft }[],
-        cleartexts: Record<string, string> | undefined,
+        cleartexts: Record<string, Uint8Array | string> | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ) {
         // Sort the payloads — this is necessary because we want to
@@ -105,7 +105,7 @@ export class StreamStateView_MemberMetadata {
 
     prependEvent(
         _event: RemoteTimelineEvent,
-        _cleartext: string | undefined,
+        _cleartext: Uint8Array | string | undefined,
         _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
@@ -116,7 +116,7 @@ export class StreamStateView_MemberMetadata {
         eventId: string,
         data: EncryptedData,
         userId: string,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
@@ -135,7 +135,7 @@ export class StreamStateView_MemberMetadata {
         eventId: string,
         data: EncryptedData,
         userId: string,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {

--- a/packages/sdk/src/streamStateView_Members.ts
+++ b/packages/sdk/src/streamStateView_Members.ts
@@ -69,7 +69,7 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
     applySnapshot(
         eventId: string,
         snapshot: Snapshot,
-        cleartexts: Record<string, string> | undefined,
+        cleartexts: Record<string, Uint8Array | string> | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ): void {
         if (!snapshot.members) {
@@ -168,7 +168,7 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
 
     prependEvent(
         _event: RemoteTimelineEvent,
-        _cleartext: string | undefined,
+        _cleartext: Uint8Array | string | undefined,
         _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
@@ -180,7 +180,7 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
      */
     appendEvent(
         event: RemoteTimelineEvent,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
@@ -462,7 +462,7 @@ export class StreamStateView_Members extends StreamStateView_AbstractContent {
     private addPin(
         creatorUserId: string,
         event: RemoteTimelineEvent,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ) {

--- a/packages/sdk/src/streamStateView_Mls.ts
+++ b/packages/sdk/src/streamStateView_Mls.ts
@@ -38,7 +38,7 @@ export class StreamStateView_Mls extends StreamStateView_AbstractContent {
 
     appendEvent(
         event: RemoteTimelineEvent,
-        _cleartext: string | undefined,
+        _cleartext: Uint8Array | string | undefined,
         _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
@@ -91,7 +91,7 @@ export class StreamStateView_Mls extends StreamStateView_AbstractContent {
 
     prependEvent(
         _event: RemoteTimelineEvent,
-        _cleartext: string | undefined,
+        _cleartext: Uint8Array | string | undefined,
         _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {

--- a/packages/sdk/src/streamStateView_Space.ts
+++ b/packages/sdk/src/streamStateView_Space.ts
@@ -46,7 +46,7 @@ export class StreamStateView_Space extends StreamStateView_AbstractContent {
         eventHash: string,
         _snapshot: Snapshot,
         content: SpacePayload_Snapshot,
-        _cleartexts: Record<string, string> | undefined,
+        _cleartexts: Record<string, Uint8Array | string> | undefined,
         _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
     ): void {
         // loop over content.channels, update space channels metadata
@@ -68,7 +68,7 @@ export class StreamStateView_Space extends StreamStateView_AbstractContent {
 
     prependEvent(
         event: RemoteTimelineEvent,
-        _cleartext: string | undefined,
+        _cleartext: Uint8Array | string | undefined,
         _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
@@ -98,7 +98,7 @@ export class StreamStateView_Space extends StreamStateView_AbstractContent {
 
     appendEvent(
         event: RemoteTimelineEvent,
-        _cleartext: string | undefined,
+        _cleartext: Uint8Array | string | undefined,
         _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {

--- a/packages/sdk/src/streamStateView_UnknownContent.ts
+++ b/packages/sdk/src/streamStateView_UnknownContent.ts
@@ -10,7 +10,7 @@ export class StreamStateView_UnknownContent extends StreamStateView_AbstractCont
 
     prependEvent(
         _event: RemoteTimelineEvent,
-        _cleartext: string | undefined,
+        _cleartext: Uint8Array | string | undefined,
         _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
@@ -19,7 +19,7 @@ export class StreamStateView_UnknownContent extends StreamStateView_AbstractCont
 
     appendEvent(
         _event: RemoteTimelineEvent,
-        _cleartext: string | undefined,
+        _cleartext: Uint8Array | string | undefined,
         _emitter: TypedEmitter<StreamEvents> | undefined,
     ): void {
         throw new Error(`Unknown content type`)

--- a/packages/sdk/src/streamStateView_User.ts
+++ b/packages/sdk/src/streamStateView_User.ts
@@ -40,7 +40,7 @@ export class StreamStateView_User extends StreamStateView_AbstractContent {
 
     prependEvent(
         event: RemoteTimelineEvent,
-        _cleartext: string | undefined,
+        _cleartext: Uint8Array | string | undefined,
         _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
@@ -67,7 +67,7 @@ export class StreamStateView_User extends StreamStateView_AbstractContent {
 
     appendEvent(
         event: RemoteTimelineEvent,
-        cleartext: string | undefined,
+        cleartext: Uint8Array | string | undefined,
         _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {

--- a/packages/sdk/src/streamStateView_UserInbox.ts
+++ b/packages/sdk/src/streamStateView_UserInbox.ts
@@ -52,7 +52,7 @@ export class StreamStateView_UserInbox extends StreamStateView_AbstractContent {
 
     prependEvent(
         event: RemoteTimelineEvent,
-        _cleartext: string | undefined,
+        _cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
@@ -75,7 +75,7 @@ export class StreamStateView_UserInbox extends StreamStateView_AbstractContent {
 
     appendEvent(
         event: RemoteTimelineEvent,
-        _cleartext: string | undefined,
+        _cleartext: Uint8Array | string | undefined,
         _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {

--- a/packages/sdk/src/streamStateView_UserMetadata.ts
+++ b/packages/sdk/src/streamStateView_UserMetadata.ts
@@ -57,7 +57,7 @@ export class StreamStateView_UserMetadata extends StreamStateView_AbstractConten
 
     prependEvent(
         _event: RemoteTimelineEvent,
-        _cleartext: string | undefined,
+        _cleartext: Uint8Array | string | undefined,
         _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
@@ -66,7 +66,7 @@ export class StreamStateView_UserMetadata extends StreamStateView_AbstractConten
 
     appendEvent(
         event: RemoteTimelineEvent,
-        _cleartext: string | undefined,
+        _cleartext: Uint8Array | string | undefined,
         encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {

--- a/packages/sdk/src/streamStateView_UserSettings.ts
+++ b/packages/sdk/src/streamStateView_UserSettings.ts
@@ -47,7 +47,7 @@ export class StreamStateView_UserSettings extends StreamStateView_AbstractConten
 
     prependEvent(
         event: RemoteTimelineEvent,
-        _cleartext: string | undefined,
+        _cleartext: Uint8Array | string | undefined,
         _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         _stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {
@@ -71,7 +71,7 @@ export class StreamStateView_UserSettings extends StreamStateView_AbstractConten
 
     appendEvent(
         event: RemoteTimelineEvent,
-        _cleartext: string | undefined,
+        _cleartext: Uint8Array | string | undefined,
         _encryptionEmitter: TypedEmitter<StreamEncryptionEvents> | undefined,
         stateEmitter: TypedEmitter<StreamStateEvents> | undefined,
     ): void {

--- a/packages/sdk/src/syncedStream.ts
+++ b/packages/sdk/src/syncedStream.ts
@@ -96,7 +96,7 @@ export class SyncedStream extends Stream implements ISyncedStream {
         miniblocks: ParsedMiniblock[],
         prependedMiniblocks: ParsedMiniblock[],
         prevSnapshotMiniblockNum: bigint,
-        cleartexts: Record<string, string> | undefined,
+        cleartexts: Record<string, Uint8Array | string> | undefined,
     ): Promise<void> {
         super.initialize(
             nextSyncCookie,
@@ -137,7 +137,7 @@ export class SyncedStream extends Stream implements ISyncedStream {
     async appendEvents(
         events: ParsedEvent[],
         nextSyncCookie: SyncCookie,
-        cleartexts: Record<string, string> | undefined,
+        cleartexts: Record<string, Uint8Array | string> | undefined,
     ): Promise<void> {
         await super.appendEvents(events, nextSyncCookie, cleartexts)
         for (const event of events) {

--- a/packages/sdk/src/syncedStreamsLoop.ts
+++ b/packages/sdk/src/syncedStreamsLoop.ts
@@ -55,7 +55,7 @@ export interface ISyncedStream {
     appendEvents(
         events: ParsedEvent[],
         nextSyncCookie: SyncCookie,
-        cleartexts: Record<string, string> | undefined,
+        cleartexts: Record<string, Uint8Array | string> | undefined,
     ): Promise<void>
 }
 

--- a/packages/sdk/src/tests/multi_ne/persistenceStore.test.ts
+++ b/packages/sdk/src/tests/multi_ne/persistenceStore.test.ts
@@ -12,9 +12,14 @@ describe('persistenceStoreTests', () => {
     })
     test('cleartextIsStored', async () => {
         const cleartext = 'decrypted event cleartext goes here'
+        const cleartextBytes = new TextEncoder().encode(cleartext)
         const eventId = genId()
-        await expect(store.saveCleartext(eventId, cleartext)).resolves.not.toThrow()
-        const cacheHit = await store.getCleartext(eventId)
+        await expect(store.saveCleartext(eventId, cleartextBytes)).resolves.not.toThrow()
+        const cacheHitBytes = await store.getCleartext(eventId)
+        const cacheHit =
+            typeof cacheHitBytes === 'string'
+                ? cacheHitBytes
+                : new TextDecoder().decode(cacheHitBytes)
         expect(cacheHit).toBe(cleartext)
     })
 

--- a/packages/sdk/src/tests/testUtils.ts
+++ b/packages/sdk/src/tests/testUtils.ts
@@ -12,6 +12,7 @@ import {
     SnapshotCaseType,
     SyncStreamsResponse,
     SyncOp,
+    EncryptedDataVersion,
 } from '@river-build/proto'
 import { Entitlements } from '../sync-agent/entitlements/entitlements'
 import { PlainMessage } from '@bufbuild/protobuf'
@@ -158,6 +159,7 @@ export const TEST_ENCRYPTED_MESSAGE_PROPS: PlainMessage<EncryptedData> = {
     senderKey: '',
     ciphertextBytes: new Uint8Array(0),
     ivBytes: new Uint8Array(0),
+    version: EncryptedDataVersion.ENCRYPTED_DATA_VERSION_1,
 }
 
 export const getXchainConfigForTesting = (): XchainConfig => {

--- a/protocol/protocol.proto
+++ b/protocol/protocol.proto
@@ -728,6 +728,13 @@ message StreamSettings {
  */
 message EncryptedData {
     /**
+     * Encrypted payload when algorithm is set to mls_0.0.1
+     */
+     message Mls {
+        uint64 epoch = 1;
+        bytes ciphertext = 2;
+      }
+    /**
     * Ciphertext of the encryption envelope.
     */
     string ciphertext = 1;
@@ -758,11 +765,6 @@ message EncryptedData {
     /**
      * Encrypted payload when algorithm is set to mls_0.0.1
      */
-    message Mls {
-      uint64 epoch = 1;
-      bytes ciphertext = 2;
-    }
-
     optional Mls mls = 7;
 
     // Used if algorithm is set to 'grpaes'
@@ -773,6 +775,9 @@ message EncryptedData {
 
     // Used if algorithm is set to 'grpaes'
     bytes session_id_bytes = 10;
+
+    // used to parse data after it's decrypted
+    EncryptedDataVersion version = 11; 
 }
 
 message WrappedEncryptedData {
@@ -1056,6 +1061,11 @@ enum MessageInteractionType {
 enum GroupMentionType {
     GROUP_MENTION_TYPE_UNSPECIFIED = 0;
     GROUP_MENTION_TYPE_AT_CHANNEL = 1;
+}
+
+enum EncryptedDataVersion {
+    ENCRYPTED_DATA_VERSION_0 = 0;
+    ENCRYPTED_DATA_VERSION_1 = 1;
 }
 
 // Codes from 1 to 16 match gRPC/Connect codes.


### PR DESCRIPTION
We are updating the encrypted payloads to have byte encoded payloads. For hybrid encryption this means bytes in bytes out encryption, for olm we base64 the bytes and encrypt that.

This pr also switches mls over to the new encrytion type