### PR TITLE
Reduce the largish log volume for a small set of corrupt streams we've deemed not worthy of repair

### DIFF
--- a/core/node/rpc/archiver.go
+++ b/core/node/rpc/archiver.go
@@ -1044,7 +1044,11 @@ func (a *Archiver) worker(ctx context.Context) {
 			}
 			err := a.ArchiveStream(ctx, record.(*ArchiveStream))
 			if err != nil {
-				log.Errorw("archiver.worker: Failed to archive stream", "error", err, "streamId", streamId)
+				// Do not log for the known set of streams that were registered under an operator address.
+				// These errors are not worth tracking.
+				if !IsRiverErrorCode(err, Err_UNKNOWN_NODE) {
+					log.Errorw("archiver.worker: Failed to archive stream", "error", err, "streamId", streamId)
+				}
 				a.failedOpsCount.Add(1)
 			} else {
 				a.successOpsCount.Add(1)


### PR DESCRIPTION
There are about 30 streams that were accidentally created when some nodes were running under their operator addresses, and these streams will consistently come up as unable to archive since the node the stream was allocated, but these errors are uninformative. They come up repeatedly because we retry stuff to self-heal the corrupted streams list, so let's just ignore this error type altogether.