### PR TITLE
increase user device expiration time to 5 day instead of 15min

### DIFF
--- a/packages/encryption/src/cryptoStore.ts
+++ b/packages/encryption/src/cryptoStore.ts
@@ -14,7 +14,7 @@ const ONE_MINUTE_MS = 60 * ONE_SECOND_MS
 const ONE_HOUR_MS = 60 * ONE_MINUTE_MS
 const ONE_DAY_MS = 24 * ONE_HOUR_MS
 
-export const DEFAULT_USER_DEVICE_EXPIRATION_TIME_MS = 10 * ONE_DAY_MS
+export const DEFAULT_USER_DEVICE_EXPIRATION_TIME_MS = 5 * ONE_DAY_MS
 
 export function createCryptoStore(databaseName: string, userId: string): CryptoStore {
     if (isBrowser) {


### PR DESCRIPTION
It was set to 15min in 2023 to catch bugs earlier.

I think it's safe to bump to 10 days as the original comment suggested. 
Original discussion on harmony: https://github.com/HereNotThere/harmony/pull/4222