### PR TITLE
separate `tick()` into `tickResponses()` and `tickModifications()`

### DIFF
--- a/packages/sdk/src/syncedStreamsLoop.ts
+++ b/packages/sdk/src/syncedStreamsLoop.ts
@@ -563,6 +563,8 @@ export class SyncedStreamsLoop {
         queueMicrotask(() => {
             tick.catch((e) => this.logError('ProcessResponseTick Error', e)).finally(() => {
                 this.inProgressResponseTick = undefined
+                // Tick both queues, not just the response queue. Handled responses affect the ModifySync flow
+                // in the modifications queue.
                 setTimeout(() => this.checkStartTicking())
             })
         })


### PR DESCRIPTION
This PR separates the syncStreams `tick()` into two parallel queues: `tickResponses()` and `tickModifications()` — this way they can do work in parallel. Specifically the calls to `ModifySync` were previously blocking processing of responses.