### PR TITLE
Mock olm.wasm to disable spurious errors

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -62,7 +62,8 @@
         "seedrandom": "^3.0.5",
         "typed-emitter": "^2.1.0",
         "typescript": "^5.1.6",
-        "vite-plugin-wasm": "^3.4.1"
+        "vite-plugin-wasm": "^3.4.1",
+        "vitest-fetch-mock": "^0.4.3"
     },
     "files": [
         "/dist"

--- a/packages/sdk/vitest.setup.ts
+++ b/packages/sdk/vitest.setup.ts
@@ -1,1 +1,38 @@
-import 'fake-indexeddb/auto'
+import 'fake-indexeddb/auto';
+import createFetchMock from 'vitest-fetch-mock';
+import { vi } from 'vitest';
+
+const fetchMocker = createFetchMock(vi);
+import { readFile } from 'fs/promises';
+import { resolve } from 'path';
+
+const olmWasmPath = resolve(__dirname, '../../node_modules/@matrix-org/olm/olm.wasm');
+
+// Return olm.wasm from olm package
+fetchMocker.mockIf(/olm\.wasm$/, async (_req: Request) => {
+    try {
+        const wasmContent = await readFile(olmWasmPath); // Read binary data
+
+        // Construct and return a Response object
+        return new Response(wasmContent, {
+            status: 200,
+            headers: {
+                'Content-Type': 'application/wasm',
+                'Cache-Control': 'public, max-age=31536000, immutable', // Optional caching
+                'Access-Control-Allow-Origin': '*', // Optional CORS
+            },
+        });
+    } catch (error) {
+        console.error('Error serving .wasm file:', error);
+
+        // Return a 500 Response object on error
+        return new Response('Internal Server Error', {
+            status: 500,
+            headers: {
+                'Content-Type': 'text/plain',
+            },
+        });
+    }
+});
+
+fetchMocker.enableMocks();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6724,6 +6724,7 @@ __metadata:
     typescript: ^5.1.6
     vite-plugin-wasm: ^3.4.1
     vitest: ^2.1.5
+    vitest-fetch-mock: ^0.4.3
   languageName: unknown
   linkType: soft
 
@@ -29944,6 +29945,15 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: a06d35566338794a877538ddacccccfdac30df7e260546dc0513e77191b86a13398b86a8082bb6c842013b0d3062f951f624a3f800867cbf06aef89e49767d6c
+  languageName: node
+  linkType: hard
+
+"vitest-fetch-mock@npm:^0.4.3":
+  version: 0.4.3
+  resolution: "vitest-fetch-mock@npm:0.4.3"
+  peerDependencies:
+    vitest: ">=2.0.0"
+  checksum: e0a4d46b38ec5d50c7cc8756f8818325496f19299c5a0b4dff664085e92a9a7e2797b388627ccd607e979404fb53d4633ca2d54857f009b7938b39c2ea8a6149
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When loaded, OLM tries to load itself from disk or make a web request, which results in extra errors reported in logs.  This change will intercept that fetch request, and return `olm.wasm` loaded from `node_modules`.