### PR TITLE
WIP: add rolling 30d/7d/all time windows for space swap volume

### DIFF
--- a/packages/subgraph/ponder.schema.ts
+++ b/packages/subgraph/ponder.schema.ts
@@ -11,6 +11,9 @@ export const space = onchainTable('spaces', (t) => ({
     createdAt: t.bigint(),
     paused: t.boolean(),
     totalAmountStaked: t.bigint().default(0n),
+    swapVolumeLast7d: t.bigint().default(0n),
+    swapVolumeLast30d: t.bigint().default(0n),
+    swapVolumeAllTime: t.bigint().default(0n),
 }))
 
 export const swap = onchainTable('swaps', (t) => ({
@@ -24,6 +27,13 @@ export const swap = onchainTable('swaps', (t) => ({
     poster: t.hex(),
     blockTimestamp: t.bigint(),
     createdAt: t.bigint(),
+}))
+
+export const spaceDailySwapVolume = onchainTable('space_daily_swap_volumes', (t) => ({
+    id: t.text().primaryKey(), // ${spaceId}-${dayIndex}
+    spaceId: t.hex(),
+    day: t.integer(),
+    volume: t.bigint().default(0n),
 }))
 
 export const swapFee = onchainTable('swap_fees', (t) => ({
@@ -43,9 +53,19 @@ export const spaceToSwaps = relations(space, ({ many }) => ({
     swaps: many(swap),
 }))
 
+// each space has many daily swap volumes
+export const spaceToDailySwapVolumes = relations(space, ({ many }) => ({
+    dailySwapVolumes: many(spaceDailySwapVolume),
+}))
+
 // each swap belongs to a space
 export const swapToSpace = relations(swap, ({ one }) => ({
     space: one(space, { fields: [swap.spaceId], references: [space.id] }),
+}))
+
+// each daily swap volume belongs to a space
+export const dailySwapVolumeToSpace = relations(spaceDailySwapVolume, ({ one }) => ({
+    space: one(space, { fields: [spaceDailySwapVolume.spaceId], references: [space.id] }),
 }))
 
 export const swapRouter = onchainTable('swap_router', (t) => ({

--- a/packages/subgraph/src/index.ts
+++ b/packages/subgraph/src/index.ts
@@ -6,6 +6,7 @@ import {
     handleStakeToSpace,
     handleRedelegation,
     decodePermissions,
+    updateSpaceSwapVolume,
 } from './utils'
 
 ponder.on('SpaceFactory:SpaceCreated', async ({ event, context }) => {
@@ -209,6 +210,17 @@ ponder.on('Space:SwapExecuted', async ({ event, context }) => {
                 blockTimestamp: blockTimestamp,
                 createdAt: blockNumber,
             })
+
+            // Update swap volume for the space
+            await updateSpaceSwapVolume(
+                context,
+                spaceId as `0x${string}`,
+                blockTimestamp,
+                event.args.tokenIn as `0x${string}`,
+                event.args.tokenOut as `0x${string}`,
+                event.args.amountIn,
+                event.args.amountOut,
+            )
         }
     } catch (error) {
         console.error(`Error processing Space:Swap at blockNumber ${blockNumber}:`, error)


### PR DESCRIPTION
Basically I'd like to be able to perform queries like:

```graphql
query MyQuery {
  spaces(
    limit: 20
    orderDirection: "gt"
    orderBy: "swapVolumeLast7d"
  ) {
    items {
      id
      name
      ...
    }
  }
}

```

This one is a little tricky, @jterzis do you have any opinion?
Theoretically, if there are no swaps for a specific space, the counters will not go to down 0 since there's no trigger to update the space — I would like to avoid looping spaces / cron jobs etc for something like this, maybe it's a tradeoff we can live with?