### PR TITLE
add swapRouter address in IStaticContractsInfo

### DIFF
--- a/packages/web3/src/utils/IStaticContractsInfo.ts
+++ b/packages/web3/src/utils/IStaticContractsInfo.ts
@@ -9,6 +9,7 @@ export interface BaseChainConfig {
         spaceOwner: Address
         baseRegistry: Address
         riverAirdrop?: Address
+        swapRouter?: Address
         utils: {
             mockNFT?: Address // mockErc721aAddress
             member?: Address // testGatingTokenAddress - For tesing token gating scenarios


### PR DESCRIPTION
this PR adds the swapRouter address in IStaticContractsInfo for easy access from other parts of the client