### PR TITLE
Retry adding stream to sync if a request is failed

### DIFF
--- a/core/node/track_streams/multi_sync_runner.go
+++ b/core/node/track_streams/multi_sync_runner.go
@@ -855,7 +855,6 @@ func (msr *MultiSyncRunner) addToSync(
 					if loaded && oldRunner == runner {
 						go newRunner.Run()
 						newRunner.WaitUntilStarted()
-						// oldRunner.
 						return newRunner, xsync.UpdateOp
 					}
 					return oldRunner, xsync.CancelOp


### PR DESCRIPTION
Create a new sync operation ONLY if the current unfilled node sync gets filled or cancelled. 