### PR TITLE
fix: improve OrderedMap.Delete to return status instead of panic

### DIFF
--- a/core/node/utils/ordered_map.go
+++ b/core/node/utils/ordered_map.go
@@ -71,10 +71,10 @@ func (m *OrderedMap[K, V]) Copy(extraCapacity int) *OrderedMap[K, V] {
 	}
 }
 
-func (m *OrderedMap[K, V]) Delete(key K) {
+func (m *OrderedMap[K, V]) Delete(key K) bool {
 	val, ok := m.Map[key]
 	if !ok {
-		panic("key does not exist")
+		return false
 	}
 	delete(m.Map, key)
 	for i, v := range m.Values {
@@ -83,4 +83,5 @@ func (m *OrderedMap[K, V]) Delete(key K) {
 			break
 		}
 	}
+	return true
 }


### PR DESCRIPTION
### Description

Replace panic with a boolean return value in OrderedMap.Delete method to improve error handling. This change makes the code more robust by allowing callers to check if a key existed rather than causing a runtime panic

### Changes

- Modified `Delete` method in `OrderedMap` to return a boolean indicating success instead of panicking
- Return false when the key doesn't exist rather than panicking
- Return true when deletion is successful


### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines
