### PR TITLE
[BUGFIX] Double auth_impl entitlements timeout

### DIFF
--- a/core/node/auth/auth_impl.go
+++ b/core/node/auth/auth_impl.go
@@ -169,7 +169,7 @@ func newArgsForLinkedWallets(principal common.Address) *ChainAuthArgs {
 }
 
 const (
-	DEFAULT_REQUEST_TIMEOUT_MS = 5000
+	DEFAULT_REQUEST_TIMEOUT_MS = 10000
 	DEFAULT_MAX_WALLETS        = 10
 )
 


### PR DESCRIPTION
Shillr is gated by a role with a rule data that has 43 token's OR'ed together, and calls to AddEvent for membership events to add members to channels were sometimes timing out on the node. Investigation showed that these timeouts often occur 5-6s into an AddEvent call, and that the chain_auth limits the duration of the segment of code that makes contracts queries in order to evaluate an entitlement to a maximum of 5s by default. Furthermore, I wrote a CLI tool to test evaluating channel entitlements locally and I see that this Shillr channel's role entitlements can sometimes can take >5s to evaluate.