### PR TITLE
fix: dont use `yarn` in preinstall commands

### DIFF
--- a/packages/generated/package.json
+++ b/packages/generated/package.json
@@ -4,9 +4,9 @@
     "packageManager": "yarn@3.8.0",
     "type": "module",
     "scripts": {
-        "build": "yarn prepare && yarn make-config",
+        "build": "node ./scripts/prepare.js && node ./scripts/make-config.js",
         "make-config": "node ./scripts/make-config.js",
-        "preinstall": "yarn make-config",
+        "preinstall": "node ./scripts/make-config.js",
         "prepare": "node ./scripts/prepare.js"
     },
     "files": [


### PR DESCRIPTION
This was blocking us of running `npm install` in bot examples.
