### PR TITLE
Add app name to web notification subscription

### DIFF
--- a/packages/sdk/src/notificationsClient.ts
+++ b/packages/sdk/src/notificationsClient.ts
@@ -214,7 +214,7 @@ export class NotificationsClient {
     async subscribeWebPush(subscription: PlainMessage<WebPushSubscriptionObject>, app: string) {
         return this.withClient(async (client) => {
             logger.log('TNS PUSH: subscribing to web push')
-            return client.subscribeWebPush({subscription: subscription, app: app})
+            return client.subscribeWebPush({ subscription: subscription, app: app })
         })
     }
 


### PR DESCRIPTION
Adding the `app` parameter to the web subscription method, to support the new field added to the `SubscribeWebPushRequest` message