### PR TITLE
fix(generated): add package-specific turbo config to cache artifacts …

### DIFF
--- a/packages/generated/turbo.json
+++ b/packages/generated/turbo.json
@@ -6,10 +6,7 @@
   "tasks": {
     "build": {
       "outputs": [
-        "dev/**",
-        "config/**",
-        "deployments/**",
-        "v3/**"
+        "dev/**"
       ]
     }
   }


### PR DESCRIPTION
…properly

### Description

This resolves turbo cache misses that left the dev/ directory empty, causing "Cannot find module" errors for generated contract factories and typings.

### Changes

- Add turbo.json to @towns-protocol/generated with proper outputs configuration
- Include dev/ directory as build outputs
- Fixes CI failures where SDK/web3 packages can't find generated TypeScript artifacts

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines
