### PR TITLE
stream-metadata fix user invalidation path

### DIFF
--- a/packages/stream-metadata/src/routes/userRefresh.ts
+++ b/packages/stream-metadata/src/routes/userRefresh.ts
@@ -40,7 +40,7 @@ export async function userRefresh(request: FastifyRequest, reply: FastifyReply) 
 
 	const paths =
 		target === 'image'
-			? [`/user/${userId}/image`]
+			? [`/user/${userId}/image*`]
 			: target === 'bio'
 				? [`/user/${userId}/bio`]
 				: [`/user/${userId}/*`]


### PR DESCRIPTION
we have query strings now, need to invalidate them all.
space invalidations alread have the right path