### PR TITLE
upgrade actions/setup-go from v4 to v5 

### DIFF
--- a/.github/workflows/Bytecode_diff_report.yml
+++ b/.github/workflows/Bytecode_diff_report.yml
@@ -97,7 +97,7 @@ jobs:
               run: yarn install --immutable
 
             - name: Set up Go
-              uses: actions/setup-go@v4
+              uses: actions/setup-go@v5
               with:
                   go-version: '1.22' # Specify the Go version you need
 


### PR DESCRIPTION
Changes Made:
Updated from actions/setup-go@v4 to actions/setup-go@v5

For full details, see: https://github.com/actions/setup-go/releases/tag/v5.5.0