### PR TITLE
Fixed stream relocation process in the sync runner

### DIFF
--- a/core/node/rpc/sync_runner_norace_test.go
+++ b/core/node/rpc/sync_runner_norace_test.go
@@ -483,8 +483,8 @@ func waitForMessagesDelivery(
 // tests that the MultiSyncer correctly detects when streams are not syncing and rotates them to new
 // nodes, verifying message delivery after each node failure.
 func TestMultiSyncerWithNodeFailures(t *testing.T) {
-	numNodes := 10
-	replFactor := 5
+	numNodes := 5
+	replFactor := 4
 	tt := newServiceTester(
 		t,
 		serviceTesterOpts{numNodes: numNodes, replicationFactor: replFactor, start: true},
@@ -603,8 +603,9 @@ func TestMultiSyncerWithNodeFailures(t *testing.T) {
 		"Not all messages from first batch were received",
 	)
 
-	// Stop first node to force stream relocation
+	// Stop first 2 nodes to force stream relocation
 	tt.CloseNode(1)
+	tt.CloseNode(2)
 
 	// Send second batch of messages after first node failure
 	for i, channelId := range channelIds {
@@ -624,8 +625,8 @@ func TestMultiSyncerWithNodeFailures(t *testing.T) {
 		"Not all messages were received after first node failure",
 	)
 
-	// Stop second node to force another stream relocation
-	tt.CloseNode(2)
+	// Stop third node to force another stream relocation
+	tt.CloseNode(3)
 
 	// Send third batch of messages after second node failure
 	for i, channelId := range channelIds {


### PR DESCRIPTION
This PR addresses critical issues in how the sync system handles remote node failures:

  Problems Fixed

  1. Improper error propagation: When a remote node fails, the sync session runner was using syncCtx.Err() which only returns the generic "context cancelled" error. This prevented proper
  identification of the root cause. The fix uses context.Cause() to retrieve the actual underlying error.
  2. Connection refused errors not handled: When a remote node is down, syscall.ECONNREFUSED errors were not being properly handled in the Modify RPC call. This led to streams being incorrectly
  reassigned to the same failed node.
  3. Missing node rotation on failure: The sync runner wasn't advancing to the next available node when the current one became unavailable, causing streams to get stuck trying to sync with
  unreachable nodes.

  Changes

  - Updated remoteSyncer.Modify() to detect ECONNREFUSED errors and return them as Err_UNAVAILABLE
  - Modified syncSessionRunner.Close() to use context.Cause() for proper error propagation
  - Added logic to advance the sticky peer when a node is unavailable, ensuring streams are relocated to healthy nodes
  - Treat Err_UNAVAILABLE errors the same as Err_SYNC_SESSION_RUNNER_UNASSIGNABLE in the multi sync runner, triggering creation of a new sync session with an available node

