### PR TITLE
node: ensure that registry stream record is up-to-date

### DIFF
--- a/core/node/events/miniblock_producer.go
+++ b/core/node/events/miniblock_producer.go
@@ -228,7 +228,7 @@ func (p *miniblockProducer) testCheckAllDone(jobs []*mbJob) bool {
 //
 // If there are no events in the minipool and forceSnapshot is false, TestMakeMiniblock does nothing and succeeds.
 //
-// Returns the hash and number of the last know miniblock.
+// Returns the hash and number of the last known miniblock.
 func (p *miniblockProducer) TestMakeMiniblock(
 	ctx context.Context,
 	streamId StreamId,

--- a/core/node/events/stream_reconcile_task.go
+++ b/core/node/events/stream_reconcile_task.go
@@ -238,6 +238,17 @@ func (s *StreamCache) reconcileStreamFromPeers(
 		}
 	}
 
+	if streamRecord.LastMbNum() < lastMiniblockNum {
+		if streamRecord.ReplicationFactor() > 1 && streamRecord.Nodes()[0] == s.params.Wallet.Address {
+			// Before replicated streams nodes would only register miniblocks every N miniblocks.
+			// Therefore, it is possible that registry stream record for streams that haven't seen new miniblocks
+			// after the stream was migrated to a replicated stream is lagging behind. For those streams register
+			// the latest miniblock to bring the record up to date.
+			go s.writeLatestMbToBlockchain(ctx, stream)
+		}
+		return nil
+	}
+
 	if streamRecord.LastMbNum() <= lastMiniblockNum {
 		return nil
 	}


### PR DESCRIPTION
Summary

  - Fixes an issue where registry stream records could be outdated for streams that were migrated to replicated streams
  - Ensures the blockchain registry reflects the actual latest miniblock for affected streams

  Problem

  Legacy non-replicated streams only registered miniblocks to the blockchain registry every N miniblocks. When these streams were migrated to replicated streams without new activity, their registry records remained outdated, showing an older miniblock number than what actually exists.

  Solution

  Added logic in the stream reconciliation process to detect when:
  1. The stream is now replicated (replication factor > 1)
  2. The current node is the primary node for the stream
  3. The registry shows an older miniblock number than what exists
  locally

  When these conditions are met, the node automatically updates the registry with the latest miniblock information.

  Changes

  - Fixed typo in comment: "know" → "known" in core/node/events/miniblock_producer.go:231
  - Added registry update logic in core/node/events/stream_reconcile_task.go:241-250 to handle outdated registry records for migrated streams

