### PR TITLE
generate-certs: use towns.com instead of hntlabs.com

### DIFF
--- a/core/scripts/generate-certs.sh
+++ b/core/scripts/generate-certs.sh
@@ -38,7 +38,7 @@ fi
 
 echo "Generating server certs..."
 current_user=$(whoami)
-email="${current_user}@hntlabs.com"
+email="${current_user}@towns.com"
 
 # Determine if we're on Ubuntu or macOS to handle OpenSSL config location
 if [[ $(uname) == "Darwin" ]]; then


### PR DESCRIPTION
Update the hntlabs.com domain to towns.com in `core/scripts/generate-certs.sh`.