### PR TITLE
Update getMembershipStatus to propogate errors up the call stack

### DIFF
--- a/packages/web3/src/space/Space.ts
+++ b/packages/web3/src/space/Space.ts
@@ -534,10 +534,7 @@ export class Space {
             })
         } catch (error) {
             log.error('getMembershipStatus expirations::error', { error })
-            // Error evaluating expirations, assume not expired
-            return {
-                isMember: false,
-            }
+            throw new Error('Error evaluating membership status', { cause: error })
         }
 
         const currentTime = BigInt(Math.floor(Date.now() / 1000))


### PR DESCRIPTION
We were seeing an issue in the stress test where clients were incorrectly being minted new memberships because the stress test evaluated those clients as not having an existing membership. The reason for that is that this method was silencing errors and returning a false membership result. Let's propagate the error here so that no one concludes a user is not a member when the call actually resulted in an error. 

### Description

<!-- Provide a clear and concise description of your changes and their purpose -->

### Changes

<!-- List the specific changes made in this PR, for example:
- Added/modified feature X
- Fixed bug in component Y
- Refactored module Z
- Updated documentation
-->

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
