### PR TITLE
process responses before calling ModifySync

### DIFF
--- a/packages/sdk/src/syncedStreamsLoop.ts
+++ b/packages/sdk/src/syncedStreamsLoop.ts
@@ -792,9 +792,10 @@ export class SyncedStreamsLoop {
         // Until we've completed canceling, accept responses
         if (this.syncState === SyncState.Syncing || this.syncState === SyncState.Canceling) {
             if (this.syncId != res.syncId) {
-                throw new Error(
+                this.logError(
                     `syncId mismatch; has:'${this.syncId}', got:${res.syncId}'. Throw away update.`,
                 )
+                return
             }
             const syncStream = res.stream
             if (syncStream !== undefined) {


### PR DESCRIPTION
We're currently performing async `ModifySync` logic _before_ we process any received responses. On startup, this potentially delays the processing of received responses while we're making calls to `ModifySync`.
Let's flip the order here.

The `syncId ===` check is already performed inside `onUpdate`, no need to do that here.