### PR TITLE
tweak logged subgraph metrics

### DIFF
--- a/packages/subgraph/src/metrics.ts
+++ b/packages/subgraph/src/metrics.ts
@@ -50,8 +50,8 @@ export const ponder = new Proxy(originalPonder, {
 
                         globalEventCount++
 
-                        // Log summary every 100 events
-                        if (LOG_METRICS && globalEventCount % 100 === 0) {
+                        // Log summary every N events
+                        if (LOG_METRICS && globalEventCount % 1000 === 0) {
                             logMetricsSummary()
                         }
 


### PR DESCRIPTION
- the multiline console.logs don't print well in datadog, let's print a stringified dictionary instead
- let's also include block number
- lower SLOW_THRESHOLD_MS to 100ms