### PR TITLE
Implement CLI entitlement evaluation for read (join) permission on channels

### DIFF
--- a/core/cmd/is_entitled_cmd.go
+++ b/core/cmd/is_entitled_cmd.go
@@ -134,7 +134,7 @@ func init() {
 			addr := common.HexToAddress(rawUserId)
 			// HexToAddress never fails, so convert the hex back to a raw string and see if the strings match,
 			// case-insensitively.
-			if strings.EqualFold(addr.String(), rawUserId) {
+			if !strings.EqualFold(addr.String(), rawUserId) {
 				return fmt.Errorf("invalid address for walletAddr: %v, decodes to %v", rawUserId, addr.String())
 			}
 

--- a/core/cmd/is_entitled_cmd.go
+++ b/core/cmd/is_entitled_cmd.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/river-build/river/core/config"
+	"github.com/river-build/river/core/node/auth"
+	"github.com/river-build/river/core/node/crypto"
+	"github.com/river-build/river/core/node/infra"
+	"github.com/river-build/river/core/node/logging"
+	"github.com/river-build/river/core/node/shared"
+	"github.com/river-build/river/core/xchain/entitlement"
+)
+
+func isEntitledForSpaceAndChannel(
+	ctx context.Context,
+	cfg config.Config,
+	spaceId shared.StreamId,
+	channelId shared.StreamId,
+	userId string,
+) error {
+	metricsFactory := infra.NewMetricsFactory(prometheus.NewRegistry(), "", "")
+	ctx = logging.CtxWithLog(ctx, logging.DefaultZapLogger(zapcore.InfoLevel))
+	baseChain, err := crypto.NewBlockchain(
+		ctx,
+		&cfg.BaseChain,
+		nil,
+		metricsFactory,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	riverChain, err := crypto.NewBlockchain(
+		ctx,
+		&cfg.RiverChain,
+		nil,
+		metricsFactory,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	chainConfig, err := crypto.NewOnChainConfig(
+		ctx, riverChain.Client, cfg.RegistryContract.Address, riverChain.InitialBlockNum, riverChain.ChainMonitor)
+	if err != nil {
+		return err
+	}
+
+	evaluator, err := entitlement.NewEvaluatorFromConfig(
+		ctx,
+		&cfg,
+		chainConfig,
+		metricsFactory,
+	)
+	if err != nil {
+		return err
+	}
+
+	chainAuth, err := auth.NewChainAuth(
+		ctx,
+		baseChain,
+		evaluator,
+		&cfg.ArchitectContract,
+		20,
+		30000,
+		metricsFactory,
+	)
+	if err != nil {
+		return err
+	}
+
+	args := auth.NewChainAuthArgsForChannel(
+		spaceId,
+		channelId,
+		userId,
+		auth.PermissionRead,
+	)
+
+	isEntitled, err := chainAuth.IsEntitled(
+		ctx,
+		&cfg,
+		args,
+	)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("User %v entitled to read permission for\n", userId)
+	fmt.Printf(" - space   %v\n", spaceId.String())
+	fmt.Printf(" - channel %v\n", channelId.String())
+	fmt.Printf("%v\n", isEntitled)
+	return nil
+}
+
+func init() {
+	isEntitledCmd := &cobra.Command{
+		Use:          "is-entitled",
+		Short:        "Determine if a user is entitled to a space or channel",
+		SilenceUsage: true,
+	}
+
+	// isEntitledToSpaceCmd := &cobra.Command{
+	// 	Use:   "space <spaceId> <walletAddr>",
+	// 	Short: "Determine if a user is entitled to a space",
+	// 	Args:  cobra.ExactArgs(2),
+	// 	RunE:  nil,
+	// }
+
+	isEntitledToChannelCmd := &cobra.Command{
+		Use:   "channel <spaceId> <channelId> <walletAddr>",
+		Short: "Determine if a user is entitled to a channel",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			spaceId, err := shared.StreamIdFromString(args[0])
+			if err != nil {
+				return fmt.Errorf("could not parse spaceId: %w", err)
+			}
+			channelId, err := shared.StreamIdFromString(args[1])
+			if err != nil {
+				return fmt.Errorf("could not parse channelId: %w", err)
+			}
+
+			rawUserId := args[2]
+			addr := common.HexToAddress(rawUserId)
+			// HexToAddress never fails, so convert the hex back to a raw string and see if the strings match,
+			// case-insensitively.
+			if strings.EqualFold(addr.String(), rawUserId) {
+				return fmt.Errorf("invalid address for walletAddr: %v, decodes to %v", rawUserId, addr.String())
+			}
+
+			return isEntitledForSpaceAndChannel(cmd.Context(), *cmdConfig, spaceId, channelId, rawUserId)
+		},
+	}
+
+	isEntitledCmd.AddCommand(isEntitledToChannelCmd)
+	// isEntitledCmd.AddCommand(isEntitledToSpaceCmd)
+	rootCmd.AddCommand(isEntitledCmd)
+}

--- a/core/cmd/list_channels.go
+++ b/core/cmd/list_channels.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/cobra"
+
+	"github.com/river-build/river/core/config"
+	"github.com/river-build/river/core/node/auth"
+	"github.com/river-build/river/core/node/crypto"
+	"github.com/river-build/river/core/node/infra"
+	"github.com/river-build/river/core/node/shared"
+
+	"gopkg.in/yaml.v3"
+)
+
+func listChannelsForSpace(ctx context.Context, cfg config.Config, spaceId shared.StreamId) error {
+	baseChain, err := crypto.NewBlockchain(
+		ctx,
+		&cfg.BaseChain,
+		nil,
+		infra.NewMetricsFactory(prometheus.NewRegistry(), "", ""),
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	spaceContract, err := auth.NewSpaceContractV3(
+		ctx,
+		&cfg.ArchitectContract,
+		&cfg.BaseChain,
+		baseChain.Client,
+	)
+	if err != nil {
+		return fmt.Errorf("could not initalize space contract (does space exist?); %w", err)
+	}
+
+	baseChannels, err := spaceContract.GetChannels(ctx, spaceId)
+	if err != nil {
+		return fmt.Errorf("unable to fetch roles for space: %w", err)
+	}
+
+	type PrintableChannel struct {
+		Id       string
+		Disabled bool
+		Metadata string
+		roleIds  []*big.Int
+	}
+	channels := make([]PrintableChannel, len(baseChannels))
+	for i, channel := range baseChannels {
+		channels[i] = PrintableChannel{
+			Id:       channel.Id.String(),
+			Disabled: channel.Disabled,
+			Metadata: channel.Metadata,
+			roleIds:  channel.RoleIds,
+		}
+	}
+
+	d, err := yaml.Marshal(&channels)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Channels for space (%v):\n%s\n\n", spaceId, string(d))
+
+	return nil
+}
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "list-channels <spaceId>",
+		Short: "List all channels for a space",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			spaceStreamId, err := shared.StreamIdFromString(args[0])
+			if err != nil {
+				return fmt.Errorf("could not parse spaceId: %w", err)
+			}
+			return listChannelsForSpace(cmd.Context(), *cmdConfig, spaceStreamId)
+		},
+	}
+
+	rootCmd.AddCommand(cmd)
+}

--- a/core/contracts/types/channel_data.go
+++ b/core/contracts/types/channel_data.go
@@ -1,0 +1,14 @@
+package types
+
+import (
+	"math/big"
+
+	"github.com/river-build/river/core/node/shared"
+)
+
+type BaseChannel struct {
+	Id       shared.StreamId
+	Disabled bool
+	Metadata string
+	RoleIds  []*big.Int
+}

--- a/core/node/auth/space_contract.go
+++ b/core/node/auth/space_contract.go
@@ -55,4 +55,8 @@ type SpaceContract interface {
 		ctx context.Context,
 		spaceId shared.StreamId,
 	) ([]types.BaseRole, error)
+	GetChannels(
+		ctx context.Context,
+		spaceId shared.StreamId,
+	) ([]types.BaseChannel, error)
 }

--- a/core/node/auth/space_contract_v3.go
+++ b/core/node/auth/space_contract_v3.go
@@ -61,6 +61,34 @@ func NewSpaceContractV3(
 	return spaceContract, nil
 }
 
+func (sc *SpaceContractV3) GetChannels(
+	ctx context.Context,
+	spaceId shared.StreamId,
+) ([]types.BaseChannel, error) {
+	space, err := sc.getSpace(ctx, spaceId)
+	if err != nil {
+		return nil, err
+	}
+	contractChannels, err := space.channels.GetChannels(nil)
+	if err != nil {
+		return nil, err
+	}
+	baseChannels := make([]types.BaseChannel, len(contractChannels))
+	for i, channel := range contractChannels {
+		streamId, err := shared.StreamIdFromBytes(channel.Id[:])
+		if err != nil {
+			return nil, err
+		}
+		baseChannels[i] = types.BaseChannel{
+			Id:       streamId,
+			Disabled: channel.Disabled,
+			Metadata: channel.Metadata,
+			RoleIds:  channel.RoleIds,
+		}
+	}
+	return baseChannels, nil
+}
+
 func (sc *SpaceContractV3) GetRoles(
 	ctx context.Context,
 	spaceId shared.StreamId,


### PR DESCRIPTION
Usage: 

```
./env/omega/run.sh is-entitled channel 107ce9312cf40ce89426e8262de3f6701b0e27d8220000000000000000000000 207ce9312cf40ce89426e8262de3f6701b0e27d822f2e4b86c478928c2742315 0xeb59fF9fF1384eC05f3dFBee403d6640635d19bb --config ~/Desktop/omega-alchemy-config.yaml
# command-line-arguments
ld: warning: ignoring duplicate libraries: '-ldl', '-lmls_lib'
{"level":"INFO","timestamp":"2025-02-04T12:20:39.626-0800","function":"github.com/river-build/river/core/node/crypto.(*onChainConfiguration).processRawSettings","msg":"OnChainConfig: applied","settings":{"FromBlockNumber":0,"MediaMaxChunkCount":50,"MediaMaxChunkSize":500000,"RecencyConstraintsAge":11000000000,"RecencyConstraintsGen":5,"ReplicationFactor":1,"MinSnapshotEvents":{"Default":100,"UserInbox":10,"UserSettings":10,"User":10,"UserDevice":10},"StreamMiniblockRegistrationFrequency":50,"StreamCacheExpiration":300000000000,"StreamCachePollIntterval":30000000000,"GetMiniblocksMaxPageSize":0,"MembershipLimits":{"GDM":48,"DM":2},"XChain":{"Blockchains":[1,8453,137,42161,10,100]}},"currentBlock":11281184}
{"level":"WARN","timestamp":"2025-02-04T12:20:39.988-0800","function":"github.com/river-build/river/core/xchain/entitlement.NewBlockchainClientPool","msg":"Chain config not found","chainId":137}
{"level":"WARN","timestamp":"2025-02-04T12:20:39.988-0800","function":"github.com/river-build/river/core/xchain/entitlement.NewBlockchainClientPool","msg":"Chain config not found","chainId":42161}
{"level":"WARN","timestamp":"2025-02-04T12:20:39.988-0800","function":"github.com/river-build/river/core/xchain/entitlement.NewBlockchainClientPool","msg":"Chain config not found","chainId":10}
{"level":"WARN","timestamp":"2025-02-04T12:20:39.988-0800","function":"github.com/river-build/river/core/xchain/entitlement.NewBlockchainClientPool","msg":"Chain config not found","chainId":100}
User 0xeb59fF9fF1384eC05f3dFBee403d6640635d19bb entitled to read permission for
 - space   107ce9312cf40ce89426e8262de3f6701b0e27d8220000000000000000000000
 - channel 207ce9312cf40ce89426e8262de3f6701b0e27d822f2e4b86c478928c2742315
false
```

where `~/Desktop/omega-alchemy-config.yaml` is a yaml config file that contains the urls of rpc providers I was using for testing.

There's another convenience tool here for listing channels on a space, since the stream node CLI is (IMO) easier to use than making cast calls to the contract directly.