### PR TITLE
Remove PingSync command from common commands channel

### DIFF
--- a/core/node/rpc/sync/handler.go
+++ b/core/node/rpc/sync/handler.go
@@ -153,8 +153,7 @@ func (h *handlerImpl) SyncStreams(
 	go h.runSyncStreams(req, sender, op, doneChan)
 
 	var errCode string
-	err = <-doneChan
-	if err != nil {
+	if err = <-doneChan; err != nil {
 		errCode = AsRiverError(err).Code.String()
 	}
 

--- a/core/node/rpc/sync/legacyclient/syncer_set.go
+++ b/core/node/rpc/sync/legacyclient/syncer_set.go
@@ -62,6 +62,7 @@ func NewSyncers(
 	streamCache *StreamCache,
 	nodeRegistry nodes.NodeRegistry,
 	localNodeAddress common.Address,
+	messages *dynmsgbuf.DynamicBuffer[*SyncStreamsResponse],
 	otelTracer trace.Tracer,
 ) (*SyncerSet, *dynmsgbuf.DynamicBuffer[*SyncStreamsResponse]) {
 	ss := &SyncerSet{
@@ -73,7 +74,7 @@ func NewSyncers(
 		localNodeAddress:      localNodeAddress,
 		syncers:               make(map[common.Address]client.StreamsSyncer),
 		streamID2Syncer:       make(map[StreamId]client.StreamsSyncer),
-		messages:              dynmsgbuf.NewDynamicBuffer[*SyncStreamsResponse](),
+		messages:              messages,
 		otelTracer:            otelTracer,
 	}
 	return ss, ss.messages

--- a/core/node/rpc/sync/operation_legacy.go
+++ b/core/node/rpc/sync/operation_legacy.go
@@ -21,10 +21,8 @@ func (syncOp *StreamSyncOperation) RunLegacy(
 
 	syncers, messages := legacyclient.NewSyncers(
 		syncOp.ctx, syncOp.cancel, syncOp.SyncID, syncOp.streamCache,
-		syncOp.nodeRegistry, syncOp.thisNodeAddress, syncOp.otelTracer)
+		syncOp.nodeRegistry, syncOp.thisNodeAddress, syncOp.messages, syncOp.otelTracer)
 	go syncers.Run()
-
-	syncOp.messages = messages
 
 	// Adding the initial sync position to the syncer
 	if len(req.Msg.GetSyncPos()) > 0 {

--- a/core/node/rpc/sync/subscription/e2e_test.go
+++ b/core/node/rpc/sync/subscription/e2e_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	. "github.com/towns-protocol/towns/core/node/protocol"
+	"github.com/towns-protocol/towns/core/node/rpc/sync/dynmsgbuf"
 	. "github.com/towns-protocol/towns/core/node/shared"
 	"github.com/towns-protocol/towns/core/node/testutils"
 )
@@ -57,7 +58,7 @@ func TestE2E_CompleteSubscriptionLifecycle(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer cancel(nil)
 
-	sub, err := env.manager.Subscribe(ctx, cancel, "test-sync-1")
+	sub, err := env.manager.Subscribe(ctx, cancel, "test-sync-1", dynmsgbuf.NewDynamicBuffer[*SyncStreamsResponse]())
 	require.NoError(t, err)
 
 	// Step 2: Verify subscription is registered
@@ -132,10 +133,10 @@ func TestE2E_MultipleSubscriptionsSameStream(t *testing.T) {
 	ctx2, cancel2 := context.WithCancelCause(context.Background())
 	defer cancel2(nil)
 
-	sub1, err := env.manager.Subscribe(ctx1, cancel1, "test-sync-1")
+	sub1, err := env.manager.Subscribe(ctx1, cancel1, "test-sync-1", dynmsgbuf.NewDynamicBuffer[*SyncStreamsResponse]())
 	require.NoError(t, err)
 
-	sub2, err := env.manager.Subscribe(ctx2, cancel2, "test-sync-2")
+	sub2, err := env.manager.Subscribe(ctx2, cancel2, "test-sync-2", dynmsgbuf.NewDynamicBuffer[*SyncStreamsResponse]())
 	require.NoError(t, err)
 
 	// Add same stream to both subscriptions
@@ -227,7 +228,7 @@ func TestE2E_MessageDistributionPatterns(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer cancel(nil)
 
-	sub, err := env.manager.Subscribe(ctx, cancel, "test-sync-1")
+	sub, err := env.manager.Subscribe(ctx, cancel, "test-sync-1", dynmsgbuf.NewDynamicBuffer[*SyncStreamsResponse]())
 	require.NoError(t, err)
 
 	streamID := testutils.FakeStreamId(STREAM_CHANNEL_BIN)
@@ -322,7 +323,7 @@ func TestE2E_ErrorHandlingAndRecovery(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer cancel(nil)
 
-	sub, err := env.manager.Subscribe(ctx, cancel, "test-sync-1")
+	sub, err := env.manager.Subscribe(ctx, cancel, "test-sync-1", dynmsgbuf.NewDynamicBuffer[*SyncStreamsResponse]())
 	assert.Error(t, err)
 	assert.Nil(t, sub)
 	assert.Contains(t, err.Error(), "subscription manager is stopped")
@@ -331,7 +332,7 @@ func TestE2E_ErrorHandlingAndRecovery(t *testing.T) {
 	env.manager.stopped.Store(false)
 
 	// Test 2: Create valid subscription and then close it
-	sub, err = env.manager.Subscribe(ctx, cancel, "test-sync-1")
+	sub, err = env.manager.Subscribe(ctx, cancel, "test-sync-1", dynmsgbuf.NewDynamicBuffer[*SyncStreamsResponse]())
 	require.NoError(t, err)
 
 	// Close subscription
@@ -373,7 +374,7 @@ func TestE2E_PerformanceAndStress(t *testing.T) {
 		contexts[i] = cancel
 		defer cancel(nil)
 
-		sub, err := env.manager.Subscribe(ctx, cancel, fmt.Sprintf("test-sync-%d", i))
+		sub, err := env.manager.Subscribe(ctx, cancel, fmt.Sprintf("test-sync-%d", i), dynmsgbuf.NewDynamicBuffer[*SyncStreamsResponse]())
 		require.NoError(t, err)
 		subscriptions[i] = sub
 	}

--- a/core/node/rpc/sync/subscription/manager.go
+++ b/core/node/rpc/sync/subscription/manager.go
@@ -74,7 +74,12 @@ func NewManager(
 }
 
 // Subscribe creates a new subscription with the given sync ID.
-func (m *Manager) Subscribe(ctx context.Context, cancel context.CancelCauseFunc, syncID string) (*Subscription, error) {
+func (m *Manager) Subscribe(
+	ctx context.Context,
+	cancel context.CancelCauseFunc,
+	syncID string,
+	messages *dynmsgbuf.DynamicBuffer[*SyncStreamsResponse],
+) (*Subscription, error) {
 	if m.stopped.Load() {
 		return nil, RiverError(Err_UNAVAILABLE, "subscription manager is stopped").Tag("syncId", syncID)
 	}
@@ -87,7 +92,7 @@ func (m *Manager) Subscribe(ctx context.Context, cancel context.CancelCauseFunc,
 		ctx:                 ctx,
 		cancel:              cancel,
 		syncID:              syncID,
-		Messages:            dynmsgbuf.NewDynamicBuffer[*SyncStreamsResponse](),
+		Messages:            messages,
 		initializingStreams: xsync.NewMap[StreamId, struct{}](),
 		backfillEvents:      xsync.NewMap[StreamId, map[common.Hash]struct{}](),
 		syncers:             m.syncers,

--- a/core/node/rpc/sync/subscription/manager_test.go
+++ b/core/node/rpc/sync/subscription/manager_test.go
@@ -13,6 +13,7 @@ import (
 
 	. "github.com/towns-protocol/towns/core/node/protocol"
 	"github.com/towns-protocol/towns/core/node/rpc/sync/client"
+	"github.com/towns-protocol/towns/core/node/rpc/sync/dynmsgbuf"
 	. "github.com/towns-protocol/towns/core/node/shared"
 	"github.com/towns-protocol/towns/core/node/testutils"
 )
@@ -22,7 +23,7 @@ func TestManager_Subscribe(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer cancel(nil)
 
-	sub, err := m.Subscribe(ctx, cancel, "test-sync-id")
+	sub, err := m.Subscribe(ctx, cancel, "test-sync-id", dynmsgbuf.NewDynamicBuffer[*SyncStreamsResponse]())
 	require.NoError(t, err)
 	require.NotNil(t, sub)
 	assert.Equal(t, "test-sync-id", sub.syncID)
@@ -34,7 +35,7 @@ func TestManager_Subscribe(t *testing.T) {
 
 	// Test stopped path
 	m.stopped.Store(true)
-	sub2, err2 := m.Subscribe(ctx, cancel, "should-fail")
+	sub2, err2 := m.Subscribe(ctx, cancel, "should-fail", dynmsgbuf.NewDynamicBuffer[*SyncStreamsResponse]())
 	assert.Nil(t, sub2)
 	assert.Error(t, err2)
 }
@@ -108,7 +109,7 @@ func TestManager_Subscribe_Concurrent(t *testing.T) {
 			ctx, cancel := context.WithCancelCause(context.Background())
 			defer cancel(nil)
 
-			sub, err := m.Subscribe(ctx, cancel, syncID)
+			sub, err := m.Subscribe(ctx, cancel, syncID, dynmsgbuf.NewDynamicBuffer[*SyncStreamsResponse]())
 			assert.NoError(t, err)
 			assert.NotNil(t, sub)
 			subs[idx] = sub
@@ -149,7 +150,7 @@ func TestManager_GetStats(t *testing.T) {
 		ctx, cancel := context.WithCancelCause(context.Background())
 		defer cancel(nil)
 
-		sub, err := m.Subscribe(ctx, cancel, syncID)
+		sub, err := m.Subscribe(ctx, cancel, syncID, dynmsgbuf.NewDynamicBuffer[*SyncStreamsResponse]())
 		require.NoError(t, err)
 		require.NotNil(t, sub)
 


### PR DESCRIPTION
To avoid populating the main sync commands channel by ping requests, remove it from there and send a response immediately directly from the handler.