### PR TITLE
Update archiver continuous test timeouts to be more forgiving

### DIFF
--- a/core/node/rpc/archiver_test.go
+++ b/core/node/rpc/archiver_test.go
@@ -670,7 +670,7 @@ func TestArchiveContinuous(t *testing.T) {
 			assert.NoError(c, err)
 			assert.Zero(c, num)
 		},
-		10*time.Second,
+		15*time.Second,
 		10*time.Millisecond,
 	)
 
@@ -683,7 +683,7 @@ func TestArchiveContinuous(t *testing.T) {
 			assert.NoError(c, err)
 			assert.Equal(c, lastMB.Num, num)
 		},
-		10*time.Second,
+		15*time.Second,
 		10*time.Millisecond,
 	)
 


### PR DESCRIPTION
We're seeing occasional TestArchiveContinuous failures that appear to occur because the test timeout is just a hair too tight for the test to complete, for example we see 9/10 miniblocks on a stream in 10 seconds. This PR increases the timeouts for a check that consistently causes failures, and another check in the same test, to hopefully reduce archiver test flakes.