### PR TITLE
Fixed panic in normalizeEphemeralStream function

### DIFF
--- a/core/node/events/stream_ephemeral.go
+++ b/core/node/events/stream_ephemeral.go
@@ -177,7 +177,7 @@ func (s *StreamCache) normalizeEphemeralStream(
 			var toNextPeer bool
 			for resp.Receive() {
 				msg := resp.Msg()
-				if msg == nil {
+				if msg == nil || msg.GetMiniblock() == nil {
 					_ = resp.Close()
 					toNextPeer = len(missingMbs) > 0
 					break


### PR DESCRIPTION
Nil miniblock in response identifies that the miniblocks stream is finished and the connection should be closed 