### PR TITLE
skip flaky sdk test

### DIFF
--- a/packages/sdk/src/tests/multi_ne/streamRpcClientGetSince.test.ts
+++ b/packages/sdk/src/tests/multi_ne/streamRpcClientGetSince.test.ts
@@ -112,7 +112,9 @@ describe('streamRpcClientGetSince', () => {
         })
     })
 
-    test('make a new snapshot', async () => {
+    // this test works most of the time, but fails about 1/100 times in CI
+    // leave it to test locally, but skip it in CI
+    test.skip('make a new snapshot', async () => {
         // this test expects RecencyConstraintsGen to be 5
         for (let i = 0; i < 6; i++) {
             const resp = await client.getLastMiniblockHash({ streamId: bobsSettingsStreamId })
@@ -142,19 +144,18 @@ describe('streamRpcClientGetSince', () => {
                     streamId: bobsSettingsStreamId,
                     syncCookie: cookie,
                 })
-
                 expect(
-                    streamSince.stream?.events.length,
-                    `events length for ${bobsSettingsStreamIdStr}`,
-                ).toBe(0)
+                    streamSince.stream?.syncReset,
+                    `sync reset for ${bobsSettingsStreamIdStr}`,
+                ).toBe(true)
                 expect(
                     streamSince.stream?.miniblocks.length,
                     `miniblocks length for ${bobsSettingsStreamIdStr}`,
                 ).toBeGreaterThan(0)
                 expect(
-                    streamSince.stream?.syncReset,
-                    `sync reset for ${bobsSettingsStreamIdStr}`,
-                ).toBe(true)
+                    streamSince.stream?.events.length,
+                    `events length for ${bobsSettingsStreamIdStr}`,
+                ).toBe(0)
             },
             { timeoutMS: 15000 },
         )


### PR DESCRIPTION
also swap the order of the conditions, but no changes