### PR TITLE
Prevent ultradeep callstacks on decription extensions tick

### DIFF
--- a/packages/encryption/src/decryptionExtensions.ts
+++ b/packages/encryption/src/decryptionExtensions.ts
@@ -404,7 +404,7 @@ export abstract class BaseDecryptionExtensions {
                 .catch((e) => this.log.error('ProcessTick Error', e))
                 .finally(() => {
                     this.timeoutId = undefined
-                    this.checkStartTicking()
+                    setTimeout(() => this.checkStartTicking())
                 })
         }, this.getDelayMs())
     }

--- a/packages/sdk/src/mls/queue/queueService.ts
+++ b/packages/sdk/src/mls/queue/queueService.ts
@@ -189,7 +189,7 @@ export class QueueService implements IQueueService {
                 .catch((e) => this.log.error('MLS ProcessTick Error', e))
                 .finally(() => {
                     this.timeoutId = undefined
-                    this.checkStartTicking()
+                    setTimeout(() => this.checkStartTicking())
                 })
         }, this.getDelayMs())
     }

--- a/packages/sdk/src/syncedStreamsExtension.ts
+++ b/packages/sdk/src/syncedStreamsExtension.ts
@@ -126,7 +126,7 @@ export class SyncedStreamsExtension {
                 .catch((e) => this.logError('ProcessTick Error', e))
                 .finally(() => {
                     this.timeoutId = undefined
-                    this.checkStartTicking()
+                    setTimeout(() => this.checkStartTicking(), 0)
                 })
         }, 0)
     }

--- a/packages/sdk/src/syncedStreamsLoop.ts
+++ b/packages/sdk/src/syncedStreamsLoop.ts
@@ -467,7 +467,7 @@ export class SyncedStreamsLoop {
         queueMicrotask(() => {
             tick.catch((e) => this.logError('ProcessTick Error', e)).finally(() => {
                 this.inProgressTick = undefined
-                this.checkStartTicking()
+                setTimeout(() => this.checkStartTicking())
             })
         })
     }


### PR DESCRIPTION
set timeout to push to next frame and allow previous run to get garabage collected

prevents memory leaks