### PR TITLE
fix: dont use `extends` in examples tsconfig

### DIFF
--- a/packages/examples/bot-ask-poll/tsconfig.json
+++ b/packages/examples/bot-ask-poll/tsconfig.json
@@ -21,5 +21,5 @@
         "outDir": "./dist",
         "types": ["node"]
     },
-    "include": ["src/**/*"]
+    "include": ["src/**/*", "esbuild.config.mjs"]
 }

--- a/packages/examples/bot-quickstart/tsconfig.json
+++ b/packages/examples/bot-quickstart/tsconfig.json
@@ -21,5 +21,5 @@
         "outDir": "./dist",
         "types": ["node"]
     },
-    "include": ["src/**/*"]
+    "include": ["src/**/*", "esbuild.config.mjs"]
 }

--- a/packages/examples/bot-thread-ai/tsconfig.json
+++ b/packages/examples/bot-thread-ai/tsconfig.json
@@ -21,5 +21,5 @@
         "outDir": "./dist",
         "types": ["node"]
     },
-    "include": ["src/**/*"]
+    "include": ["src/**/*", "esbuild.config.mjs"]
 }


### PR DESCRIPTION
When you call `bunx towns-bot init`, the tsconfig should not extend, since it only git clones the specific example and not the whole repo.