### PR TITLE
[BUGFIX] - Fix test schema cleanup and enforce proper cleanup by test writers

### DIFF
--- a/core/node/events/notifications_stream_tracker.go
+++ b/core/node/events/notifications_stream_tracker.go
@@ -58,7 +58,6 @@ func NewNotificationsStreamTrackerFromStreamAndCookie(
 	listener StreamEventListener,
 	userPreferences UserPreferencesStore,
 ) (*TrackedNotificationStreamView, error) {
-	// lint:ignore context.Background() is fine here
 	view, err := MakeRemoteStreamView(ctx, stream)
 	if err != nil {
 		return nil, err

--- a/core/node/rpc/tester_test.go
+++ b/core/node/rpc/tester_test.go
@@ -55,11 +55,16 @@ func (n *testNodeRecord) Close(ctx context.Context, dbUrl string) {
 		n.service = nil
 	}
 	if n.address != (common.Address{}) {
-		_ = dbtestutils.DeleteTestSchema(
-			ctx,
+	// lint:ignore context.Background() is fine here
+	err := dbtestutils.DeleteTestSchema(
+			context.Background(),
 			dbUrl,
 			storage.DbSchemaNameFromAddress(n.address.String()),
 		)
+		// Force test writers to properly clean up schemas if this fails for some reason.
+		if err != nil {
+			panic(err)
+		}
 	}
 }
 

--- a/core/node/rpc/tester_test.go
+++ b/core/node/rpc/tester_test.go
@@ -55,8 +55,8 @@ func (n *testNodeRecord) Close(ctx context.Context, dbUrl string) {
 		n.service = nil
 	}
 	if n.address != (common.Address{}) {
-	// lint:ignore context.Background() is fine here
-	err := dbtestutils.DeleteTestSchema(
+		// lint:ignore context.Background() is fine here
+		err := dbtestutils.DeleteTestSchema(
 			context.Background(),
 			dbUrl,
 			storage.DbSchemaNameFromAddress(n.address.String()),

--- a/core/node/testutils/dbtestutils/db.go
+++ b/core/node/testutils/dbtestutils/db.go
@@ -88,7 +88,12 @@ func ConfigureDB(ctx context.Context) (*config.DatabaseConfig, string, func(), e
 		return cfg,
 			dbSchemaName,
 			func() {
-				_ = DeleteTestSchema(ctx, cfg.GetUrl(), dbSchemaName)
+				// lint:ignore context.Background() is fine here
+				err := DeleteTestSchema(context.Background(), cfg.GetUrl(), dbSchemaName)
+				// Force test writers to properly clean up schemas if this fails for some reason.
+				if err != nil {
+					panic(err)
+				}
 			},
 			nil
 	}


### PR DESCRIPTION
This is a low priority bugfix of test case cleanup. Sometimes schemas were not being deleted because the context used for schema deletion would be cancelled since it was derived from a context created for the lifetime of a particular test object, and that object was cleaned up before the schema was deleted. For simplicity of reasoning, I swapped the argument ctx with context.Background() and added a panic to ensure that schemas are always properly deleted.