### PR TITLE
fix: resolve deadlock in applyStreamMiniblockUpdates by deferring sync task submission

### DIFF
--- a/core/node/events/stream.go
+++ b/core/node/events/stream.go
@@ -1100,15 +1100,18 @@ func (s *Stream) applyStreamMiniblockUpdates(
 	}
 
 	view, err := s.lockMuAndLoadView(ctx)
-	defer s.mu.Unlock()
 	if err != nil {
 		logging.FromCtx(ctx).Errorw("applyStreamEvents: failed to load view", "error", err)
 		return
 	}
 
 	if view == nil {
+		s.mu.Unlock()
 		return // stream is not local, no need to apply miniblock updates
 	}
+
+	// Track if we need to submit a sync task after releasing the lock
+	needsSyncTask := false
 
 	// TODO: REPLICATION: FIX: this function now can be called multiple times per block.
 	// Sanity check
@@ -1129,7 +1132,7 @@ func (s *Stream) applyStreamMiniblockUpdates(
 			})
 			if err != nil {
 				if IsRiverErrorCode(err, Err_STREAM_RECONCILIATION_REQUIRED) {
-					s.params.streamCache.SubmitSyncStreamTask(s, nil)
+					needsSyncTask = true
 				} else {
 					logging.FromCtx(ctx).Errorw("onStreamLastMiniblockUpdated: failed to promote candidate", "error", err)
 				}
@@ -1140,6 +1143,12 @@ func (s *Stream) applyStreamMiniblockUpdates(
 	}
 
 	s.lastAppliedBlockNum = blockNum
+	s.mu.Unlock()
+
+	// Submit sync task after releasing the lock to avoid deadlock
+	if needsSyncTask {
+		s.params.streamCache.SubmitSyncStreamTask(s, nil)
+	}
 }
 
 // GetQuorumNodes returns the list of nodes this stream resides on according to the stream


### PR DESCRIPTION
## Problem
Deadlock between `applyStreamMiniblockUpdates` holding `s.mu.Lock()` and sync task calling `AdvanceStickyPeer` trying to acquire the same lock.

## Solution
Move `SubmitSyncStreamTask` call outside critical section to break circular dependency.

Fixes #3090