### PR TITLE
[BUGFIX] Fix lack of metrics for entitlement evaluations

### DIFF
--- a/core/cmd/is_entitled_cmd.go
+++ b/core/cmd/is_entitled_cmd.go
@@ -61,6 +61,7 @@ func isEntitledForSpaceAndChannel(
 		&cfg,
 		chainConfig,
 		metricsFactory,
+		nil,
 	)
 	if err != nil {
 		return err

--- a/core/node/rpc/server.go
+++ b/core/node/rpc/server.go
@@ -557,7 +557,7 @@ func (s *Service) serve() {
 
 func (s *Service) initEntitlements() error {
 	var err error
-	s.entitlementEvaluator, err = entitlement.NewEvaluatorFromConfig(s.serverCtx, s.config, s.chainConfig, s.metrics)
+	s.entitlementEvaluator, err = entitlement.NewEvaluatorFromConfig(s.serverCtx, s.config, s.chainConfig, s.metrics, s.otelTracer)
 	if err != nil {
 		return err
 	}

--- a/core/xchain/entitlement/client_pool.go
+++ b/core/xchain/entitlement/client_pool.go
@@ -3,6 +3,8 @@ package entitlement
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/river-build/river/core/config"
 
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -35,6 +37,7 @@ func NewBlockchainClientPool(
 	cfg *config.Config,
 	onChainCfg crypto.OnChainConfiguration,
 	metrics infra.MetricsFactory,
+	tracer trace.Tracer,
 ) (BlockchainClientPool, error) {
 	log := logging.FromCtx(ctx)
 	clients := make(map[uint64]crypto.BlockchainClient)
@@ -69,7 +72,7 @@ func NewBlockchainClientPool(
 		}
 
 		// Add metrics collection to contract calls for this chain
-		clients[chainID] = crypto.NewInstrumentedEthClient(client, chainID, metrics, nil)
+		clients[chainID] = crypto.NewInstrumentedEthClient(client, chainID, metrics, tracer)
 	}
 
 	return &blockchainClientPoolImpl{clients: clients}, nil

--- a/core/xchain/entitlement/client_pool.go
+++ b/core/xchain/entitlement/client_pool.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/river-build/river/core/node/base"
 	"github.com/river-build/river/core/node/crypto"
+	"github.com/river-build/river/core/node/infra"
 	"github.com/river-build/river/core/node/logging"
 	. "github.com/river-build/river/core/node/protocol"
 )
@@ -33,6 +34,7 @@ func NewBlockchainClientPool(
 	ctx context.Context,
 	cfg *config.Config,
 	onChainCfg crypto.OnChainConfiguration,
+	metrics infra.MetricsFactory,
 ) (BlockchainClientPool, error) {
 	log := logging.FromCtx(ctx)
 	clients := make(map[uint64]crypto.BlockchainClient)
@@ -66,7 +68,8 @@ func NewBlockchainClientPool(
 			continue
 		}
 
-		clients[chainID] = client
+		// Add metrics collection to contract calls for this chain
+		clients[chainID] = crypto.NewInstrumentedEthClient(client, chainID, metrics, nil)
 	}
 
 	return &blockchainClientPoolImpl{clients: clients}, nil

--- a/core/xchain/entitlement/entitlement_test.go
+++ b/core/xchain/entitlement/entitlement_test.go
@@ -341,6 +341,7 @@ func TestMain(m *testing.M) {
 		cfg,
 		allSepoliaChains_onChainConfig,
 		infra.NewMetricsFactory(nil, "", ""),
+		nil,
 	)
 	if err != nil {
 		panic(err)
@@ -980,6 +981,7 @@ func Test_evaluateEthBalance_withConfig(t *testing.T) {
 				allSepoliaChains_onChainConfig,
 				singleEtherChainBlockChainInfo,
 				infra.NewMetricsFactory(nil, "", ""),
+				nil,
 			)
 			require.NoError(err)
 

--- a/core/xchain/entitlement/evaluator.go
+++ b/core/xchain/entitlement/evaluator.go
@@ -38,7 +38,7 @@ func NewEvaluatorFromConfigWithBlockchainInfo(
 	blockChainInfo map[uint64]config.BlockchainInfo,
 	metrics infra.MetricsFactory,
 ) (*Evaluator, error) {
-	clients, err := NewBlockchainClientPool(ctx, cfg, onChainCfg)
+	clients, err := NewBlockchainClientPool(ctx, cfg, onChainCfg, metrics)
 	if err != nil {
 		return nil, err
 	}

--- a/core/xchain/entitlement/evaluator.go
+++ b/core/xchain/entitlement/evaluator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/river-build/river/core/config"
 	"github.com/river-build/river/core/node/crypto"
@@ -21,6 +22,7 @@ func NewEvaluatorFromConfig(
 	cfg *config.Config,
 	onChainCfg crypto.OnChainConfiguration,
 	metrics infra.MetricsFactory,
+	tracer trace.Tracer,
 ) (*Evaluator, error) {
 	return NewEvaluatorFromConfigWithBlockchainInfo(
 		ctx,
@@ -28,6 +30,7 @@ func NewEvaluatorFromConfig(
 		onChainCfg,
 		config.GetDefaultBlockchainInfo(),
 		metrics,
+		tracer,
 	)
 }
 
@@ -37,8 +40,9 @@ func NewEvaluatorFromConfigWithBlockchainInfo(
 	onChainCfg crypto.OnChainConfiguration,
 	blockChainInfo map[uint64]config.BlockchainInfo,
 	metrics infra.MetricsFactory,
+	tracer trace.Tracer,
 ) (*Evaluator, error) {
-	clients, err := NewBlockchainClientPool(ctx, cfg, onChainCfg, metrics)
+	clients, err := NewBlockchainClientPool(ctx, cfg, onChainCfg, metrics, tracer)
 	if err != nil {
 		return nil, err
 	}

--- a/core/xchain/server/server.go
+++ b/core/xchain/server/server.go
@@ -145,7 +145,7 @@ func New(
 		return nil, err
 	}
 
-	evaluator, err := entitlement.NewEvaluatorFromConfig(ctx, cfg, chainConfig, metrics)
+	evaluator, err := entitlement.NewEvaluatorFromConfig(ctx, cfg, chainConfig, metrics, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Clients created by the client pool used by the entitlement evaluator were not reporting metrics. This PR wraps those clients so that metrics and, optionally, tracing can be measured on the clients used by the entitlements module.