### PR TITLE
feat(docker): implement git hash-based versioning for Anvil Docker im…

### DIFF
--- a/.github/workflows/Towns_anvil_docker.yml
+++ b/.github/workflows/Towns_anvil_docker.yml
@@ -59,27 +59,33 @@ jobs:
               run: |
                   COMMIT_HASH=$(git describe --tags --always --dirty)
                   BRANCH=$(git rev-parse --abbrev-ref HEAD)
-                  TAGS=($COMMIT_HASH)
 
-                  # If this is a push to main, we also tag the image as dev,
-                  # But RELEASE_VERSION remains untouched, as `dev` is not a version, but just a tag.
+                  # Compute the contracts source hash - this is the primary tag
+                  CONTRACTS_HASH=$(git rev-parse HEAD:packages/contracts/src)
+                  TAGS=($CONTRACTS_HASH)
+
+                  # Also tag with commit hash for traceability
+                  TAGS+=($COMMIT_HASH)
+
+                  # If this is a push to main, we also tag the image as latest
                   if [ "$BRANCH" == "main" ] && [ "${{ github.event_name }}" == "push" ]; then  
                     TAGS+=(latest)
                   fi
 
                   echo "Building image with the following tags: ${TAGS[@]}"
+                  echo "Contracts hash: $CONTRACTS_HASH"
                   echo "Commit hash: $COMMIT_HASH"
                   echo "Branch: $BRANCH"
                   echo "Release version: $RELEASE_VERSION"
 
                   docker build \
-                    -t towns-anvil:local-latest \
+                    -t towns-anvil:local \
                     -f ./packages/contracts/docker/Dockerfile \
                     .
 
                   for tag in "${TAGS[@]}"; do
                     echo "Pushing image to $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:$tag"
-                    docker tag towns-anvil:local-latest $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:$tag
+                    docker tag towns-anvil:local $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:$tag
                     docker push $ECR_REGISTRY/$REGISTRY_ALIAS/$ECR_REPOSITORY:$tag
                   done
             # If action failed, we send a slack notification

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,7 +26,7 @@
       // start local dev:
       //
       // 1. yarn install
-      // 2. start blockchains
+      // 2. start blockchains (Docker by default)
       // 3. configure nodes
       // 4. starts all servers and clients
       //
@@ -35,32 +35,30 @@
       "label": "~Start Local Dev~",
       "dependsOn": [
         "Dependencies",
-        "Stage 1",
+        "Start Anvil Chains",
+        "Configure Nodes",
+        "Start Services"
       ],
       // Mark as the default build task so cmd/ctrl+shift+b will create them
       "group": {
         "kind": "build",
         "isDefault": true
       },
-      "dependsOrder": "sequence"
+      "dependsOrder": "sequence",
+      "options": {
+        "env": {
+          "USE_DOCKER_CHAINS": "1"
+        }
+      }
     },
     {
-      "label": "Stage 1",
+      // Native Anvil fallback - same as above but without Docker
+      "label": "~Start Local Dev (Native Anvil)~",
       "dependsOn": [
-        "BaseChain",
-        "RiverChain",
-        "Stage 2"
-      ],
-      "group": {
-        "kind": "build",
-        "isDefault": false
-      },
-    },
-    {
-      "label": "Stage 2",
-      "dependsOn": [
-        "Configure Nodes",
-        "Stage 3"
+        "Dependencies",
+        "Start Anvil Chains (Native)",
+        "Configure Nodes (Native)",
+        "Start Services"
       ],
       "group": {
         "kind": "build",
@@ -69,7 +67,7 @@
       "dependsOrder": "sequence"
     },
     {
-      "label": "Stage 3",
+      "label": "Start Services",
       "dependsOn": [
         "Start Watches",
         "Run Nodes and Services",
@@ -270,9 +268,24 @@
       }
     },
     {
-      "label": "BaseChain",
+      "label": "Configure Nodes (Native)",
       "type": "shell",
-      "command": "just anvil-base",
+      "command": "just config build",
+      "isBackground": true,
+      "problemMatcher": [],
+      "options": {
+        "cwd": "./core"
+      },
+      "presentation": {
+        "group": "ephemeral",
+        "focus": true,
+        "panel": "shared",
+      }
+    },
+    {
+      "label": "Start Anvil Chains",
+      "type": "shell",
+      "command": "just anvils",
       "isBackground": true,
       "problemMatcher": [],
       "options": {
@@ -286,16 +299,13 @@
       }
     },
     {
-      "label": "RiverChain",
+      "label": "Start Anvil Chains (Native)",
       "type": "shell",
-      "command": "just anvil-river",
+      "command": "just anvils",
       "isBackground": true,
       "problemMatcher": [],
       "options": {
-        "cwd": "./core",
-        "env": {
-          "USE_DOCKER_CHAINS": "1"
-        }
+        "cwd": "./core"
       },
       "presentation": {
         "group": "local-blockchains"
@@ -495,53 +505,6 @@
         "isDefault": true
       },
       "dependsOrder": "sequence"
-    },
-    {
-      "label": "~Start Local Docker Dev~",
-      "dependsOn": [
-        "Dependencies",
-        "BuildLocalDockerImage",
-        "AnvilsLocalDocker",
-        "Configure Nodes",
-        "Stage 3"
-      ],
-      "group": {
-        "kind": "build",
-        "isDefault": false
-      },
-      "dependsOrder": "sequence"
-    },
-    {
-      "label": "BuildLocalDockerImage",
-      "type": "shell",
-      "command": "just build-local-docker",
-      "isBackground": false,
-      "problemMatcher": [],
-      "options": {
-        "cwd": "./core"
-      },
-      "presentation": {
-        "group": "ephemeral",
-        "focus": true,
-        "panel": "shared"
-      }
-    },
-    {
-      "label": "AnvilsLocalDocker",
-      "type": "shell",
-      "command": "just anvils",
-      "isBackground": true,
-      "problemMatcher": [],
-      "options": {
-        "cwd": "./core",
-        "env": {
-          "USE_LOCAL_DOCKER": "1",
-          "USE_DOCKER_CHAINS": "1"
-        }
-      },
-      "presentation": {
-        "group": "local-blockchains"
-      }
     },
     {
       "label": "Kill All, Clean and Start Local Dev",

--- a/core/justfile
+++ b/core/justfile
@@ -14,7 +14,6 @@ RPC_RIVER := 'http://127.0.0.1:8546'
 
 # Docker-related environment variables
 USE_DOCKER_CHAINS := env_var_or_default("USE_DOCKER_CHAINS", "0")
-USE_LOCAL_DOCKER := env_var_or_default("USE_LOCAL_DOCKER", "0")
 
 OPERATOR_ADDRESS := `source ../packages/contracts/.env.localhost && echo "${SENDER_ADDRESS}"`
 LOCAL_PRIVATE_KEY := `source ../packages/contracts/.env.localhost && echo "${LOCAL_PRIVATE_KEY}"`
@@ -49,6 +48,40 @@ clear-logs: (_loop-instances "_clear_instance_logs")
 _clear_instance_logs $INSTANCE_NUM $INSTANCE_DIR:
     @rm -rf $INSTANCE_DIR/logs/*
 
+_get-contracts-hash:
+    #!/usr/bin/env -S bash {{BASH_OPTS}}
+    git rev-parse HEAD:../packages/contracts/src 2>/dev/null || echo "dev"
+
+_check-remote-image IMAGE_TAG:
+    #!/usr/bin/env -S bash {{BASH_OPTS}}
+    docker manifest inspect {{IMAGE_TAG}} >/dev/null 2>&1
+
+_get-docker-image:
+    #!/usr/bin/env -S bash {{BASH_OPTS}}
+    CONTRACTS_HASH=$(just _get-contracts-hash)
+    IMAGE_TAG="public.ecr.aws/h5v6m2x1/towns-anvil:${CONTRACTS_HASH}"
+    
+    echo "Checking for remote image: ${IMAGE_TAG}" >&2
+    if just _check-remote-image "${IMAGE_TAG}"; then
+        echo "Found remote image with hash: ${CONTRACTS_HASH}" >&2
+        echo "${IMAGE_TAG}"
+    else
+        echo "Remote image not found for hash: ${CONTRACTS_HASH}" >&2
+        echo "Building local image..." >&2
+        
+        # Build the image locally with the contracts hash tag
+        just build-anvil-docker "${CONTRACTS_HASH}"
+        
+        echo "towns-anvil:${CONTRACTS_HASH}"
+    fi
+
+# Build Docker image locally with specified tag
+build-anvil-docker $TAG="local":
+    #!/usr/bin/env -S bash {{BASH_OPTS}}
+    cd ../
+    docker build -t towns-anvil:${TAG} -f ./packages/contracts/docker/Dockerfile .
+    echo "Built local image: towns-anvil:${TAG}" >&2
+
 _anvil-start $NAME $PORT $CHAIN_ID:
     #!/usr/bin/env -S bash {{BASH_OPTS}}
     mkdir -p ./run_files/anvil
@@ -57,12 +90,7 @@ _anvil-start $NAME $PORT $CHAIN_ID:
     else
         if [ "${USE_DOCKER_CHAINS}" = "1" ]; then
             echo "Starting Docker ${NAME} chain on port ${PORT}"
-            # Use local image if USE_LOCAL_DOCKER=1, otherwise use AWS
-            if [ "${USE_LOCAL_DOCKER}" = "1" ]; then
-                IMAGE="towns-anvil:local"
-            else
-                IMAGE="${DOCKER_IMAGE:-public.ecr.aws/h5v6m2x1/towns-anvil:latest}"
-            fi
+            IMAGE=$(just _get-docker-image)
 
             docker run -d \
                 --name towns-${NAME}-chain \
@@ -119,14 +147,6 @@ anvils-stop: anvil-base-stop anvil-river-stop
 anvils-tail-logs:
     #!/usr/bin/env -S bash {{BASH_OPTS}}
     tail -n 10 -F ./run_files/anvil/*.log
-
-# Build Docker image locally
-build-local-docker:
-    #!/usr/bin/env -S bash {{BASH_OPTS}}
-    cd ../
-    docker build -t towns-anvil:local -f ./packages/contracts/docker/Dockerfile .
-    echo "Built local image: towns-anvil:local"
-    echo "To use it, run: USE_LOCAL_DOCKER=1 USE_DOCKER_CHAINS=1 just anvils"
 
 storage-start:
     #!/usr/bin/env -S bash {{BASH_OPTS}}

--- a/packages/contracts/docker/README.md
+++ b/packages/contracts/docker/README.md
@@ -28,8 +28,8 @@ just anvils-stop                       # Stop chains
 
 ```bash
 cd core
-just build-local-docker                # Build local image
-USE_LOCAL_DOCKER=1 USE_DOCKER_CHAINS=1 just anvils
+just build-anvil-docker
+USE_DOCKER_CHAINS=1 just anvils
 ```
 
 ### VSCode Integration
@@ -39,7 +39,6 @@ VSCode tasks automatically use Docker chains when configured:
 - **BaseChain** - Starts Base chain (Docker or native based on environment)
 - **RiverChain** - Starts River chain (Docker or native based on environment)
 - **Configure Nodes** - Configures nodes using Docker chains by default
-- **AnvilsLocalDocker** - Uses local Docker image for development
 
 ## Files
 
@@ -83,13 +82,11 @@ which runs `just-deploy-contracts`. Contract addresses are extracted to `package
 
 ### Docker-specific targets:
 
-- `build-local-docker` - Build Docker image locally
+- `build-anvil-docker` - Build Anvil Docker image locally
 
 ## Environment Variables
 
 - `USE_DOCKER_CHAINS` - Set to `1` to use Docker chains instead of native Anvil
-- `USE_LOCAL_DOCKER` - Set to `1` to use local Docker image instead of AWS ECR
-- `DOCKER_IMAGE` - Override Docker image (default: AWS ECR image)
 - `RUN_ENV` - Environment (defaults to `local_dev`)
 
 ## CI/CD Integration


### PR DESCRIPTION
…ages

Replaced manual local/remote Docker image switching with automatic hash-based versioning:
- Images tagged with contracts source hash (git rev-parse HEAD:packages/contracts/src)
- Automatically pulls from AWS ECR if hash exists, builds locally if not
- Removed USE_LOCAL_DOCKER environment variable - no longer needed
- Simplified VSCode tasks structure by consolidating chain tasks and removing intermediate stages

Benefits:
- Immutable versioning tied directly to contract source code
- No stale images - always uses correct version for current contracts
- Automatic local building when specific version unavailable remotely
- Simpler configuration with no manual mode switching

🤖 Generated with [Claude Code](https://claude.ai/code)
