### PR TITLE
Remove the limit on number of usernames decrypted in one go

### DIFF
--- a/packages/sdk/src/memberMetadata_Usernames.ts
+++ b/packages/sdk/src/memberMetadata_Usernames.ts
@@ -4,15 +4,10 @@ import { usernameChecksum } from './utils'
 import { dlog } from '@river-build/dlog'
 import { StreamEncryptionEvents, StreamStateEvents } from './streamEvents'
 
-// this is a hack to prevent too much cpu usage from spamming the client with too many decrypted names
-// temporary until we move encrypted user and display names to the user metadata stream
-const MAX_DECRYPTED_NAMES_PER_STREAM = 50
-
 const textDecoder = new TextDecoder()
 
 export class MemberMetadata_Usernames {
     log = dlog('csb:streams:usernames')
-    private decryptionDispatchCount = 0
     readonly streamId: string
     readonly plaintextUsernames = new Map<string, string>()
     readonly userIdToEventId = new Map<string, string>()
@@ -63,15 +58,13 @@ export class MemberMetadata_Usernames {
                 userId,
                 typeof cleartext === 'string' ? cleartext : textDecoder.decode(cleartext),
             )
-        } else if (this.decryptionDispatchCount < MAX_DECRYPTED_NAMES_PER_STREAM) {
-            this.decryptionDispatchCount++
-            // Clear the plaintext username for this user on name change
-            this.plaintextUsernames.delete(userId)
-            encryptionEmitter?.emit('newEncryptedContent', this.streamId, eventId, {
-                kind: 'text',
-                content: encryptedData,
-            })
         }
+        // Clear the plaintext username for this user on name change
+        this.plaintextUsernames.delete(userId)
+        encryptionEmitter?.emit('newEncryptedContent', this.streamId, eventId, {
+            kind: 'text',
+            content: encryptedData,
+        })
 
         if (!pending) {
             this.confirmedUserIds.add(userId)


### PR DESCRIPTION
I think we still need throttling here, but now that the new encryption is in I want to clear the way for new spaces to scale up.

fixes TOWNS-17886