### PR TITLE
ci: bump golangci-lint-action to v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
 
             - name: Linting River Node
               if: ${{ !cancelled() && steps.setup_success.outcome == 'success' }}
-              uses: golangci/golangci-lint-action@v7
+              uses: golangci/golangci-lint-action@v8
               with:
                   version: v2.0.2
                   working-directory: core


### PR DESCRIPTION
Maintenance update: switch all jobs to golangci-lint-action@v8 for better performance and compatibility. Pure maintenance, behavior unchanged. More details in the [v8.0.0 release](https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0).