### PR TITLE
chore: add tags for `redactMessage`

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -54,6 +54,7 @@ import {
     EnvelopeSchema,
     GetLastMiniblockHashResponse,
     InfoResponse,
+    MessageInteractionType,
 } from '@towns-protocol/proto'
 import {
     bin_fromHexString,
@@ -2111,6 +2112,12 @@ export class Client
             make_ChannelPayload_Redaction(bin_fromHexString(eventId)),
             {
                 method: 'redactMessage',
+                tags: {
+                    groupMentionTypes: [],
+                    messageInteractionType: MessageInteractionType.REDACTION,
+                    mentionedUserAddresses: [],
+                    participatingUserAddresses: [],
+                },
             },
         )
     }


### PR DESCRIPTION
Unsure. Was implementing for bot framework in #3967 and realized that we're not passing the `messageInteractionType` here (iirc - thats for the notification service isnt it?)

Keep in mind that this is the `adminRedaction` function call.