### PR TITLE
yarn build added to vscode ~Start Local Dev steps

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,6 +14,7 @@
         "CheckVersions",
         "FoundryUp",
         "YarnInstall",
+        "YarnBuild",
         "BuildProtobufs",
       ],
       "group": {
@@ -21,6 +22,18 @@
         "isDefault": true
       },
       "dependsOrder": "sequence"
+    },
+    {
+      "label": "YarnBuild",
+      "type": "shell",
+      "command": "yarn build",
+      "isBackground": true,
+      "problemMatcher": [],
+      "presentation": {
+        "group": "ephemeral",
+        "focus": true,
+        "panel": "shared",
+      }
     },
     {
       // start local dev:


### PR DESCRIPTION
### Description

The `~Start Local Dev` vscode script has implicit assumptions about what's currently present in the local file system. For example, the playground assumes that the react-sdk is built. But the `~Start Local Dev` script does not actually build this package, resulting in a broken JS experience with errors. This PR adds a `yarn build` step to the workflow, which makes sure these implicit dependencies are explicitly built.