### PR TITLE
Add self correcting code in the persistence store for streams that have gotten out of sync

### DIFF
--- a/packages/sdk/src/persistenceStore.ts
+++ b/packages/sdk/src/persistenceStore.ts
@@ -184,6 +184,19 @@ export class PersistenceStore extends Dexie implements IPersistenceStore {
             return undefined
         }
 
+        if (
+            persistedSyncedStream.lastMiniblockNum !==
+            persistedSyncedStream.syncCookie.minipoolGen - 1n
+        ) {
+            logError(
+                'Persisted miniblock num mismatch',
+                streamId,
+                persistedSyncedStream.lastMiniblockNum,
+                persistedSyncedStream.syncCookie.minipoolGen - 1n,
+            )
+            return undefined
+        }
+
         const miniblocks = await this.getMiniblocks(
             streamId,
             persistedSyncedStream.lastSnapshotMiniblockNum,


### PR DESCRIPTION
saw this locally when testing - the stream would try to send a fulfillemnt every client restart, but the solicitation had already been fulfilled