### PR TITLE
Add the peer address to the errors returned when forwarding requests

### DIFF
--- a/core/node/utils/rpc.go
+++ b/core/node/utils/rpc.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+
 	. "github.com/towns-protocol/towns/core/node/base"
 	"github.com/towns-protocol/towns/core/node/logging"
 	. "github.com/towns-protocol/towns/core/node/nodes"
@@ -137,12 +138,14 @@ func PeerNodeRequestWithRetries[T any](
 				Func("peerNodeRequestWithRetries").
 				Message("makeStubRequest failed").
 				Tag("retry", retry).
-				Tag("numRetries", numRetries)
+				Tag("numRetries", numRetries).
+				Tag("lastPeer", peer)
 		}
 	}
 	// If all requests fail, return the last error.
 	return nil, AsRiverError(err).
 		Func("peerNodeRequestWithRetries").
 		Message("All retries failed").
-		Tag("numRetries", numRetries)
+		Tag("numRetries", numRetries).
+		Tag("lastPeer", nodes.GetStickyPeer())
 }


### PR DESCRIPTION
For ease of debugging, add peer address to errors returned when forwarding fails, so we know the node that generated the most recent error.