### PR TITLE
[BUGFIX] Error handling fixes in pg stream store, notifications store

### DIFF
--- a/core/node/storage/pg_stream_store.go
+++ b/core/node/storage/pg_stream_store.go
@@ -56,13 +56,12 @@ func (s *PostgresStreamStore) createSettingsTableTxnWithPartitions(partitions in
 	return func(ctx context.Context, tx pgx.Tx) error {
 		log := logging.FromCtx(ctx)
 		log.Infow("Creating settings table")
-		_, err := tx.Exec(
+		if _, err := tx.Exec(
 			ctx,
 			`CREATE TABLE IF NOT EXISTS settings (
 				single_row_key BOOL PRIMARY KEY DEFAULT TRUE,
 				num_partitions INT DEFAULT 256 NOT NULL);`,
-		)
-		if err != nil {
+		); err != nil {
 			log.Errorw("Error creating settings table", "error", err)
 			return err
 		}
@@ -80,11 +79,10 @@ func (s *PostgresStreamStore) createSettingsTableTxnWithPartitions(partitions in
 		}
 
 		var numPartitions int
-		err = tx.QueryRow(
+		if err = tx.QueryRow(
 			ctx,
 			`SELECT num_partitions FROM settings WHERE single_row_key=true;`,
-		).Scan(&numPartitions)
-		if err != nil {
+		).Scan(&numPartitions); err != nil {
 			return err
 		}
 
@@ -257,12 +255,11 @@ func (s *PostgresStreamStore) acquireSchemaLock(ctx context.Context) error {
 	var lockWasUnavailable bool
 	for {
 		var acquired bool
-		err := conn.QueryRow(
+		if err := conn.QueryRow(
 			ctx,
 			"select pg_try_advisory_lock($1)",
 			lockId,
-		).Scan(&acquired)
-		if err != nil {
+		).Scan(&acquired); err != nil {
 			return AsRiverError(
 				err,
 				Err_DB_OPERATION_FAILURE,
@@ -322,26 +319,24 @@ func (s *PostgresStreamStore) acquireSchemaLock(ctx context.Context) error {
 
 func (s *PostgresStreamStore) initStreamStorage(ctx context.Context) error {
 	logging.FromCtx(ctx).Infow("Detecting other instances")
-	err := s.txRunner(
+	if err := s.txRunner(
 		ctx,
 		"listOtherInstances",
 		pgx.ReadOnly,
 		s.listOtherInstancesTx,
 		nil,
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
 
 	logging.FromCtx(ctx).Infow("Establishing database usage")
-	err = s.txRunner(
+	if err := s.txRunner(
 		ctx,
 		"initializeSingleNodeKey",
 		pgx.ReadWrite,
 		s.initializeSingleNodeKeyTx,
 		nil,
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
 
@@ -349,10 +344,9 @@ func (s *PostgresStreamStore) initStreamStorage(ctx context.Context) error {
 	// In the meantime, any other nodes should detect the new entry in the table and
 	// shut themselves down.
 	ctx, cancel := context.WithCancel(ctx)
-	err = s.acquireSchemaLock(ctx)
 	s.cleanupLockFunc = cancel
 
-	if err != nil {
+	if err := s.acquireSchemaLock(ctx); err != nil {
 		return AsRiverError(err, Err_DB_OPERATION_FAILURE).
 			Message("Unable to acquire lock on database schema").
 			Func("initStreamStorage")
@@ -493,8 +487,7 @@ func (s *PostgresStreamStore) createStreamStorageTx(
 			INSERT INTO {{minipools}} (stream_id, generation, slot_num) VALUES ($1, 1, -1);`,
 		streamId,
 	)
-	_, err := tx.Exec(ctx, sql, streamId, genesisMiniblock)
-	if err != nil {
+	if _, err := tx.Exec(ctx, sql, streamId, genesisMiniblock); err != nil {
 		if pgerr, ok := err.(*pgconn.PgError); ok && pgerr.Code == pgerrcode.UniqueViolation {
 			return WrapRiverError(Err_ALREADY_EXISTS, err).Message("stream already exists")
 		}
@@ -525,8 +518,7 @@ func (s *PostgresStreamStore) createStreamArchiveStorageTx(
 	streamId StreamId,
 ) error {
 	sql := `INSERT INTO es (stream_id, latest_snapshot_miniblock, migrated) VALUES ($1, -1, true);`
-	_, err := tx.Exec(ctx, sql, streamId)
-	if err != nil {
+	if _, err := tx.Exec(ctx, sql, streamId); err != nil {
 		if pgerr, ok := err.(*pgconn.PgError); ok && pgerr.Code == pgerrcode.UniqueViolation {
 			return WrapRiverError(Err_ALREADY_EXISTS, err).Message("stream already exists")
 		}
@@ -540,7 +532,7 @@ func (s *PostgresStreamStore) GetMaxArchivedMiniblockNumber(
 	streamId StreamId,
 ) (int64, error) {
 	var maxArchivedMiniblockNumber int64
-	err := s.txRunner(
+	if err := s.txRunner(
 		ctx,
 		"GetMaxArchivedMiniblockNumber",
 		pgx.ReadWrite,
@@ -549,8 +541,7 @@ func (s *PostgresStreamStore) GetMaxArchivedMiniblockNumber(
 		},
 		&txRunnerOpts{skipLoggingNotFound: true},
 		"streamId", streamId,
-	)
-	if err != nil {
+	); err != nil {
 		return -1, err
 	}
 	return maxArchivedMiniblockNumber, nil
@@ -562,31 +553,28 @@ func (s *PostgresStreamStore) getMaxArchivedMiniblockNumberTx(
 	streamId StreamId,
 	maxArchivedMiniblockNumber *int64,
 ) error {
-	_, err := s.lockStream(ctx, tx, streamId, false)
-	if err != nil {
+	if _, err := s.lockStream(ctx, tx, streamId, false); err != nil {
 		return err
 	}
 
-	err = tx.QueryRow(
+	if err := tx.QueryRow(
 		ctx,
 		s.sqlForStream(
 			"SELECT COALESCE(MAX(seq_num), -1) FROM {{miniblocks}} WHERE stream_id = $1",
 			streamId,
 		),
 		streamId,
-	).Scan(maxArchivedMiniblockNumber)
-	if err != nil {
+	).Scan(maxArchivedMiniblockNumber); err != nil {
 		return err
 	}
 
 	if *maxArchivedMiniblockNumber == -1 {
 		var exists bool
-		err = tx.QueryRow(
+		if err := tx.QueryRow(
 			ctx,
 			"SELECT EXISTS(SELECT 1 FROM es WHERE stream_id = $1)",
 			streamId,
-		).Scan(&exists)
-		if err != nil {
+		).Scan(&exists); err != nil {
 			return err
 		}
 		if !exists {
@@ -623,16 +611,15 @@ func (s *PostgresStreamStore) writeArchiveMiniblocksTx(
 	startMiniblockNum int64,
 	miniblocks [][]byte,
 ) error {
-	_, err := s.lockStream(ctx, tx, streamId, true)
-	if err != nil {
+	if _, err := s.lockStream(ctx, tx, streamId, true); err != nil {
 		return err
 	}
 
 	var lastKnownMiniblockNum int64
-	err = s.getMaxArchivedMiniblockNumberTx(ctx, tx, streamId, &lastKnownMiniblockNum)
-	if err != nil {
+	if err := s.getMaxArchivedMiniblockNumberTx(ctx, tx, streamId, &lastKnownMiniblockNum); err != nil {
 		return err
 	}
+
 	if lastKnownMiniblockNum+1 != startMiniblockNum {
 		return RiverError(
 			Err_DB_OPERATION_FAILURE,
@@ -644,7 +631,7 @@ func (s *PostgresStreamStore) writeArchiveMiniblocksTx(
 	}
 
 	for i, miniblock := range miniblocks {
-		_, err := tx.Exec(
+		if _, err := tx.Exec(
 			ctx,
 			s.sqlForStream(
 				"INSERT INTO {{miniblocks}} (stream_id, seq_num, blockdata) VALUES ($1, $2, $3)",
@@ -652,8 +639,7 @@ func (s *PostgresStreamStore) writeArchiveMiniblocksTx(
 			),
 			streamId,
 			startMiniblockNum+int64(i),
-			miniblock)
-		if err != nil {
+			miniblock); err != nil {
 			return err
 		}
 	}
@@ -666,7 +652,7 @@ func (s *PostgresStreamStore) ReadStreamFromLastSnapshot(
 	numToRead int,
 ) (*ReadStreamFromLastSnapshotResult, error) {
 	var ret *ReadStreamFromLastSnapshotResult
-	err := s.txRunner(
+	if err := s.txRunner(
 		ctx,
 		"ReadStreamFromLastSnapshot",
 		pgx.ReadWrite,
@@ -677,8 +663,7 @@ func (s *PostgresStreamStore) ReadStreamFromLastSnapshot(
 		},
 		nil,
 		"streamId", streamId,
-	)
-	if err != nil {
+	); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -696,7 +681,7 @@ func (s *PostgresStreamStore) readStreamFromLastSnapshotTx(
 	}
 
 	var lastMiniblockIndex int64
-	err = tx.
+	if err = tx.
 		QueryRow(
 			ctx,
 			s.sqlForStream(
@@ -704,8 +689,7 @@ func (s *PostgresStreamStore) readStreamFromLastSnapshotTx(
 				streamId,
 			),
 			streamId).
-		Scan(&lastMiniblockIndex)
-	if err != nil {
+		Scan(&lastMiniblockIndex); err != nil {
 		return nil, WrapRiverError(Err_INTERNAL, err).Message("db inconsistency: failed to get last miniblock index")
 	}
 
@@ -725,31 +709,33 @@ func (s *PostgresStreamStore) readStreamFromLastSnapshotTx(
 	if err != nil {
 		return nil, err
 	}
-	defer miniblocksRow.Close()
 
 	var miniblocks [][]byte
 	var counter int64 = 0
-	var readLastSeqNum int64
 	var readFirstSeqNum int64
-	for miniblocksRow.Next() {
-		var blockdata []byte
-		err = miniblocksRow.Scan(&blockdata, &readLastSeqNum)
-		if err != nil {
-			return nil, err
-		}
-		if counter == 0 {
-			readFirstSeqNum = readLastSeqNum
-		} else if readLastSeqNum != readFirstSeqNum+counter {
-			return nil, RiverError(
-				Err_INTERNAL,
-				"Miniblocks consistency violation - miniblocks are not sequential in db",
-				"ActualSeqNum", readLastSeqNum,
-				"ExpectedSeqNum", readFirstSeqNum+counter)
-		}
-		miniblocks = append(miniblocks, blockdata)
-		counter++
+
+	var blockdata []byte
+	var readLastSeqNum int64
+	if _, err := pgx.ForEachRow(
+		miniblocksRow,
+		[]any{&blockdata, &readLastSeqNum},
+		func() error {
+			if counter == 0 {
+				readFirstSeqNum = readLastSeqNum
+			} else if readLastSeqNum != readFirstSeqNum+counter {
+				return RiverError(
+					Err_INTERNAL,
+					"Miniblocks consistency violation - miniblocks are not sequential in db",
+					"ActualSeqNum", readLastSeqNum,
+					"ExpectedSeqNum", readFirstSeqNum+counter)
+			}
+			miniblocks = append(miniblocks, blockdata)
+			counter++
+			return nil
+		},
+	); err != nil {
+		return nil, err
 	}
-	miniblocksRow.Close()
 
 	if !(readFirstSeqNum <= snapshotMiniblockIndex && snapshotMiniblockIndex <= readLastSeqNum) {
 		return nil, RiverError(
@@ -771,21 +757,18 @@ func (s *PostgresStreamStore) readStreamFromLastSnapshotTx(
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
 	var envelopes [][]byte
 	var expectedGeneration int64 = readLastSeqNum + 1
 	var expectedSlot int64 = -1
-	for rows.Next() {
-		var envelope []byte
-		var generation int64
-		var slotNum int64
-		err = rows.Scan(&envelope, &generation, &slotNum)
-		if err != nil {
-			return nil, err
-		}
+
+	// Scan variables
+	var envelope []byte
+	var generation int64
+	var slotNum int64
+	if _, err := pgx.ForEachRow(rows, []any{&envelope, &generation, &slotNum}, func() error {
 		if generation != expectedGeneration {
-			return nil, RiverError(
+			return RiverError(
 				Err_MINIBLOCKS_STORAGE_FAILURE,
 				"Minipool consistency violation - minipool generation doesn't match last miniblock generation",
 			).
@@ -793,7 +776,7 @@ func (s *PostgresStreamStore) readStreamFromLastSnapshotTx(
 				Tag("expectedGeneration", expectedGeneration)
 		}
 		if slotNum != expectedSlot {
-			return nil, RiverError(
+			return RiverError(
 				Err_MINIBLOCKS_STORAGE_FAILURE,
 				"Minipool consistency violation - slotNums are not sequential",
 			).
@@ -805,6 +788,9 @@ func (s *PostgresStreamStore) readStreamFromLastSnapshotTx(
 			envelopes = append(envelopes, envelope)
 		}
 		expectedSlot++
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return &ReadStreamFromLastSnapshotResult{
@@ -868,17 +854,11 @@ func (s *PostgresStreamStore) writeEventTx(
 	if err != nil {
 		return err
 	}
-	defer envelopesRow.Close()
 
 	var counter int = -1 // counter is set to -1 as we have service record in the first row of minipool table
-
-	for envelopesRow.Next() {
-		var generation int64
-		var slotNum int
-		err = envelopesRow.Scan(&generation, &slotNum)
-		if err != nil {
-			return err
-		}
+	var generation int64
+	var slotNum int
+	if _, err := pgx.ForEachRow(envelopesRow, []any{&generation, &slotNum}, func() error {
 		if generation != minipoolGeneration {
 			return RiverError(Err_DB_OPERATION_FAILURE, "Wrong event generation in minipool").
 				Tag("ExpectedGeneration", minipoolGeneration).Tag("ActualGeneration", generation)
@@ -889,6 +869,9 @@ func (s *PostgresStreamStore) writeEventTx(
 		}
 		// Slots number for envelopes start from 1, so we skip counter equal to zero
 		counter++
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// At this moment counter should be equal to minipoolSlot otherwise it is discrepancy of actual and expected records in minipool
@@ -910,7 +893,7 @@ func (s *PostgresStreamStore) writeEventTx(
 	}
 
 	// All checks passed - we need to insert event into minipool
-	_, err = tx.Exec(
+	if _, err = tx.Exec(
 		ctx,
 		s.sqlForStream(
 			"INSERT INTO {{minipools}} (stream_id, envelope, generation, slot_num) VALUES ($1, $2, $3, $4)",
@@ -920,8 +903,7 @@ func (s *PostgresStreamStore) writeEventTx(
 		envelope,
 		minipoolGeneration,
 		minipoolSlot,
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
 	return nil
@@ -940,7 +922,7 @@ func (s *PostgresStreamStore) ReadMiniblocks(
 	toExclusive int64,
 ) ([][]byte, error) {
 	var miniblocks [][]byte
-	err := s.txRunner(
+	if err := s.txRunner(
 		ctx,
 		"ReadMiniblocks",
 		pgx.ReadWrite,
@@ -953,8 +935,7 @@ func (s *PostgresStreamStore) ReadMiniblocks(
 		"streamId", streamId,
 		"fromInclusive", fromInclusive,
 		"toExclusive", toExclusive,
-	)
-	if err != nil {
+	); err != nil {
 		return nil, err
 	}
 
@@ -968,8 +949,7 @@ func (s *PostgresStreamStore) readMiniblocksTx(
 	fromInclusive int64,
 	toExclusive int64,
 ) ([][]byte, error) {
-	_, err := s.lockStream(ctx, tx, streamId, false)
-	if err != nil {
+	if _, err := s.lockStream(ctx, tx, streamId, false); err != nil {
 		return nil, err
 	}
 
@@ -986,30 +966,27 @@ func (s *PostgresStreamStore) readMiniblocksTx(
 	if err != nil {
 		return nil, err
 	}
-	defer miniblocksRow.Close()
 
 	// Retrieve miniblocks starting from the latest miniblock with snapshot
 	miniblocks := make([][]byte, 0, toExclusive-fromInclusive)
 
 	var prevSeqNum int = -1 // There is no negative generation, so we use it as a flag on the first step of the loop during miniblocks sequence check
-	for miniblocksRow.Next() {
-		var blockdata []byte
-		var seq_num int
+	var blockdata []byte
+	var seq_num int
 
-		err = miniblocksRow.Scan(&blockdata, &seq_num)
-		if err != nil {
-			return nil, err
-		}
-
+	if _, err := pgx.ForEachRow(miniblocksRow, []any{&blockdata, &seq_num}, func() error {
 		if (prevSeqNum != -1) && (seq_num != prevSeqNum+1) {
 			// There is a gap in sequence numbers
-			return nil, RiverError(Err_MINIBLOCKS_STORAGE_FAILURE, "Miniblocks consistency violation").
+			return RiverError(Err_MINIBLOCKS_STORAGE_FAILURE, "Miniblocks consistency violation").
 				Tag("ActualBlockNumber", seq_num).Tag("ExpectedBlockNumber", prevSeqNum+1).Tag("streamId", streamId)
 		}
 		prevSeqNum = seq_num
-
 		miniblocks = append(miniblocks, blockdata)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
+
 	return miniblocks, nil
 }
 
@@ -1039,8 +1016,7 @@ func (s *PostgresStreamStore) readMiniblocksByStreamTx(
 	streamId StreamId,
 	onEachMb func(blockdata []byte, seqNum int) error,
 ) error {
-	_, err := s.lockStream(ctx, tx, streamId, false)
-	if err != nil {
+	if _, err := s.lockStream(ctx, tx, streamId, false); err != nil {
 		return err
 	}
 
@@ -1107,26 +1083,26 @@ func (s *PostgresStreamStore) writeMiniblockCandidateTx(
 	blockNumber int64,
 	miniblock []byte,
 ) error {
-	_, err := s.lockStream(ctx, tx, streamId, true)
-	if err != nil {
+	if _, err := s.lockStream(ctx, tx, streamId, true); err != nil {
 		return err
 	}
 
 	var seqNum *int64
-	err = tx.QueryRow(
+	if err := tx.QueryRow(
 		ctx,
 		s.sqlForStream(
 			"SELECT MAX(seq_num) as latest_blocks_number FROM {{miniblocks}} WHERE stream_id = $1",
 			streamId,
 		),
 		streamId,
-	).Scan(&seqNum)
-	if err != nil {
+	).Scan(&seqNum); err != nil {
 		return err
 	}
+
 	if seqNum == nil {
 		return RiverError(Err_NOT_FOUND, "No blocks for the stream found in block storage")
 	}
+
 	// Candidate block number should be greater than the last block number in storage.
 	if blockNumber <= *seqNum {
 		return RiverError(Err_MINIBLOCKS_STORAGE_FAILURE, "Candidate is too old").
@@ -1134,7 +1110,7 @@ func (s *PostgresStreamStore) writeMiniblockCandidateTx(
 	}
 
 	// insert miniblock proposal into miniblock_candidates table
-	_, err = tx.Exec(
+	if _, err := tx.Exec(
 		ctx,
 		s.sqlForStream(
 			"INSERT INTO {{miniblock_candidates}} (stream_id, seq_num, block_hash, blockdata) VALUES ($1, $2, $3, $4)",
@@ -1144,8 +1120,7 @@ func (s *PostgresStreamStore) writeMiniblockCandidateTx(
 		blockNumber,
 		hex.EncodeToString(blockHash.Bytes()), // avoid leading '0x'
 		miniblock,
-	)
-	if err != nil {
+	); err != nil {
 		if pgErr, ok := err.(*pgconn.PgError); ok && pgErr.Code == pgerrcode.UniqueViolation {
 			return RiverError(Err_ALREADY_EXISTS, "Miniblock candidate already exists")
 		}
@@ -1188,13 +1163,12 @@ func (s *PostgresStreamStore) readMiniblockCandidateTx(
 	blockHash common.Hash,
 	blockNumber int64,
 ) ([]byte, error) {
-	_, err := s.lockStream(ctx, tx, streamId, false)
-	if err != nil {
+	if _, err := s.lockStream(ctx, tx, streamId, false); err != nil {
 		return nil, err
 	}
 
 	var miniblock []byte
-	err = tx.QueryRow(
+	if err := tx.QueryRow(
 		ctx,
 		s.sqlForStream(
 			"SELECT blockdata FROM {{miniblock_candidates}} WHERE stream_id = $1 AND seq_num = $2 AND block_hash = $3",
@@ -1203,8 +1177,7 @@ func (s *PostgresStreamStore) readMiniblockCandidateTx(
 		streamId,
 		blockNumber,
 		hex.EncodeToString(blockHash.Bytes()), // avoid leading '0x'
-	).Scan(&miniblock)
-	if err != nil {
+	).Scan(&miniblock); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, RiverError(Err_NOT_FOUND, "Miniblock candidate not found")
 		}
@@ -1282,24 +1255,22 @@ func (s *PostgresStreamStore) writeMiniblocksTx(
 	prevMinipoolGeneration int64,
 	prevMinipoolSize int,
 ) error {
-	_, err := s.lockStream(ctx, tx, streamId, true)
-	if err != nil {
+	if _, err := s.lockStream(ctx, tx, streamId, true); err != nil {
 		return err
 	}
 
 	var lastMbNumInStorage *int64
-
-	err = tx.QueryRow(
+	if err := tx.QueryRow(
 		ctx,
 		s.sqlForStream(
 			"SELECT MAX(seq_num) FROM {{miniblocks}} WHERE stream_id = $1",
 			streamId,
 		),
 		streamId,
-	).Scan(&lastMbNumInStorage)
-	if err != nil {
+	).Scan(&lastMbNumInStorage); err != nil {
 		return err
 	}
+
 	if lastMbNumInStorage == nil {
 		return RiverError(
 			Err_INTERNAL,
@@ -1428,13 +1399,12 @@ func (s *PostgresStreamStore) writeMiniblocksTx(
 
 	// Update stream_snapshots_index if needed.
 	if newLastSnapshotMiniblock > -1 {
-		_, err := tx.Exec(
+		if _, err := tx.Exec(
 			ctx,
 			`UPDATE es SET latest_snapshot_miniblock = $1 WHERE stream_id = $2`,
 			newLastSnapshotMiniblock,
 			streamId,
-		)
-		if err != nil {
+		); err != nil {
 			return err
 		}
 	}
@@ -1474,8 +1444,7 @@ func (s *PostgresStreamStore) GetStreamsNumber(ctx context.Context) (int, error)
 func (s *PostgresStreamStore) getStreamsNumberTx(ctx context.Context, tx pgx.Tx) (int, error) {
 	var count int
 	row := tx.QueryRow(ctx, "SELECT COUNT(stream_id) FROM es")
-	err := row.Scan(&count)
-	if err != nil {
+	if err := row.Scan(&count); err != nil {
 		return 0, err
 	}
 	logging.FromCtx(ctx).Debugw("GetStreamsNumberTx", "count", count)
@@ -1485,8 +1454,7 @@ func (s *PostgresStreamStore) getStreamsNumberTx(ctx context.Context, tx pgx.Tx)
 // Close removes instance record from singlenodekey table, releases the listener connection, and
 // closes the postgres connection pool
 func (s *PostgresStreamStore) Close(ctx context.Context) {
-	err := s.CleanupStreamStorage(ctx)
-	if err != nil {
+	if err := s.CleanupStreamStorage(ctx); err != nil {
 		log := logging.FromCtx(ctx)
 		log.Errorw("Error when deleting singlenodekey entry", "error", err)
 	}
@@ -1518,7 +1486,7 @@ func (s *PostgresStreamStore) cleanupStreamStorageTx(ctx context.Context, tx pgx
 // GetStreams returns a list of all event streams
 func (s *PostgresStreamStore) GetStreams(ctx context.Context) ([]StreamId, error) {
 	var streams []StreamId
-	err := s.txRunner(
+	if err := s.txRunner(
 		ctx,
 		"GetStreams",
 		pgx.ReadOnly,
@@ -1528,8 +1496,7 @@ func (s *PostgresStreamStore) GetStreams(ctx context.Context) ([]StreamId, error
 			return err
 		},
 		nil,
-	)
-	if err != nil {
+	); err != nil {
 		return nil, err
 	}
 	return streams, nil
@@ -1541,20 +1508,18 @@ func (s *PostgresStreamStore) getStreamsTx(ctx context.Context, tx pgx.Tx) ([]St
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var streamName string
-		err = rows.Scan(&streamName)
-		if err != nil {
-			return nil, err
-		}
+
+	var streamName string
+	if _, err := pgx.ForEachRow(rows, []any{&streamName}, func() error {
 		streams = append(streams, streamName)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	ret := make([]StreamId, len(streams))
 	for i, stream := range streams {
-		ret[i], err = StreamIdFromString(stream)
-		if err != nil {
+		if ret[i], err = StreamIdFromString(stream); err != nil {
 			return nil, err
 		}
 	}
@@ -1575,12 +1540,11 @@ func (s *PostgresStreamStore) DeleteStream(ctx context.Context, streamId StreamI
 }
 
 func (s *PostgresStreamStore) deleteStreamTx(ctx context.Context, tx pgx.Tx, streamId StreamId) error {
-	_, err := s.lockStream(ctx, tx, streamId, true)
-	if err != nil {
+	if _, err := s.lockStream(ctx, tx, streamId, true); err != nil {
 		return err
 	}
 
-	_, err = tx.Exec(
+	_, err := tx.Exec(
 		ctx,
 		s.sqlForStream(
 			`DELETE from {{miniblocks}} WHERE stream_id = $1;
@@ -1609,17 +1573,12 @@ func (s *PostgresStreamStore) listOtherInstancesTx(ctx context.Context, tx pgx.T
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
 
 	found := false
-	for rows.Next() {
-		var storedUUID string
-		var storedTimestamp time.Time
-		var storedInfo string
-		err := rows.Scan(&storedUUID, &storedTimestamp, &storedInfo)
-		if err != nil {
-			return err
-		}
+	var storedUUID string
+	var storedTimestamp time.Time
+	var storedInfo string
+	if _, err := pgx.ForEachRow(rows, []any{&storedUUID, &storedTimestamp, &storedInfo}, func() error {
 		log.Infow(
 			"Found UUID during startup",
 			"uuid",
@@ -1630,6 +1589,9 @@ func (s *PostgresStreamStore) listOtherInstancesTx(ctx context.Context, tx pgx.T
 			storedInfo,
 		)
 		found = true
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	if found {
@@ -1641,8 +1603,7 @@ func (s *PostgresStreamStore) listOtherInstancesTx(ctx context.Context, tx pgx.T
 		}
 		if delay > 0 {
 			log.Infow("singlenodekey is not empty; Delaying startup to let other instance exit", "delay", delay)
-			err = SleepWithContext(ctx, delay)
-			if err != nil {
+			if err = SleepWithContext(ctx, delay); err != nil {
 				return err
 			}
 		}
@@ -1652,23 +1613,18 @@ func (s *PostgresStreamStore) listOtherInstancesTx(ctx context.Context, tx pgx.T
 }
 
 func (s *PostgresStreamStore) initializeSingleNodeKeyTx(ctx context.Context, tx pgx.Tx) error {
-	_, err := tx.Exec(ctx, "DELETE FROM singlenodekey")
-	if err != nil {
+	if _, err := tx.Exec(ctx, "DELETE FROM singlenodekey"); err != nil {
 		return err
 	}
 
-	_, err = tx.Exec(
+	_, err := tx.Exec(
 		ctx,
 		"INSERT INTO singlenodekey (uuid, storage_connection_time, info) VALUES ($1, $2, $3)",
 		s.nodeUUID,
 		time.Now(),
 		getCurrentNodeProcessInfo(s.schemaName),
 	)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // acquireListeningConnection returns a connection that listens for changes to the schema, or
@@ -1679,10 +1635,8 @@ func (s *PostgresStreamStore) acquireListeningConnection(ctx context.Context) *p
 	var conn *pgxpool.Conn
 	log := logging.FromCtx(ctx)
 	for {
-		conn, err = s.pool.Acquire(ctx)
-		if err == nil {
-			_, err = conn.Exec(ctx, "listen singlenodekey")
-			if err == nil {
+		if conn, err = s.pool.Acquire(ctx); err == nil {
+			if _, err = conn.Exec(ctx, "listen singlenodekey"); err == nil {
 				log.Debugw("Listening connection acquired")
 				return conn
 			} else {
@@ -1690,12 +1644,14 @@ func (s *PostgresStreamStore) acquireListeningConnection(ctx context.Context) *p
 			}
 		}
 		// Expect cancellations if node is shut down
-		if err == context.Canceled {
+		if errors.Is(err, context.Canceled) {
 			return nil
 		}
 		log.Debugw("Failed to acquire listening connection, retrying", "error", err)
 
 		// In the event of networking issues, wait a small period of time for recovery.
+		// (SleepWithContext should only return an error in the event of an expired or
+		// cancelled context, hence returning nil here.)
 		if err = SleepWithContext(ctx, 100*time.Millisecond); err != nil {
 			return nil
 		}
@@ -1715,8 +1671,7 @@ func (s *PostgresStreamStore) acquireConnection(ctx context.Context) (*pgxpool.C
 	// 20 retries * 1s delay = 20s of connection attempts
 	retries := 20
 	for i := 0; i < retries; i++ {
-		conn, err = s.pool.Acquire(ctx)
-		if err == nil {
+		if conn, err = s.pool.Acquire(ctx); err == nil {
 			return conn, nil
 		}
 
@@ -1765,7 +1720,7 @@ func (s *PostgresStreamStore) listenForNewNodes(ctx context.Context) {
 		notification, err := conn.Conn().WaitForNotification(ctx)
 
 		// Cancellation indicates a valid exit.
-		if err == context.Canceled {
+		if errors.Is(err, context.Canceled) {
 			return
 		}
 
@@ -1801,7 +1756,7 @@ func (s *PostgresStreamStore) DebugReadStreamData(
 	streamId StreamId,
 ) (*DebugReadStreamDataResult, error) {
 	var ret *DebugReadStreamDataResult
-	err := s.txRunner(
+	if err := s.txRunner(
 		ctx,
 		"DebugReadStreamData",
 		pgx.ReadWrite,
@@ -1812,8 +1767,7 @@ func (s *PostgresStreamStore) DebugReadStreamData(
 		},
 		nil,
 		"streamId", streamId,
-	)
-	if err != nil {
+	); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -1845,16 +1799,13 @@ func (s *PostgresStreamStore) debugReadStreamDataTx(
 	if err != nil {
 		return nil, err
 	}
-	defer miniblocksRow.Close()
 
-	for miniblocksRow.Next() {
-		var mb MiniblockDescriptor
-
-		err = miniblocksRow.Scan(&mb.MiniblockNumber, &mb.Data)
-		if err != nil {
-			return nil, err
-		}
+	var mb MiniblockDescriptor
+	if _, err := pgx.ForEachRow(miniblocksRow, []any{&mb.MiniblockNumber, &mb.Data}, func() error {
 		result.Miniblocks = append(result.Miniblocks, mb)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	rows, err := tx.Query(
@@ -1868,15 +1819,13 @@ func (s *PostgresStreamStore) debugReadStreamDataTx(
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
-	for rows.Next() {
-		var e EventDescriptor
-		err = rows.Scan(&e.Generation, &e.Slot, &e.Data)
-		if err != nil {
-			return nil, err
-		}
+	var e EventDescriptor
+	if _, err := pgx.ForEachRow(rows, []any{&e.Generation, &e.Slot, &e.Data}, func() error {
 		result.Events = append(result.Events, e)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	candRows, err := tx.Query(
@@ -1890,20 +1839,19 @@ func (s *PostgresStreamStore) debugReadStreamDataTx(
 	if err != nil {
 		return nil, err
 	}
-	defer candRows.Close()
 
-	for candRows.Next() {
-		var num int64
-		var hashStr string
-		var data []byte
-		if err = candRows.Scan(&num, &hashStr, &data); err != nil {
-			return nil, err
-		}
+	var num int64
+	var hashStr string
+	var data []byte
+	if _, err := pgx.ForEachRow(candRows, []any{&num, &hashStr, &data}, func() error {
 		result.MbCandidates = append(result.MbCandidates, MiniblockDescriptor{
 			MiniblockNumber: num,
 			Data:            data,
 			Hash:            common.HexToHash(hashStr),
 		})
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return result, nil
@@ -1914,7 +1862,7 @@ func (s *PostgresStreamStore) DebugReadStreamStatistics(
 	streamId StreamId,
 ) (*DebugReadStreamStatisticsResult, error) {
 	var ret *DebugReadStreamStatisticsResult
-	err := s.txRunner(
+	if err := s.txRunner(
 		ctx,
 		"DebugReadStreamStatistics",
 		pgx.ReadWrite,
@@ -1925,8 +1873,7 @@ func (s *PostgresStreamStore) DebugReadStreamStatistics(
 		},
 		nil,
 		"streamId", streamId,
-	)
-	if err != nil {
+	); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -1980,15 +1927,13 @@ func (s *PostgresStreamStore) debugReadStreamStatisticsTx(
 	if err != nil {
 		return nil, AsRiverError(err, Err_DB_OPERATION_FAILURE).Tag("query", "candidates")
 	}
-	defer candRows.Close()
 
-	for candRows.Next() {
-		var candidate MiniblockCandidateStatisticsResult
-		if err = candRows.Scan(&candidate.BlockNum, &candidate.Hash); err != nil {
-			return nil, err
-		}
-
+	var candidate MiniblockCandidateStatisticsResult
+	if _, err := pgx.ForEachRow(candRows, []any{&candidate.BlockNum, &candidate.Hash}, func() error {
 		result.CurrentMiniblockCandidates = append(result.CurrentMiniblockCandidates, candidate)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return result, nil
@@ -2022,21 +1967,19 @@ func (s *PostgresStreamStore) getLastMiniblockNumberTx(
 	tx pgx.Tx,
 	streamID StreamId,
 ) (int64, error) {
-	_, err := s.lockStream(ctx, tx, streamID, false)
-	if err != nil {
+	if _, err := s.lockStream(ctx, tx, streamID, false); err != nil {
 		return 0, err
 	}
 
 	var maxSeqNum int64
-	err = tx.QueryRow(
+	if err := tx.QueryRow(
 		ctx,
 		s.sqlForStream(
 			"SELECT MAX(seq_num) FROM {{miniblocks}} WHERE stream_id = $1",
 			streamID,
 		),
 		streamID,
-	).Scan(&maxSeqNum)
-	if err != nil {
+	).Scan(&maxSeqNum); err != nil {
 		if err == pgx.ErrNoRows {
 			return 0, RiverError(Err_INTERNAL, "Stream exists in es table, but no miniblocks in DB")
 		}

--- a/core/node/storage/pg_stream_store.go
+++ b/core/node/storage/pg_stream_store.go
@@ -1980,7 +1980,7 @@ func (s *PostgresStreamStore) getLastMiniblockNumberTx(
 		),
 		streamID,
 	).Scan(&maxSeqNum); err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return 0, RiverError(Err_INTERNAL, "Stream exists in es table, but no miniblocks in DB")
 		}
 		return 0, err


### PR DESCRIPTION
As part of investigating the pg code for archiver go test flakes, I noticed and fixed the following:
- whenever we iterate over a result set using `rows.Next()` and `rows.Next()` returns false, according to the pgx documentation we are supposed to check for an error on `rows.Err()` before assuming we correctly ran through the entire result set, but we weren't doing this in several places. So, I swapped the file's predominant row iteration pattern with a pattern that uses the `pgx.ForEachRow` function, which automatically closes the result set stream and checks for errors during and after row scans.
- In some places in the code we were checking to see if `err == context.Canceled` or `err == pgx.*`  instead of checking it's unwrap tree with `errors.Is` - this was unlikely to produce error behaviors based on where we used it, but I fixed anyway since it's not a good pattern.

I also made a lot of more general `if err = ...; err != nil` changes for the sake of concision.

Why did this come up? There is an occasional test flake that comes up with the archiver where I added some extra debug information and noticed that the transaction is aborted when we get to the error check that fails the test case, but the last `Query` call succeeded. If there was an issue in the pg streaming connection for reading rows that lead this transaction to fail, then we'd like to capture that so we can be aware of it and have more information about how to debug this flake.