### PR TITLE
chore: update @ethereumjs/utils

### DIFF
--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -22,7 +22,6 @@
     },
     "dependencies": {
         "@bufbuild/protobuf": "^2.2.2",
-        "@ethereumjs/util": "^8.0.1",
         "@towns-protocol/dlog": "workspace:^",
         "@towns-protocol/olm": "3.2.28",
         "@towns-protocol/proto": "workspace:^",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -29,7 +29,7 @@
         "@connectrpc/connect": "^2.0.0",
         "@connectrpc/connect-node": "^2.0.0",
         "@connectrpc/connect-web": "^2.0.0",
-        "@ethereumjs/util": "^8.0.1",
+        "@ethereumjs/util": "^10.0.0",
         "@noble/curves": "^1.9.1",
         "@noble/hashes": "^1.8.0",
         "@towns-protocol/dlog": "workspace:^",

--- a/packages/sdk/src/signerContext.ts
+++ b/packages/sdk/src/signerContext.ts
@@ -1,4 +1,4 @@
-import { ecrecover, fromRpcSig, hashPersonalMessage } from '@ethereumjs/util'
+import { ecrecover, fromRPCSig, hashPersonalMessage } from '@ethereumjs/util'
 import { ethers } from 'ethers'
 import { bin_equal, bin_fromHexString, bin_toHexString, check } from '@towns-protocol/dlog'
 import { publicKeyToAddress, publicKeyToUint8Array, riverDelegateHashSrc } from './sign'
@@ -60,8 +60,8 @@ export const recoverPublicKeyFromDelegateSig = (params: {
             ? publicKeyToUint8Array(params.delegatePubKey)
             : params.delegatePubKey
     const hashSource = riverDelegateHashSrc(delegatePubKey, expiryEpochMs)
-    const hash = hashPersonalMessage(Buffer.from(hashSource))
-    const { v, r, s } = fromRpcSig('0x' + bin_toHexString(delegateSig))
+    const hash = hashPersonalMessage(hashSource)
+    const { v, r, s } = fromRPCSig(('0x' + bin_toHexString(delegateSig)) as `0x${string}`)
     const recoveredCreatorPubKey = ecrecover(hash, v, r, s)
     const recoveredCreatorAddress = Uint8Array.from(publicKeyToAddress(recoveredCreatorPubKey))
     return recoveredCreatorAddress

--- a/yarn.lock
+++ b/yarn.lock
@@ -2823,6 +2823,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethereumjs/rlp@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "@ethereumjs/rlp@npm:10.0.0"
+  bin:
+    rlp: bin/rlp.cjs
+  checksum: 18ef68b779cd7c721270e5479e0a4db073c92be5adcfad505a0edb06a580b96e7ec74c209c63652194150d57faeaac90190ebe311c3b8b852c34603b29d9c013
+  languageName: node
+  linkType: hard
+
 "@ethereumjs/rlp@npm:^4.0.1":
   version: 4.0.1
   resolution: "@ethereumjs/rlp@npm:4.0.1"
@@ -2844,7 +2853,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethereumjs/util@npm:^8.0.1, @ethereumjs/util@npm:^8.1.0":
+"@ethereumjs/util@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "@ethereumjs/util@npm:10.0.0"
+  dependencies:
+    "@ethereumjs/rlp": ^10.0.0
+    ethereum-cryptography: ^3.2.0
+  checksum: 9e23b0af5e87a0c923993534800f01e3df263111c6db3edfc5917796c1796c10b60586e4d90027a9a43d6664483a2d24e9e85fe8115efb99a1bea02bd5b95ce8
+  languageName: node
+  linkType: hard
+
+"@ethereumjs/util@npm:^8.1.0":
   version: 8.1.0
   resolution: "@ethereumjs/util@npm:8.1.0"
   dependencies:
@@ -8501,7 +8520,6 @@ __metadata:
   resolution: "@towns-protocol/encryption@workspace:packages/encryption"
   dependencies:
     "@bufbuild/protobuf": ^2.2.2
-    "@ethereumjs/util": ^8.0.1
     "@towns-protocol/dlog": "workspace:^"
     "@towns-protocol/olm": 3.2.28
     "@towns-protocol/proto": "workspace:^"
@@ -8697,7 +8715,7 @@ __metadata:
     "@connectrpc/connect": ^2.0.0
     "@connectrpc/connect-node": ^2.0.0
     "@connectrpc/connect-web": ^2.0.0
-    "@ethereumjs/util": ^8.0.1
+    "@ethereumjs/util": ^10.0.0
     "@noble/curves": ^1.9.1
     "@noble/hashes": ^1.8.0
     "@towns-protocol/dlog": "workspace:^"


### PR DESCRIPTION
Updating to v10 since it supports ESM and has support for browser crypto.

Removed from `@towns-protocol/encryption` since it wasn't using this dependency at all.

Note: we're only using 3 functions from this package, only  in `signerContext.ts`. 
We should be sticking with one ethereum utils package. 

Viem export those functions (with a bit of different API), and we're already using it in `web3`, so it's already in the `node_modules` of our users. 

Required for #3235 