### PR TITLE
Revert "Introduce a delay when closing a sync session runner"

### DIFF
--- a/core/node/track_streams/multi_sync_runner.go
+++ b/core/node/track_streams/multi_sync_runner.go
@@ -435,6 +435,7 @@ func (ssr *syncSessionRunner) relocateStream(streamID shared.StreamId) {
 
 	newTarget := record.remotes.AdvanceStickyPeer(ssr.node)
 	log.Debugw("Relocating stream", "oldNode", ssr.node, "newTarget", newTarget)
+	ssr.relocateStreams <- record
 }
 
 func (ssr *syncSessionRunner) GetSyncId() string {
@@ -452,7 +453,7 @@ func (ssr *syncSessionRunner) Close(err error) {
 	ssr.mu.Lock()
 	if ssr.closeErr != nil {
 		defer ssr.mu.Unlock()
-		log.Warnw("syncSessionRunner.Close already called", "existingError", ssr.closeErr, "newError", err)
+		log.Debugw("syncSessionRunner.Close already called", "existingError", ssr.closeErr, "newError", err)
 		return
 	}
 	ssr.closeErr = err
@@ -479,12 +480,6 @@ func (ssr *syncSessionRunner) Close(err error) {
 	// Kill the sync session if it is still running
 	if ssr.syncCtx.Err() == nil {
 		ssr.cancelSync(err)
-	}
-
-	// 1 second delay before relocating streams so that non-replicated streams are not causing repeated
-	// attempted connections if a node is down.
-	if err := base.SleepWithContext(ssr.rootCtx, 1*time.Second); err != nil {
-		return
 	}
 
 	// Relocate all streams on this runner.


### PR DESCRIPTION
Reverts towns-protocol/towns#3179

Looks like I introduced a typo here and missed it, and it caused a bug.