### PR TITLE
Unpack new snapshot format only

### DIFF
--- a/packages/sdk/src/sign.ts
+++ b/packages/sdk/src/sign.ts
@@ -251,7 +251,7 @@ export const unpackSnapshot = async (
     // make sure the given snapshot corresponds to the miniblock
     check(
         bin_equal(miniblock.header.snapshotHash, snapshot.hash),
-        `Snapshot hash does not match miniblock snapshot hash: ${miniblock.header.snapshotHash} != ${snapshot.hash}`,
+        'Snapshot hash does not match miniblock snapshot hash',
         Err.BAD_EVENT_ID,
     )
 


### PR DESCRIPTION
2025-05-08T16:57:42.817Z csb:error throwWithCode CodeException [Error]: Snapshot hash does not match miniblock snapshot hash