### PR TITLE
make generated package compatible with esm

### DIFF
--- a/packages/generated/package.json
+++ b/packages/generated/package.json
@@ -5,6 +5,13 @@
     "publishConfig": {
         "access": "public"
     },
+    "type": "module",
+    "imports": {
+        "#/dev/*": "./dev/*",
+        "#/v3/*": "./v3/*",
+        "#/deployments/*": "./deployments/*",
+        "#/config/*": "./config/*"
+    },
     "scripts": {
         "build": "yarn make-config",
         "make-config": "node ./scripts/make-config.js",

--- a/packages/generated/scripts/make-config.js
+++ b/packages/generated/scripts/make-config.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+import fs from 'node:fs';
+import path from 'node:path';
 
 const deploymentsOutputFile = 'config/deployments.json';
 const deploymentsSourceDir = 'deployments';


### PR DESCRIPTION
I'm curious to what this implies to the published `npm` version of this package, but this allow us to move towards `tsx` running a bot example or any of our packages correctly. 