### PR TITLE
refactor: use LibDeploy for SimpleApp deployment

### DIFF
--- a/packages/contracts/scripts/deployments/facets/DeploySimpleApp.s.sol
+++ b/packages/contracts/scripts/deployments/facets/DeploySimpleApp.s.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.29;
 
-import {SimpleApp} from "src/apps/helpers/SimpleApp.sol";
+import {LibDeploy} from "@towns-protocol/diamond/src/utils/LibDeploy.sol";
 
 library DeploySimpleApp {
     function deploy() internal returns (address) {
-        return address(new SimpleApp());
+        return LibDeploy.deployCode("SimpleApp.sol", "");
     }
 }


### PR DESCRIPTION
### Description

Updated the `DeploySimpleApp` script to use `LibDeploy.deployCode` instead of directly instantiating a new contract instance.

### Changes

- Replaced the import of `SimpleApp` with `LibDeploy` from the towns-protocol diamond library
- Changed the deployment method from `new SimpleApp()` to `LibDeploy.deployCode("SimpleApp.sol", "")`

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines