### PR TITLE
Rename userNickname to logId

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -221,7 +221,7 @@ export class Client
         highPriorityStreamIds?: string[],
         unpackEnvelopeOpts?: UnpackEnvelopeOpts,
         defaultGroupEncryptionAlgorithm?: GroupEncryptionAlgorithmId,
-        userNickname?: string,
+        logId?: string,
     ) {
         super()
         if (logNamespaceFilter) {
@@ -245,7 +245,7 @@ export class Client
             defaultGroupEncryptionAlgorithm ?? GroupEncryptionAlgorithmId.HybridGroupEncryption
 
         const shortId =
-            userNickname ??
+            logId ??
             shortenHexString(this.userId.startsWith('0x') ? this.userId.slice(2) : this.userId)
 
         this.logCall = dlog('csb:cl:call').extend(shortId)


### PR DESCRIPTION
So it doesn’t get confused with a product feature for nicknames