### PR TITLE
Update synced streams loop to “modify stream” and add a few streams at a time

### DIFF
--- a/packages/encryption/src/decryptionExtensions.ts
+++ b/packages/encryption/src/decryptionExtensions.ts
@@ -293,7 +293,7 @@ export abstract class BaseDecryptionExtensions {
         keySolicitation: KeySolicitationContent,
     ): void {
         if (keySolicitation.deviceKey === this.userDevice.deviceKey) {
-            this.log.debug('ignoring key solicitation for our own device')
+            //this.log.debug('ignoring key solicitation for our own device')
             return
         }
         const selectedQueue =
@@ -309,7 +309,7 @@ export abstract class BaseDecryptionExtensions {
             selectedQueue.splice(index, 1)
         }
         if (keySolicitation.sessionIds.length > 0 || keySolicitation.isNewDevice) {
-            this.log.debug('new key solicitation', { fromUserId, streamId, keySolicitation })
+            //this.log.debug('new key solicitation', { fromUserId, streamId, keySolicitation })
             this.keySolicitationsNeedsSort = true
             selectedQueue.push({
                 streamId,
@@ -322,12 +322,12 @@ export abstract class BaseDecryptionExtensions {
             } satisfies KeySolicitationItem)
             this.checkStartTicking()
         } else if (index > -1) {
-            this.log.debug('cleared key solicitation', keySolicitation)
+            //this.log.debug('cleared key solicitation', keySolicitation)
         }
     }
 
     public setStreamUpToDate(streamId: string): void {
-        this.log.debug('streamUpToDate', streamId)
+        //this.log.debug('streamUpToDate', streamId)
         this.upToDateStreams.add(streamId)
         this.checkStartTicking()
     }

--- a/packages/sdk/src/clientDecryptionExtensions.ts
+++ b/packages/sdk/src/clientDecryptionExtensions.ts
@@ -144,7 +144,7 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
         const numMembers = stream.view.getMembers().joinedParticipants().size
         const maxWaitTimeSeconds = Math.max(5, Math.min(30, numMembers))
         const waitTime = maxWaitTimeSeconds * 1000 * Math.random() // this could be much better
-        this.log.debug('getRespondDelayMSForKeySolicitation', { streamId, userId, waitTime })
+        //this.log.debug('getRespondDelayMSForKeySolicitation', { streamId, userId, waitTime })
         return waitTime * multiplier
     }
 

--- a/packages/sdk/src/persistenceStore.ts
+++ b/packages/sdk/src/persistenceStore.ts
@@ -1,18 +1,30 @@
-import { PersistedMiniblock, PersistedSyncedStream, SyncCookie } from '@river-build/proto'
+import { PersistedMiniblock, PersistedSyncedStream, Snapshot } from '@river-build/proto'
 import Dexie, { Table } from 'dexie'
-import { ParsedEvent, ParsedMiniblock } from './types'
+import { ParsedMiniblock } from './types'
 import {
     persistedSyncedStreamToParsedSyncedStream,
     persistedMiniblockToParsedMiniblock,
     parsedMiniblockToPersistedMiniblock,
+    ParsedPersistedSyncedStream,
 } from './streamUtils'
 
-import { dlog, dlogError } from '@river-build/dlog'
+import { bin_toHexString, dlog, dlogError } from '@river-build/dlog'
 import { isDefined } from './check'
+import { isChannelStreamId, isDMChannelStreamId, isGDMChannelStreamId } from './id'
 
+const MAX_CACHED_SCROLLBACK_COUNT = 3
 const DEFAULT_RETRY_COUNT = 2
-const log = dlog('csb:persistence')
+const log = dlog('csb:persistence', { defaultEnabled: false })
 const logError = dlogError('csb:persistence:error')
+
+export interface LoadedStream {
+    persistedSyncedStream: ParsedPersistedSyncedStream
+    miniblocks: ParsedMiniblock[]
+    cleartexts: Record<string, Uint8Array | string> | undefined
+    snapshot: Snapshot
+    prependedMiniblocks: ParsedMiniblock[]
+    prevSnapshotMiniblockNum: bigint
+}
 
 async function fnReadRetryer<T>(
     fn: () => Promise<T | undefined>,
@@ -67,16 +79,13 @@ export interface IPersistenceStore {
     saveCleartext(eventId: string, cleartext: Uint8Array | string): Promise<void>
     getCleartext(eventId: string): Promise<Uint8Array | string | undefined>
     getCleartexts(eventIds: string[]): Promise<Record<string, Uint8Array | string> | undefined>
-    getSyncedStream(streamId: string): Promise<
-        | {
-              syncCookie: SyncCookie
-              lastSnapshotMiniblockNum: bigint
-              minipoolEvents: ParsedEvent[]
-              lastMiniblockNum: bigint
-          }
-        | undefined
-    >
+    getSyncedStream(streamId: string): Promise<ParsedPersistedSyncedStream | undefined>
     saveSyncedStream(streamId: string, syncedStream: PersistedSyncedStream): Promise<void>
+    loadStream(
+        streamId: string,
+        inPersistedSyncedStream?: ParsedPersistedSyncedStream,
+    ): Promise<LoadedStream | undefined>
+    loadStreams(streamIds: string[]): Promise<Record<string, LoadedStream | undefined>>
     saveMiniblock(streamId: string, miniblock: ParsedMiniblock): Promise<void>
     saveMiniblocks(
         streamId: string,
@@ -153,7 +162,98 @@ export class PersistenceStore extends Dexie implements IPersistenceStore {
             return undefined
         }
         const cachedSyncedStream = PersistedSyncedStream.fromBinary(record.data)
-        return persistedSyncedStreamToParsedSyncedStream(cachedSyncedStream)
+        const psstpss = persistedSyncedStreamToParsedSyncedStream(streamId, cachedSyncedStream)
+        return psstpss
+    }
+
+    async loadStream(
+        streamId: string,
+        inPersistedSyncedStream?: ParsedPersistedSyncedStream,
+    ): Promise<LoadedStream | undefined> {
+        const persistedSyncedStream =
+            inPersistedSyncedStream ?? (await this.getSyncedStream(streamId))
+        if (!persistedSyncedStream) {
+            return undefined
+        }
+
+        const miniblocks = await this.getMiniblocks(
+            streamId,
+            persistedSyncedStream.lastSnapshotMiniblockNum,
+            persistedSyncedStream.lastMiniblockNum,
+        )
+        if (miniblocks.length === 0) {
+            return undefined
+        }
+
+        const snapshot = miniblocks[0].header.snapshot
+        if (!snapshot) {
+            return undefined
+        }
+
+        const isChannelStream =
+            isChannelStreamId(streamId) ||
+            isDMChannelStreamId(streamId) ||
+            isGDMChannelStreamId(streamId)
+        const prependedMiniblocks = isChannelStream
+            ? hasTopLevelRenderableEvent(miniblocks)
+                ? []
+                : await this.cachedScrollback(
+                      streamId,
+                      miniblocks[0].header.prevSnapshotMiniblockNum,
+                      miniblocks[0].header.miniblockNum,
+                  )
+            : []
+
+        const snapshotEventIds = eventIdsFromSnapshot(snapshot)
+        const eventIds = miniblocks.flatMap((mb) => mb.events.map((e) => e.hashStr))
+        const prependedEventIds = prependedMiniblocks.flatMap((mb) =>
+            mb.events.map((e) => e.hashStr),
+        )
+        const cleartexts = await this.getCleartexts([
+            ...eventIds,
+            ...snapshotEventIds,
+            ...prependedEventIds,
+        ])
+        return {
+            persistedSyncedStream,
+            miniblocks,
+            cleartexts,
+            snapshot,
+            prependedMiniblocks,
+            prevSnapshotMiniblockNum: miniblocks[0].header.prevSnapshotMiniblockNum,
+        }
+    }
+
+    async loadStreams(streamIds: string[]) {
+        const result = await this.transaction(
+            'r',
+            [this.syncedStreams, this.cleartexts, this.miniblocks],
+            async () => {
+                const syncedStreams = await this.getSyncedStreams(streamIds)
+                const retVal: Record<string, LoadedStream | undefined> = {}
+                for (const streamId of streamIds) {
+                    retVal[streamId] = await this.loadStream(streamId, syncedStreams[streamId])
+                }
+                return retVal
+            },
+        )
+        return result
+    }
+
+    private async getSyncedStreams(streamIds: string[]) {
+        const records = await this.syncedStreams.bulkGet(streamIds)
+        const cachedSyncedStreams = records.map((x) =>
+            x
+                ? { streamId: x.streamId, data: PersistedSyncedStream.fromBinary(x.data) }
+                : undefined,
+        )
+        const psstpss = cachedSyncedStreams.reduce((acc, x) => {
+            if (x) {
+                acc[x.streamId] = persistedSyncedStreamToParsedSyncedStream(x.streamId, x.data)
+            }
+            return acc
+        }, {} as Record<string, ParsedPersistedSyncedStream | undefined>)
+        return psstpss
     }
 
     async saveSyncedStream(streamId: string, syncedStream: PersistedSyncedStream) {
@@ -256,6 +356,87 @@ export class PersistenceStore extends Dexie implements IPersistenceStore {
             log('navigator.storage unavailable')
         }
     }
+    private async cachedScrollback(
+        streamId: string,
+        fromInclusive: bigint,
+        toExclusive: bigint,
+    ): Promise<ParsedMiniblock[]> {
+        // If this is a channel, DM or GDM, perform a few scrollbacks
+        if (
+            !isChannelStreamId(streamId) &&
+            !isDMChannelStreamId(streamId) &&
+            !isGDMChannelStreamId(streamId)
+        ) {
+            return []
+        }
+        let miniblocks: ParsedMiniblock[] = []
+        for (let i = 0; i < MAX_CACHED_SCROLLBACK_COUNT; i++) {
+            if (toExclusive <= 0n) {
+                break
+            }
+            const result = await this.getMiniblocks(streamId, fromInclusive, toExclusive - 1n)
+            if (result.length > 0) {
+                miniblocks = [...result, ...miniblocks]
+                fromInclusive = result[0].header.prevSnapshotMiniblockNum
+                toExclusive = result[0].header.miniblockNum
+                if (hasTopLevelRenderableEvent(miniblocks)) {
+                    break
+                }
+            } else {
+                break
+            }
+        }
+        return miniblocks
+    }
+}
+
+function hasTopLevelRenderableEvent(miniblocks: ParsedMiniblock[]): boolean {
+    for (const mb of miniblocks) {
+        if (topLevelRenderableEventInMiniblock(mb)) {
+            return true
+        }
+    }
+    return false
+}
+
+function topLevelRenderableEventInMiniblock(miniblock: ParsedMiniblock): boolean {
+    for (const e of miniblock.events) {
+        switch (e.event.payload.case) {
+            case 'channelPayload':
+            case 'gdmChannelPayload':
+            case 'dmChannelPayload':
+                switch (e.event.payload.value.content.case) {
+                    case 'message':
+                        if (!e.event.payload.value.content.value.refEventId) {
+                            return true
+                        }
+                }
+        }
+    }
+    return false
+}
+
+function eventIdsFromSnapshot(snapshot: Snapshot): string[] {
+    const usernameEventIds =
+        snapshot.members?.joined
+            .filter((m) => isDefined(m.username))
+            .map((m) => bin_toHexString(m.username!.eventHash)) ?? []
+    const displayNameEventIds =
+        snapshot.members?.joined
+            .filter((m) => isDefined(m.displayName))
+            .map((m) => bin_toHexString(m.displayName!.eventHash)) ?? []
+
+    switch (snapshot.content.case) {
+        case 'gdmChannelContent': {
+            const channelPropertiesEventIds = snapshot.content.value.channelProperties
+                ? [bin_toHexString(snapshot.content.value.channelProperties.eventHash)]
+                : []
+
+            return [...usernameEventIds, ...displayNameEventIds, ...channelPropertiesEventIds]
+        }
+        default:
+            return [...usernameEventIds, ...displayNameEventIds]
+    }
 }
 
 //Linting below is disable as this is a stub class which is used for testing and just follows the interface
@@ -275,6 +456,14 @@ export class StubPersistenceStore implements IPersistenceStore {
 
     async getSyncedStream(streamId: string) {
         return Promise.resolve(undefined)
+    }
+
+    async loadStream(streamId: string, inPersistedSyncedStream?: ParsedPersistedSyncedStream) {
+        return Promise.resolve(undefined)
+    }
+
+    async loadStreams(streamIds: string[]) {
+        return Promise.resolve({})
     }
 
     async saveSyncedStream(streamId: string, syncedStream: PersistedSyncedStream) {

--- a/packages/sdk/src/streamUtils.ts
+++ b/packages/sdk/src/streamUtils.ts
@@ -8,6 +8,14 @@ import { ParsedEvent, ParsedMiniblock } from './types'
 import { bin_toHexString } from '@river-build/dlog'
 import { isDefined, logNever } from './check'
 
+export interface ParsedPersistedSyncedStream {
+    streamId: string
+    syncCookie: SyncCookie
+    lastSnapshotMiniblockNum: bigint
+    minipoolEvents: ParsedEvent[]
+    lastMiniblockNum: bigint
+}
+
 export function isPersistedEvent(event: ParsedEvent, direction: 'forward' | 'backward'): boolean {
     if (!event.event) {
         return false
@@ -105,18 +113,15 @@ function parsedEventToPersistedEvent(event: ParsedEvent) {
     })
 }
 
-export function persistedSyncedStreamToParsedSyncedStream(stream: PersistedSyncedStream):
-    | {
-          syncCookie: SyncCookie
-          lastSnapshotMiniblockNum: bigint
-          minipoolEvents: ParsedEvent[]
-          lastMiniblockNum: bigint
-      }
-    | undefined {
+export function persistedSyncedStreamToParsedSyncedStream(
+    streamId: string,
+    stream: PersistedSyncedStream,
+): ParsedPersistedSyncedStream | undefined {
     if (!stream.syncCookie) {
         return undefined
     }
     return {
+        streamId,
         syncCookie: stream.syncCookie,
         lastSnapshotMiniblockNum: stream.lastSnapshotMiniblockNum,
         minipoolEvents: stream.minipoolEvents.map(persistedEventToParsedEvent).filter(isDefined),

--- a/packages/sdk/src/syncedStream.ts
+++ b/packages/sdk/src/syncedStream.ts
@@ -4,12 +4,10 @@ import { Stream } from './stream'
 import { ParsedMiniblock, ParsedEvent, ParsedStreamResponse } from './types'
 import { DLogger, bin_toHexString, dlog } from '@river-build/dlog'
 import { isDefined } from './check'
-import { IPersistenceStore } from './persistenceStore'
+import { IPersistenceStore, LoadedStream } from './persistenceStore'
 import { StreamEvents } from './streamEvents'
-import { isChannelStreamId, isDMChannelStreamId, isGDMChannelStreamId } from './id'
 import { ISyncedStream } from './syncedStreamsLoop'
 
-const MAX_CACHED_SCROLLBACK_COUNT = 3
 export class SyncedStream extends Stream implements ISyncedStream {
     log: DLogger
     isUpToDate = false
@@ -22,65 +20,26 @@ export class SyncedStream extends Stream implements ISyncedStream {
         persistenceStore: IPersistenceStore,
     ) {
         super(userId, streamId, clientEmitter, logEmitFromStream)
-        this.log = dlog('csb:syncedStream').extend(userId)
+        this.log = dlog('csb:syncedStream', { defaultEnabled: false }).extend(userId)
         this.persistenceStore = persistenceStore
     }
 
-    async initializeFromPersistence(): Promise<boolean> {
-        const cachedSyncedStream = await this.persistenceStore.getSyncedStream(this.streamId)
-        if (!cachedSyncedStream) {
+    async initializeFromPersistence(persistedData?: LoadedStream): Promise<boolean> {
+        const loadedStream =
+            persistedData ?? (await this.persistenceStore.loadStream(this.streamId))
+        if (!loadedStream) {
+            this.log('No persisted data found for stream', this.streamId, persistedData)
             return false
         }
-        const miniblocks = await this.persistenceStore.getMiniblocks(
-            this.streamId,
-            cachedSyncedStream.lastSnapshotMiniblockNum,
-            cachedSyncedStream.lastMiniblockNum,
-        )
-
-        if (miniblocks.length === 0) {
-            return false
-        }
-
-        const snapshot = miniblocks[0].header.snapshot
-        if (!snapshot) {
-            return false
-        }
-
-        const isChannelStream =
-            isChannelStreamId(this.streamId) ||
-            isDMChannelStreamId(this.streamId) ||
-            isGDMChannelStreamId(this.streamId)
-        const prependedMiniblocks = isChannelStream
-            ? hasTopLevelRenderableEvent(miniblocks)
-                ? []
-                : await this.cachedScrollback(
-                      miniblocks[0].header.prevSnapshotMiniblockNum,
-                      miniblocks[0].header.miniblockNum,
-                  )
-            : []
-
-        const snapshotEventIds = eventIdsFromSnapshot(snapshot)
-        const eventIds = miniblocks.flatMap((mb) => mb.events.map((e) => e.hashStr))
-        const prependedEventIds = prependedMiniblocks.flatMap((mb) =>
-            mb.events.map((e) => e.hashStr),
-        )
-
-        const cleartexts = await this.persistenceStore.getCleartexts([
-            ...eventIds,
-            ...snapshotEventIds,
-            ...prependedEventIds,
-        ])
-
-        this.log('Initializing from persistence', this.streamId)
         try {
             super.initialize(
-                cachedSyncedStream.syncCookie,
-                cachedSyncedStream.minipoolEvents,
-                snapshot,
-                miniblocks,
-                prependedMiniblocks,
-                miniblocks[0].header.prevSnapshotMiniblockNum,
-                cleartexts,
+                loadedStream.persistedSyncedStream.syncCookie,
+                loadedStream.persistedSyncedStream.minipoolEvents,
+                loadedStream.snapshot,
+                loadedStream.miniblocks,
+                loadedStream.prependedMiniblocks,
+                loadedStream.miniblocks[0].header.prevSnapshotMiniblockNum,
+                loadedStream.cleartexts,
             )
         } catch (e) {
             this.log('Error initializing from persistence', this.streamId, e)
@@ -205,42 +164,6 @@ export class SyncedStream extends Stream implements ISyncedStream {
         await this.persistenceStore.saveSyncedStream(this.streamId, cachedSyncedStream)
     }
 
-    private async cachedScrollback(
-        fromInclusive: bigint,
-        toExclusive: bigint,
-    ): Promise<ParsedMiniblock[]> {
-        // If this is a channel, DM or GDM, perform a few scrollbacks
-        if (
-            !isChannelStreamId(this.streamId) &&
-            !isDMChannelStreamId(this.streamId) &&
-            !isGDMChannelStreamId(this.streamId)
-        ) {
-            return []
-        }
-        let miniblocks: ParsedMiniblock[] = []
-        for (let i = 0; i < MAX_CACHED_SCROLLBACK_COUNT; i++) {
-            if (toExclusive <= 0n) {
-                break
-            }
-            const result = await this.persistenceStore.getMiniblocks(
-                this.streamId,
-                fromInclusive,
-                toExclusive - 1n,
-            )
-            if (result.length > 0) {
-                miniblocks = [...result, ...miniblocks]
-                fromInclusive = result[0].header.prevSnapshotMiniblockNum
-                toExclusive = result[0].header.miniblockNum
-                if (hasTopLevelRenderableEvent(miniblocks)) {
-                    break
-                }
-            } else {
-                break
-            }
-        }
-        return miniblocks
-    }
-
     private markUpToDate(): void {
         if (this.isUpToDate) {
             return
@@ -248,53 +171,4 @@ export class SyncedStream extends Stream implements ISyncedStream {
         this.isUpToDate = true
         this.emit('streamUpToDate', this.streamId)
     }
-}
-
-function eventIdsFromSnapshot(snapshot: Snapshot): string[] {
-    const usernameEventIds =
-        snapshot.members?.joined
-            .filter((m) => isDefined(m.username))
-            .map((m) => bin_toHexString(m.username!.eventHash)) ?? []
-    const displayNameEventIds =
-        snapshot.members?.joined
-            .filter((m) => isDefined(m.displayName))
-            .map((m) => bin_toHexString(m.displayName!.eventHash)) ?? []
-
-    switch (snapshot.content.case) {
-        case 'gdmChannelContent': {
-            const channelPropertiesEventIds = snapshot.content.value.channelProperties
-                ? [bin_toHexString(snapshot.content.value.channelProperties.eventHash)]
-                : []
-
-            return [...usernameEventIds, ...displayNameEventIds, ...channelPropertiesEventIds]
-        }
-        default:
-            return [...usernameEventIds, ...displayNameEventIds]
-    }
-}
-
-function hasTopLevelRenderableEvent(miniblocks: ParsedMiniblock[]): boolean {
-    for (const mb of miniblocks) {
-        if (topLevelRenderableEventInMiniblock(mb)) {
-            return true
-        }
-    }
-    return false
-}
-
-function topLevelRenderableEventInMiniblock(miniblock: ParsedMiniblock): boolean {
-    for (const e of miniblock.events) {
-        switch (e.event.payload.case) {
-            case 'channelPayload':
-            case 'gdmChannelPayload':
-            case 'dmChannelPayload':
-                switch (e.event.payload.value.content.case) {
-                    case 'message':
-                        if (!e.event.payload.value.content.value.refEventId) {
-                            return true
-                        }
-                }
-        }
-    }
-    return false
 }

--- a/packages/sdk/src/syncedStreamsLoop.ts
+++ b/packages/sdk/src/syncedStreamsLoop.ts
@@ -1,4 +1,4 @@
-import { Err, SyncCookie, SyncOp, SyncStreamsResponse } from '@river-build/proto'
+import { SyncCookie, SyncOp, SyncStreamsResponse } from '@river-build/proto'
 import { DLogger, dlog, dlogError } from '@river-build/dlog'
 import { StreamRpcClient } from './makeStreamRpcClient'
 import { UnpackEnvelopeOpts, unpackStream, unpackStreamAndCookie } from './sign'
@@ -6,10 +6,21 @@ import { SyncedStreamEvents } from './streamEvents'
 import TypedEmitter from 'typed-emitter'
 import { nanoid } from 'nanoid'
 import { isMobileSafari } from './utils'
-import { streamIdAsBytes, streamIdAsString } from './id'
+import {
+    spaceIdFromChannelId,
+    isDMChannelStreamId,
+    isGDMChannelStreamId,
+    isSpaceStreamId,
+    isUserDeviceStreamId,
+    isUserInboxStreamId,
+    isUserSettingsStreamId,
+    isUserStreamId,
+    streamIdAsBytes,
+    streamIdAsString,
+    isChannelStreamId,
+} from './id'
 import { ParsedEvent, ParsedStreamResponse } from './types'
 import { isDefined, logNever } from './check'
-import { errorContains } from './rpcInterceptors'
 
 export enum SyncState {
     Canceling = 'Canceling', // syncLoop, maybe syncId if was syncing, not is was starting or retrying
@@ -81,6 +92,7 @@ export class SyncedStreamsLoop {
     private readonly streams: Map<string, { syncCookie: SyncCookie; stream: ISyncedStream }>
     // loggers
     private readonly logSync: DLogger
+    private readonly logDebug: DLogger
     private readonly logError: DLogger
     // clientEmitter is used to proxy the events from the streams to the client
     private readonly clientEmitter: TypedEmitter<SyncedStreamEvents>
@@ -115,8 +127,8 @@ export class SyncedStreamsLoop {
     private inProgressTick?: Promise<void>
     private pendingSyncCookies: string[] = []
     private inFlightSyncCookies = new Set<string>()
-    private readonly MAX_IN_FLIGHT_COOKIES = 25
-    private readonly MIN_IN_FLIGHT_COOKIES = 5
+    private readonly MAX_IN_FLIGHT_COOKIES = 40
+    private readonly MIN_IN_FLIGHT_COOKIES = 10
 
     public pingInfo: PingInfo = {
         currentSequence: 0,
@@ -129,6 +141,7 @@ export class SyncedStreamsLoop {
         streams: { syncCookie: SyncCookie; stream: ISyncedStream }[],
         logNamespace: string,
         readonly unpackEnvelopeOpts: UnpackEnvelopeOpts | undefined,
+        private highPriorityIds: Set<string>,
     ) {
         this.rpcClient = rpcClient
         this.clientEmitter = clientEmitter
@@ -138,7 +151,8 @@ export class SyncedStreamsLoop {
                 { syncCookie, stream },
             ]),
         )
-        this.logSync = dlog('csb:cl:sync', { defaultEnabled: false }).extend(logNamespace)
+        this.logDebug = dlog('csb:cl:sync:debug').extend(logNamespace)
+        this.logSync = dlog('csb:cl:sync', { defaultEnabled: true }).extend(logNamespace)
         this.logError = dlogError('csb:cl:sync:stream').extend(logNamespace)
     }
 
@@ -159,12 +173,12 @@ export class SyncedStreamsLoop {
         return this.syncId
     }
 
-    public async start(): Promise<void> {
+    public start() {
         if (isMobileSafari()) {
             document.addEventListener('visibilitychange', this.onMobileSafariBackgrounded)
         }
 
-        await this.createSyncLoop()
+        this.createSyncLoop()
     }
 
     public async stop() {
@@ -210,37 +224,14 @@ export class SyncedStreamsLoop {
     // adds stream to the sync subscription
     public async addStreamToSync(syncCookie: SyncCookie, stream: ISyncedStream): Promise<void> {
         const streamId = streamIdAsString(syncCookie.streamId)
-        this.log('addStreamToSync', streamId)
+        this.logDebug('addStreamToSync', streamId)
         if (this.streams.has(streamId)) {
             this.log('stream already in sync', streamId)
             return
         }
         this.streams.set(streamId, { syncCookie, stream })
-
-        if (this.syncState === SyncState.Starting || this.syncState === SyncState.Retrying) {
-            await this.waitForSyncingState()
-        }
-        if (this.syncState === SyncState.Syncing) {
-            try {
-                await this.rpcClient.addStreamToSync({
-                    syncId: this.syncId,
-                    syncPos: syncCookie,
-                })
-                this.log('addStreamToSync complete', syncCookie)
-            } catch (err) {
-                // Trigger restart of sync loop
-                this.logError(`addStreamToSync error`, err)
-                if (errorContains(err, Err.BAD_SYNC_COOKIE)) {
-                    this.log('addStreamToSync BAD_SYNC_COOKIE', syncCookie)
-                    throw err
-                }
-            }
-        } else {
-            this.log(
-                'addStreamToSync: not in "syncing" state; let main sync loop handle this with its streams map',
-                { streamId: syncCookie.streamId, syncState: this.syncState },
-            )
-        }
+        this.pendingSyncCookies.push(streamId)
+        this.checkStartTicking()
     }
 
     // remove stream from the sync subsbscription
@@ -250,6 +241,14 @@ export class SyncedStreamsLoop {
         if (!streamRecord) {
             this.log('removeStreamFromSync streamId not found', streamId)
             // no such stream
+            return
+        }
+        const pendingIndex = this.pendingSyncCookies.indexOf(streamId)
+        if (pendingIndex !== -1) {
+            this.pendingSyncCookies.splice(pendingIndex, 1)
+            streamRecord.stream.stop()
+            this.streams.delete(streamId)
+            this.log('removed stream from pending sync', streamId)
             return
         }
         if (this.syncState === SyncState.Starting || this.syncState === SyncState.Retrying) {
@@ -277,167 +276,165 @@ export class SyncedStreamsLoop {
         }
     }
 
-    private async createSyncLoop() {
-        return new Promise<void>((resolve, reject) => {
-            if (stateConstraints[this.syncState].has(SyncState.Starting)) {
-                this.setSyncState(SyncState.Starting)
-                this.log('starting sync loop')
-            } else {
-                this.log(
-                    'runSyncLoop: invalid state transition',
-                    this.syncState,
-                    '->',
-                    SyncState.Starting,
-                )
-                reject(new Error('invalid state transition'))
-            }
+    public setHighPriorityStreams(streamIds: string[]) {
+        this.highPriorityIds = new Set(streamIds)
+    }
 
-            if (this.syncLoop) {
-                reject(new Error('createSyncLoop called while a loop exists'))
-            }
+    private createSyncLoop() {
+        if (stateConstraints[this.syncState].has(SyncState.Starting)) {
+            this.setSyncState(SyncState.Starting)
+            this.log('starting sync loop')
+        } else {
+            this.log(
+                'runSyncLoop: invalid state transition',
+                this.syncState,
+                '->',
+                SyncState.Starting,
+            )
+            throw new Error('invalid state transition')
+        }
 
-            this.syncLoop = (async (): Promise<number> => {
-                let iteration = 0
+        if (this.syncLoop) {
+            throw new Error('createSyncLoop called while a loop exists')
+        }
 
-                this.log('sync loop created')
-                resolve()
+        this.syncLoop = (async (): Promise<number> => {
+            let iteration = 0
 
-                try {
-                    while (
-                        this.syncState === SyncState.Starting ||
-                        this.syncState === SyncState.Syncing ||
-                        this.syncState === SyncState.Retrying
-                    ) {
-                        this.log('sync ITERATION start', ++iteration, this.syncState)
-                        if (this.syncState === SyncState.Retrying) {
-                            this.setSyncState(SyncState.Starting)
-                        }
+            this.log('sync loop created')
 
-                        // get cookies from all the known streams to sync
-                        this.pendingSyncCookies = Array.from(this.streams.keys())
-                        try {
-                            // syncId needs to be reset before starting a new syncStreams
-                            // syncStreams() should return a new syncId
-                            this.syncId = undefined
-                            const streams = this.rpcClient.syncStreams(
-                                {
-                                    syncPos: [],
-                                },
-                                { timeoutMs: -1 },
+            try {
+                while (
+                    this.syncState === SyncState.Starting ||
+                    this.syncState === SyncState.Syncing ||
+                    this.syncState === SyncState.Retrying
+                ) {
+                    this.log('sync ITERATION start', ++iteration, this.syncState)
+                    if (this.syncState === SyncState.Retrying) {
+                        this.setSyncState(SyncState.Starting)
+                    }
+
+                    // get cookies from all the known streams to sync
+                    this.pendingSyncCookies = Array.from(this.streams.keys())
+                    try {
+                        // syncId needs to be reset before starting a new syncStreams
+                        // syncStreams() should return a new syncId
+                        this.syncId = undefined
+                        const streams = this.rpcClient.syncStreams(
+                            {
+                                syncPos: [],
+                            },
+                            { timeoutMs: -1 },
+                        )
+
+                        const iterator = streams[Symbol.asyncIterator]()
+
+                        while (
+                            this.syncState === SyncState.Syncing ||
+                            this.syncState === SyncState.Starting
+                        ) {
+                            const interruptSyncPromise = new Promise<void>((resolve, reject) => {
+                                this.forceStopSyncStreams = () => {
+                                    this.log('forceStopSyncStreams called')
+                                    resolve()
+                                }
+                                this.interruptSync = (e: unknown) => {
+                                    this.logError('sync interrupted', e)
+                                    reject(e)
+                                }
+                            })
+                            const { value, done } = await Promise.race([
+                                iterator.next(),
+                                interruptSyncPromise.then(() => ({
+                                    value: undefined,
+                                    done: true,
+                                })),
+                            ])
+                            if (done || value === undefined) {
+                                this.log('exiting syncStreams', done, value)
+                                // exit the syncLoop, it's done
+                                this.forceStopSyncStreams = undefined
+                                this.interruptSync = undefined
+                                return iteration
+                            }
+
+                            this.logDebug(
+                                'got syncStreams response',
+                                'syncOp',
+                                value.syncOp,
+                                'syncId',
+                                value.syncId,
                             )
 
-                            const iterator = streams[Symbol.asyncIterator]()
-
-                            while (
-                                this.syncState === SyncState.Syncing ||
-                                this.syncState === SyncState.Starting
-                            ) {
-                                const interruptSyncPromise = new Promise<void>(
-                                    (resolve, reject) => {
-                                        this.forceStopSyncStreams = () => {
-                                            this.log('forceStopSyncStreams called')
-                                            resolve()
-                                        }
-                                        this.interruptSync = (e: unknown) => {
-                                            this.logError('sync interrupted', e)
-                                            reject(e)
-                                        }
-                                    },
-                                )
-                                const { value, done } = await Promise.race([
-                                    iterator.next(),
-                                    interruptSyncPromise.then(() => ({
-                                        value: undefined,
-                                        done: true,
-                                    })),
-                                ])
-                                if (done || value === undefined) {
-                                    this.log('exiting syncStreams', done, value)
-                                    // exit the syncLoop, it's done
-                                    this.forceStopSyncStreams = undefined
-                                    this.interruptSync = undefined
-                                    return iteration
-                                }
-
-                                this.log(
-                                    'got syncStreams response',
-                                    'syncOp',
-                                    value.syncOp,
-                                    'syncId',
-                                    value.syncId,
-                                )
-
-                                if (!value.syncId || !value.syncOp) {
-                                    this.log('missing syncId or syncOp', value)
-                                    continue
-                                }
-                                let pingStats: NonceStats | undefined
-                                switch (value.syncOp) {
-                                    case SyncOp.SYNC_NEW:
-                                        this.syncStarted(value.syncId)
-                                        break
-                                    case SyncOp.SYNC_CLOSE:
-                                        this.syncClosed()
-                                        break
-                                    case SyncOp.SYNC_UPDATE:
-                                        this.responsesQueue.push(value)
-                                        this.checkStartTicking()
-                                        break
-                                    case SyncOp.SYNC_PONG:
-                                        pingStats = this.pingInfo.nonces[value.pongNonce]
-                                        if (pingStats) {
-                                            pingStats.receivedAt = performance.now()
-                                            pingStats.duration =
-                                                pingStats.receivedAt - pingStats.pingAt
-                                        } else {
-                                            this.logError('pong nonce not found', value.pongNonce)
-                                            this.printNonces()
-                                        }
-                                        break
-                                    case SyncOp.SYNC_DOWN:
-                                        this.syncDown(value.streamId)
-                                        break
-                                    default:
-                                        logNever(
-                                            value.syncOp,
-                                            `unknown syncOp { syncId: ${this.syncId}, syncOp: ${value.syncOp} }`,
-                                        )
-                                        break
-                                }
+                            if (!value.syncId || !value.syncOp) {
+                                this.log('missing syncId or syncOp', value)
+                                continue
                             }
-                        } catch (err) {
-                            this.logError('syncLoop error', err)
-                            await this.attemptRetry()
+                            let pingStats: NonceStats | undefined
+                            switch (value.syncOp) {
+                                case SyncOp.SYNC_NEW:
+                                    this.syncStarted(value.syncId)
+                                    break
+                                case SyncOp.SYNC_CLOSE:
+                                    this.syncClosed()
+                                    break
+                                case SyncOp.SYNC_UPDATE:
+                                    this.responsesQueue.push(value)
+                                    this.checkStartTicking()
+                                    break
+                                case SyncOp.SYNC_PONG:
+                                    pingStats = this.pingInfo.nonces[value.pongNonce]
+                                    if (pingStats) {
+                                        pingStats.receivedAt = performance.now()
+                                        pingStats.duration = pingStats.receivedAt - pingStats.pingAt
+                                    } else {
+                                        this.logError('pong nonce not found', value.pongNonce)
+                                        this.printNonces()
+                                    }
+                                    break
+                                case SyncOp.SYNC_DOWN:
+                                    this.syncDown(value.streamId)
+                                    break
+                                default:
+                                    logNever(
+                                        value.syncOp,
+                                        `unknown syncOp { syncId: ${this.syncId}, syncOp: ${value.syncOp} }`,
+                                    )
+                                    break
+                            }
                         }
+                    } catch (err) {
+                        this.logError('syncLoop error', err)
+                        await this.attemptRetry()
                     }
-                } finally {
-                    this.log('sync loop stopping ITERATION', {
-                        iteration,
-                        syncState: this.syncState,
-                    })
-                    this.stopPing()
-                    if (stateConstraints[this.syncState].has(SyncState.NotSyncing)) {
-                        this.setSyncState(SyncState.NotSyncing)
-                        this.streams.forEach((streamRecord) => {
-                            streamRecord.stream.stop()
-                        })
-                        this.streams.clear()
-                        this.releaseRetryWait = undefined
-                        this.syncId = undefined
-                        this.clientEmitter.emit('streamSyncActive', false)
-                    } else {
-                        this.log(
-                            'onStopped: invalid state transition',
-                            this.syncState,
-                            '->',
-                            SyncState.NotSyncing,
-                        )
-                    }
-                    this.log('sync loop stopped ITERATION', iteration)
                 }
-                return iteration
-            })()
-        })
+            } finally {
+                this.log('sync loop stopping ITERATION', {
+                    iteration,
+                    syncState: this.syncState,
+                })
+                this.stopPing()
+                if (stateConstraints[this.syncState].has(SyncState.NotSyncing)) {
+                    this.setSyncState(SyncState.NotSyncing)
+                    this.streams.forEach((streamRecord) => {
+                        streamRecord.stream.stop()
+                    })
+                    this.streams.clear()
+                    this.releaseRetryWait = undefined
+                    this.syncId = undefined
+                    this.clientEmitter.emit('streamSyncActive', false)
+                } else {
+                    this.log(
+                        'onStopped: invalid state transition',
+                        this.syncState,
+                        '->',
+                        SyncState.NotSyncing,
+                    )
+                }
+                this.log('sync loop stopped ITERATION', iteration)
+            }
+            return iteration
+        })()
     }
 
     private onMobileSafariBackgrounded = () => {
@@ -480,6 +477,11 @@ export class SyncedStreamsLoop {
                 this.inFlightSyncCookies.size <= this.MIN_IN_FLIGHT_COOKIES &&
                 this.pendingSyncCookies.length > 0
             ) {
+                this.pendingSyncCookies.sort((a, b) => {
+                    const aPriority = priorityFromStreamId(a, this.highPriorityIds)
+                    const bPriority = priorityFromStreamId(b, this.highPriorityIds)
+                    return aPriority - bPriority
+                })
                 const streamsToAdd = this.pendingSyncCookies.splice(0, this.MAX_IN_FLIGHT_COOKIES)
                 streamsToAdd.forEach((x) => this.inFlightSyncCookies.add(x))
                 const syncPos = streamsToAdd.map((x) => this.streams.get(x)?.syncCookie)
@@ -814,4 +816,46 @@ export class SyncedStreamsLoop {
     private log(...args: unknown[]): void {
         this.logSync(...args)
     }
+}
+
+// priority from stream id for syncing, dms if that's what we're looking at
+// channels for any high priority spaces are more important than spaces we're not looking at
+// then spaces, then other channels
+function priorityFromStreamId(streamId: string, highPriorityIds: Set<string>) {
+    if (
+        isUserDeviceStreamId(streamId) ||
+        isUserInboxStreamId(streamId) ||
+        isUserStreamId(streamId) ||
+        isUserSettingsStreamId(streamId)
+    ) {
+        return 0
+    }
+    if (highPriorityIds.has(streamId)) {
+        return 1
+    }
+
+    if (isChannelStreamId(streamId)) {
+        const spaceId = spaceIdFromChannelId(streamId)
+        if (highPriorityIds.has(spaceId)) {
+            return 2
+        } else {
+            return 3
+        }
+    }
+    // if we're prioritizing dms, load other dms and gdm channels
+    if (highPriorityIds.size > 0) {
+        const firstHPI = Array.from(highPriorityIds.values())[0]
+        if (isDMChannelStreamId(firstHPI) || isGDMChannelStreamId(firstHPI)) {
+            if (isDMChannelStreamId(streamId) || isGDMChannelStreamId(streamId)) {
+                return 4
+            }
+        }
+    }
+
+    // we need spaces to structure the app
+    if (isSpaceStreamId(streamId)) {
+        return 5
+    }
+
+    return 6
 }

--- a/packages/sdk/src/tests/multi_ne/syncedStreams.test.ts
+++ b/packages/sdk/src/tests/multi_ne/syncedStreams.test.ts
@@ -94,7 +94,7 @@ describe('syncStreams', () => {
         )
         await userInboxStream.initializeFromResponse(userInboxStreamResponse)
 
-        await alicesSyncedStreams.startSyncStreams()
+        alicesSyncedStreams.startSyncStreams()
         await done1.promise
 
         alicesSyncedStreams.set(alicesUserInboxStreamIdStr, userInboxStream)


### PR DESCRIPTION
keeps us from getting the “buffer full” messages