### PR TITLE
set STREAM_MINIBLOCK_REGISTRATION_FREQUENCY on chain config value to 1

### DIFF
--- a/packages/contracts/scripts/interactions/InteractRiverRegistrySetFreq.s.sol
+++ b/packages/contracts/scripts/interactions/InteractRiverRegistrySetFreq.s.sol
@@ -14,7 +14,7 @@ contract InteractRiverRegistrySetFreq is Interaction {
     function __interact(address deployer) internal override {
         address riverRegistry = getDeployment("riverRegistry");
 
-        uint64 value = 10;
+        uint64 value = 1;
 
         vm.startBroadcast(deployer);
         IRiverConfig(riverRegistry).setConfiguration(


### PR DESCRIPTION
To save on gas costs end of last year the Towns protocol stopped registering every miniblock in the streams registry but only registeres every `OnChainConfig.STREAM_MINIBLOCK_REGISTRATION_FREQUENCY` miniblock for a stream. With the move to a different DA this isn't a problem anymore.

This script updates the existing script from 10 to 1. On omega this value is 50. This prevents the streams to fork again which can happen during stream migration.