### PR TITLE
chore: dont clean `.turbo` in `yarn-clean.sh`

### DIFF
--- a/scripts/yarn-clean.sh
+++ b/scripts/yarn-clean.sh
@@ -27,7 +27,6 @@ find . -name "node_modules" -type d -exec rm -r "{}" \;
 find . -name "dist" -type d -exec rm -r "{}" \;
 find . -name "coverage" -type d -exec rm -r "{}" \;
 find . -name "out" -type d -exec rm -r "{}" \;
-find . -name ".turbo" -type d -exec rm -r "{}" \;
 find . -name "tsconfig.tsbuildinfo" -type f -exec rm -r "{}" \;
 find . -name ".eslintcache" -type f -exec rm -r "{}" \;
 


### PR DESCRIPTION
Let's say that you moved into a branch that contains changes to the `sdk` package and you run the `kill all clean and start local dev` vscode task. This task will call `yarn-clean.sh`, but If we clean the `.turbo` folder, you will need to rebuild **all packages**. Including contracts, which takes some time.

If we keep `.turbo`, we can reuse build cache of other packages and turbo will only re-build the `sdk` package.
