### PR TITLE
add SwapRouter conditionally in ponderConfig

### DIFF
--- a/packages/subgraph/src/index.ts
+++ b/packages/subgraph/src/index.ts
@@ -275,89 +275,92 @@ ponder.on('Space:SwapExecuted', async ({ event, context }) => {
         console.error(`Error processing Space:Swap at blockNumber ${blockNumber}:`, error)
     }
 })
-ponder.on('SwapRouter:Swap', async ({ event, context }) => {
-    // Get block number
-    const blockNumber = event.block.number
-    const blockTimestamp = event.block.timestamp
-    const transactionHash = event.transaction.hash
+// SwapRouter events - only register if SwapRouter exists in the environment (Omega only)
+if (process.env.PONDER_ENVIRONMENT === 'omega') {
+    ponder.on('SwapRouter:Swap' as any, async ({ event, context }: any) => {
+        // Get block number
+        const blockNumber = event.block.number
+        const blockTimestamp = event.block.timestamp
+        const transactionHash = event.transaction.hash
 
-    try {
-        // update swap router swap table
-        const existing = await context.db.sql.query.swapRouterSwap.findFirst({
-            where: eq(schema.swapRouterSwap.txHash, transactionHash),
-        })
-        if (!existing) {
-            await context.db.insert(schema.swapRouterSwap).values({
-                txHash: transactionHash,
-                router: event.args.router,
-                caller: event.args.caller,
-                tokenIn: event.args.tokenIn,
-                tokenOut: event.args.tokenOut,
-                amountIn: event.args.amountIn,
-                amountOut: event.args.amountOut,
-                recipient: event.args.recipient,
-                blockTimestamp: blockTimestamp,
-                createdAt: blockNumber,
+        try {
+            // update swap router swap table
+            const existing = await context.db.sql.query.swapRouterSwap.findFirst({
+                where: eq(schema.swapRouterSwap.txHash, transactionHash),
             })
+            if (!existing) {
+                await context.db.insert(schema.swapRouterSwap).values({
+                    txHash: transactionHash,
+                    router: event.args.router,
+                    caller: event.args.caller,
+                    tokenIn: event.args.tokenIn,
+                    tokenOut: event.args.tokenOut,
+                    amountIn: event.args.amountIn,
+                    amountOut: event.args.amountOut,
+                    recipient: event.args.recipient,
+                    blockTimestamp: blockTimestamp,
+                    createdAt: blockNumber,
+                })
+            }
+        } catch (error) {
+            console.error(`Error processing SwapRouter:Swap at blockNumber ${blockNumber}:`, error)
         }
-    } catch (error) {
-        console.error(`Error processing SwapRouter:Swap at blockNumber ${blockNumber}:`, error)
-    }
-})
+    })
 
-ponder.on('SwapRouter:FeeDistribution', async ({ event, context }) => {
-    // Get block number
-    const blockNumber = event.block.number
-    const transactionHash = event.transaction.hash
+    ponder.on('SwapRouter:FeeDistribution' as any, async ({ event, context }: any) => {
+        // Get block number
+        const blockNumber = event.block.number
+        const transactionHash = event.transaction.hash
 
-    try {
-        // update fee distribution table
-        const existing = await context.db.sql.query.feeDistribution.findFirst({
-            where: eq(schema.feeDistribution.txHash, transactionHash),
-        })
-        if (!existing) {
-            await context.db.insert(schema.feeDistribution).values({
-                txHash: transactionHash,
-                token: event.args.token,
-                treasury: event.args.protocol,
-                poster: event.args.poster,
-                treasuryAmount: event.args.protocolAmount,
-                posterAmount: event.args.posterAmount,
-                createdAt: blockNumber,
+        try {
+            // update fee distribution table
+            const existing = await context.db.sql.query.feeDistribution.findFirst({
+                where: eq(schema.feeDistribution.txHash, transactionHash),
             })
+            if (!existing) {
+                await context.db.insert(schema.feeDistribution).values({
+                    txHash: transactionHash,
+                    token: event.args.token,
+                    treasury: event.args.protocol,
+                    poster: event.args.poster,
+                    treasuryAmount: event.args.protocolAmount,
+                    posterAmount: event.args.posterAmount,
+                    createdAt: blockNumber,
+                })
+            }
+        } catch (error) {
+            console.error(
+                `Error processing SwapRouter:FeeDistribution at blockNumber ${blockNumber}:`,
+                error,
+            )
         }
-    } catch (error) {
-        console.error(
-            `Error processing SwapRouter:FeeDistribution at blockNumber ${blockNumber}:`,
-            error,
-        )
-    }
-})
+    })
 
-ponder.on('SwapRouter:SwapRouterInitialized', async ({ event, context }) => {
-    // Get block number
-    const blockNumber = event.block.number
-    const transactionHash = event.transaction.hash
+    ponder.on('SwapRouter:SwapRouterInitialized' as any, async ({ event, context }: any) => {
+        // Get block number
+        const blockNumber = event.block.number
+        const transactionHash = event.transaction.hash
 
-    try {
-        // update swap router onchainTable
-        const existing = await context.db.sql.query.swapRouter.findFirst({
-            where: eq(schema.swapRouter.txHash, transactionHash),
-        })
-        if (!existing) {
-            await context.db.insert(schema.swapRouter).values({
-                txHash: transactionHash,
-                spaceFactory: event.args.spaceFactory,
-                createdAt: blockNumber,
+        try {
+            // update swap router onchainTable
+            const existing = await context.db.sql.query.swapRouter.findFirst({
+                where: eq(schema.swapRouter.txHash, transactionHash),
             })
+            if (!existing) {
+                await context.db.insert(schema.swapRouter).values({
+                    txHash: transactionHash,
+                    spaceFactory: event.args.spaceFactory,
+                    createdAt: blockNumber,
+                })
+            }
+        } catch (error) {
+            console.error(
+                `Error processing SwapRouter:SwapRouterInitialized at blockNumber ${blockNumber}:`,
+                error,
+            )
         }
-    } catch (error) {
-        console.error(
-            `Error processing SwapRouter:SwapRouterInitialized at blockNumber ${blockNumber}:`,
-            error,
-        )
-    }
-})
+    })
+}
 
 // Event handlers remain the same but now use properly typed context
 ponder.on('BaseRegistry:Stake', async ({ event, context }) => {

--- a/packages/subgraph/utils/makePonderConfig.ts
+++ b/packages/subgraph/utils/makePonderConfig.ts
@@ -49,10 +49,10 @@ export function makePonderConfig(
         throw new Error('Space owner address not found')
     }
 
-    const swapRouter = getContractAddress('swapRouter', baseChainName, environment)
-    if (!swapRouter) {
-        throw new Error('Swap router address not found')
-    }
+    // SwapRouter only exists in Omega environment, make it optional
+    const swapRouter = getContractAddress('swapRouter', baseChainName, environment, {
+        throwOnError: false,
+    })
 
     const baseRegistry = getContractAddress('baseRegistry', baseChainName, environment)
     if (!baseRegistry) {
@@ -124,12 +124,15 @@ export function makePonderConfig(
                 startBlock: baseChainStartBlock,
                 chain: baseChainName,
             },
-            SwapRouter: {
-                abi: swapRouterAbi,
-                address: swapRouter,
-                startBlock: baseChainStartBlock,
-                chain: baseChainName,
-            },
+            // Only add SwapRouter if it exists (only in Omega environment)
+            ...(swapRouter && {
+                SwapRouter: {
+                    abi: swapRouterAbi,
+                    address: swapRouter,
+                    startBlock: baseChainStartBlock,
+                    chain: baseChainName,
+                },
+            }),
             RiverAirdrop: {
                 abi: mergeAbis([rewardsDistributionV2Abi]),
                 address: riverAirdrop,


### PR DESCRIPTION
This PR should fix the build issue we're seeing for Alpha. the SwapRouter contract is only deployed on omega, so let's:
- conditionally look up the deployment address
- conditionally register the event listener

```
Using NODE_ENV=production
Starting Ponder in production mode
3:57:27 PM INFO  telemetry  Ponder collects anonymous telemetry data to identify issues and prioritize features. See https://ponder.sh/docs/advanced/telemetry for more information.
Working directory: /river/packages/subgraph
Current directory (__dirname): /river/packages/subgraph/utils
Testing path: /river/packages/subgraph/utils/contracts - NOT FOUND
Testing path: /river/packages/subgraph/contracts - NOT FOUND
Testing path: /river/packages/contracts - EXISTS
Error loading address for contract swapRouter in environment alpha: Error: Address file not found for contract swapRouter in environment alpha
    at Module.getContractAddress (/river/packages/subgraph/utils/contractAddresses.ts:91:23)
    at Module.makePonderConfig (/river/packages/subgraph/utils/makePonderConfig.ts:52:24)
    at /river/packages/subgraph/ponder.config.alpha.ts:10:16
    at ViteNodeRunner.runModule (file:///river/node_modules/ponder/node_modules/vite-node/dist/client.mjs:352:5)
    at ViteNodeRunner.directRequest (file:///river/node_modules/ponder/node_modules/vite-node/dist/client.mjs:336:5)
    at ViteNodeRunner.cachedRequest (file:///river/node_modules/ponder/node_modules/vite-node/dist/client.mjs:189:14)
    at ViteNodeRunner.executeFile (file:///river/node_modules/ponder/node_modules/vite-node/dist/client.mjs:161:12)
    at executeFile (file:///river/node_modules/ponder/src/build/index.ts:158:23)
    at Object.executeConfig (file:///river/node_modules/ponder/src/build/index.ts:169:29)
    at start (file:///river/node_modules/ponder/src/bin/commands/start.ts:94:24)
3:57:29 PM ERROR build      Error while executing 'ponder.config.ts':
Error: Address file not found for contract swapRouter in environment alpha
    at Module.getContractAddress (/river/packages/subgraph/utils/contractAddresses.ts:91:23)
    at Module.makePonderConfig (/river/packages/subgraph/utils/makePonderConfig.ts:52:24)
    at /river/packages/subgraph/ponder.config.alpha.ts:10:16
  89 |         if (!fs.existsSync(addressPath)) {
  90 |             if (opts.throwOnError) {
> 91 |                 throw new Error(
     |                       ^
  92 |                     `Address file not found for contract ${contractName} in environment ${env}`,
  93 |                 )
  94 |             }
3:57:29 PM WARN  process    Failed intial build, starting shutdown sequence
```