### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/Bytecode_diff_report.yml
+++ b/.github/workflows/Bytecode_diff_report.yml
@@ -79,7 +79,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   ref: ${{ github.ref }}
 

--- a/.github/workflows/Metrics_discovery_docker.yml
+++ b/.github/workflows/Metrics_discovery_docker.yml
@@ -23,7 +23,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup AWS Credentials
               uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/Publish_npm_packages.yml
+++ b/.github/workflows/Publish_npm_packages.yml
@@ -18,7 +18,7 @@ jobs:
                   access_token: ${{ github.token }}
 
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   ref: main
 

--- a/.github/workflows/River_node_docker.yml
+++ b/.github/workflows/River_node_docker.yml
@@ -34,7 +34,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup AWS Credentials
               uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/Stream_metadata_docker.yml
+++ b/.github/workflows/Stream_metadata_docker.yml
@@ -30,7 +30,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup AWS Credentials
               uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/Stress_test_node_docker.yml
+++ b/.github/workflows/Stress_test_node_docker.yml
@@ -25,7 +25,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup AWS Credentials
               uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/Subgraph_docker.yml
+++ b/.github/workflows/Subgraph_docker.yml
@@ -34,7 +34,7 @@ jobs:
             packages: write
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup AWS Credentials
               uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/Subgraph_service_continuous_deployment.yml
+++ b/.github/workflows/Subgraph_service_continuous_deployment.yml
@@ -46,7 +46,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Set Deployment Parameters
               env:

--- a/.github/workflows/Towns_anvil_docker.yml
+++ b/.github/workflows/Towns_anvil_docker.yml
@@ -25,7 +25,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup AWS Credentials
               uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/XChain_monitor_docker.yml
+++ b/.github/workflows/XChain_monitor_docker.yml
@@ -30,7 +30,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup AWS Credentials
               uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
                   access_token: ${{ github.token }}
 
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup Go
               uses: actions/setup-go@v5
@@ -274,7 +274,7 @@ jobs:
                   PGPASSWORD: postgres
 
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup Go
               uses: actions/setup-go@v5
@@ -424,7 +424,7 @@ jobs:
                   PGPASSWORD: postgres
 
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup Go
               uses: actions/setup-go@v5
@@ -573,7 +573,7 @@ jobs:
                   PGPASSWORD: postgres
 
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup Go
               uses: actions/setup-go@v5
@@ -713,7 +713,7 @@ jobs:
                   PGPASSWORD: postgres
 
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup Go
               uses: actions/setup-go@v5
@@ -781,7 +781,7 @@ jobs:
                   access_token: ${{ github.token }}
 
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Install Binaries
               run: sudo apt update && sudo apt-get install -y zstd make libsecp256k1-dev gcc netcat-openbsd

--- a/.github/workflows/clean_turbo_cache.yml
+++ b/.github/workflows/clean_turbo_cache.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Cleanup Turbo Cache
               run: |


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0