### PR TITLE
only check fulfillments against solicitations with matching device key

### DIFF
--- a/packages/sdk/src/decryptionExtensions.ts
+++ b/packages/sdk/src/decryptionExtensions.ts
@@ -1020,6 +1020,10 @@ export abstract class BaseDecryptionExtensions {
         // Remove solicitations that are completely fulfilled
         streamQueue.ephemeralKeySolicitations = streamQueue.ephemeralKeySolicitations.filter(
             (solicitation) => {
+                if (solicitation.solicitation.deviceKey !== event.deviceKey) {
+                    return true // not the same device, keep it
+                }
+
                 // Check if all requested sessions are fulfilled by this fulfillment
                 const remainingSessionIds = solicitation.solicitation.sessionIds.filter(
                     (id) => !event.sessionIds.includes(id),


### PR DESCRIPTION
sorry, i missed this check — we can't just cancel _any_ solicitation based on the session ids — we need to check that the device key matches