### PR TITLE
Add lru cache to keep session keys in memory

### DIFF
--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -27,6 +27,7 @@
         "debug": "^4.3.4",
         "dexie": "^4.0.7",
         "ethers": "^5.7.2",
+        "lru-cache": "^11.0.1",
         "nanoid": "^4.0.0",
         "typed-emitter": "^2.1.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6507,6 +6507,7 @@ __metadata:
     eslint-plugin-import: ^2.27.5
     ethers: ^5.7.2
     fake-indexeddb: ^4.0.1
+    lru-cache: ^11.0.1
     nanoid: ^4.0.0
     ts-node: ^10.9.1
     typed-emitter: ^2.1.0


### PR DESCRIPTION
loading them from index db every time is slow, especially now that we just use the same key over and over