### PR TITLE
deploy(contract): add `EIP712Facet` deployment addresses for Omega an…

### DIFF
--- a/contracts/deployments/gamma/base/addresses/eip712Facet.json
+++ b/contracts/deployments/gamma/base/addresses/eip712Facet.json
@@ -1,0 +1,3 @@
+{
+  "address": "0x08513E183fcAf8df185247B629A05b4C0290fbAA"
+}

--- a/contracts/deployments/omega/base/addresses/eip712Facet.json
+++ b/contracts/deployments/omega/base/addresses/eip712Facet.json
@@ -1,0 +1,3 @@
+{
+  "address": "0xc079FB4e6EeA41cc9F6b779610004dB2FEb9dA06"
+}


### PR DESCRIPTION
…d Gamma

This commit includes the deployment addresses for the EIP712Facet contract in the Omega and Gamma base directories. These additions are necessary for referencing the deployed contracts in respective environments.