### PR TITLE
feat: add InteractImplementationRegistry script for app registry registration

### DIFF
--- a/packages/contracts/scripts/interactions/InteractImplementationRegistry.s.sol
+++ b/packages/contracts/scripts/interactions/InteractImplementationRegistry.s.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// interfaces
+import {IImplementationRegistry} from "src/factory/facets/registry/IImplementationRegistry.sol";
+
+// contracts
+import {Interaction} from "scripts/common/Interaction.s.sol";
+import {MetadataFacet} from "src/diamond/facets/metadata/MetadataFacet.sol";
+
+contract InteractImplementationRegistry is Interaction {
+    function __interact(address deployer) internal override {
+        address spaceFactory = getDeployment("spaceFactory");
+        address appRegistry = getDeployment("appRegistry");
+
+        bytes32 appRegistryType = MetadataFacet(appRegistry).contractType();
+        address latestAppRegistry = IImplementationRegistry(spaceFactory).getLatestImplementation(
+            appRegistryType
+        );
+
+        if (latestAppRegistry == address(0)) {
+            vm.startBroadcast(deployer);
+            IImplementationRegistry(spaceFactory).addImplementation(appRegistry);
+            vm.stopBroadcast();
+        }
+
+        require(
+            IImplementationRegistry(spaceFactory).getLatestImplementation(appRegistryType) ==
+                appRegistry,
+            "appRegistry not found"
+        );
+    }
+}


### PR DESCRIPTION
### Description

Added a new script to interact with the Implementation Registry, allowing for the registration of the App Registry contract in the Space Factory.

### Changes

- Created a new script `InteractImplementationRegistry.s.sol` that checks if the App Registry is registered in the Space Factory
- Implemented logic to add the App Registry implementation if it's not already registered
- Added validation to ensure the App Registry is properly registered after the interaction

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines