### PR TITLE
Fix bug that was causing us to re-decrypt all usernames and clogging the queue

### DIFF
--- a/packages/sdk/src/memberMetadata_Usernames.ts
+++ b/packages/sdk/src/memberMetadata_Usernames.ts
@@ -58,13 +58,14 @@ export class MemberMetadata_Usernames {
                 userId,
                 typeof cleartext === 'string' ? cleartext : textDecoder.decode(cleartext),
             )
+        } else {
+            // Clear the plaintext username for this user on name change
+            this.plaintextUsernames.delete(userId)
+            encryptionEmitter?.emit('newEncryptedContent', this.streamId, eventId, {
+                kind: 'text',
+                content: encryptedData,
+            })
         }
-        // Clear the plaintext username for this user on name change
-        this.plaintextUsernames.delete(userId)
-        encryptionEmitter?.emit('newEncryptedContent', this.streamId, eventId, {
-            kind: 'text',
-            content: encryptedData,
-        })
 
         if (!pending) {
             this.confirmedUserIds.add(userId)

--- a/packages/sdk/src/tests/multi_ne/client.test.ts
+++ b/packages/sdk/src/tests/multi_ne/client.test.ts
@@ -1043,7 +1043,10 @@ describe('clientTest', () => {
         } satisfies PlainMessage<ChunkedMedia>
 
         const { eventId } = await bobsClient.setUserProfileImage(chunkedMediaInfo)
-        expect(await waitFor(() => userMetadataStream.view.events.has(eventId))).toBe(true)
+        const hasEvent = await waitFor(() => userMetadataStream.view.events.has(eventId), {
+            timeoutMS: 10000,
+        })
+        expect(hasEvent).toBe(true)
 
         const decrypted = await bobsClient.getUserProfileImage(bobsClient.userId)
         expect(decrypted).toBeDefined()
@@ -1067,7 +1070,8 @@ describe('clientTest', () => {
 
         const bio = new UserBio({ bio: 'Hello, world!' })
         const { eventId } = await bobsClient.setUserBio(bio)
-        expect(await waitFor(() => userMetadataStream.view.events.has(eventId))).toBe(true)
+        const hasEvent = await waitFor(() => userMetadataStream.view.events.has(eventId))
+        expect(hasEvent).toBe(true)
 
         const decrypted = await bobsClient.getUserBio(bobsClient.userId)
         expect(decrypted).toStrictEqual(bio)
@@ -1087,7 +1091,8 @@ describe('clientTest', () => {
 
         const bio = new UserBio({ bio: '' })
         const { eventId } = await bobsClient.setUserBio(bio)
-        expect(await waitFor(() => userMetadataStream.view.events.has(eventId))).toBe(true)
+        const hasEvent = await waitFor(() => userMetadataStream.view.events.has(eventId))
+        expect(hasEvent).toBe(true)
 
         const decrypted = await bobsClient.getUserBio(bobsClient.userId)
         expect(decrypted).toStrictEqual(bio)


### PR DESCRIPTION
dear god
i broke this here: https://github.com/river-build/river/commit/07f33f01abd1fe590d742bf9269f808c279d7905, oops