### PR TITLE
Fix broken link to distribution page in delegation.mdx

### DIFF
--- a/packages/docs/towns-token/delegation.mdx
+++ b/packages/docs/towns-token/delegation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Delegation"
-description: Towns tokens follow the [ERC20Votes](https://docs.openzeppelin.com/contracts/4.x/api/token/erc20#ERC20Votes) standard and can be delegated to Node Operators on Base or Ethereum Mainnet to participate in rewards [distribution](distribution).
+description: Towns tokens follow the [ERC20Votes](https://docs.openzeppelin.com/contracts/4.x/api/token/erc20#ERC20Votes) standard and can be delegated to Node Operators on Base or Ethereum Mainnet to participate in rewards [distribution](distribution.mdx).
 ---
 
 ## Base Mainnet


### PR DESCRIPTION
Replaced the incorrect link to the "distribution" page in delegation.mdx with the correct path to distribution.mdx. This resolves the "Cannot find file" error when building or viewing the documentation.