### PR TITLE
prioritize DMs if highPriorityIds contains a DM

### DIFF
--- a/packages/sdk/src/syncedStreamsLoop.ts
+++ b/packages/sdk/src/syncedStreamsLoop.ts
@@ -1062,7 +1062,7 @@ function priorityFromStreamId(streamId: string, highPriorityIds: Set<string>) {
         const firstHPI = Array.from(highPriorityIds.values())[0]
         if (isDMChannelStreamId(firstHPI) || isGDMChannelStreamId(firstHPI)) {
             if (isDMChannelStreamId(streamId) || isGDMChannelStreamId(streamId)) {
-                return 4
+                return 2
             }
         }
     }


### PR DESCRIPTION
This PR makes sure that if the `highPriorityIds` contains a DM, we prioritize other DMs as well over other stream types.
The _currently viewed_ DM (in `highPriorityIds`) is given prio 1.