### PR TITLE
feat: add app tipping functionality to Tipping facet

### DIFF
--- a/packages/contracts/scripts/deployments/facets/DeployTipping.s.sol
+++ b/packages/contracts/scripts/deployments/facets/DeployTipping.s.sol
@@ -10,12 +10,14 @@ import {LibDeploy} from "@towns-protocol/diamond/src/utils/LibDeploy.sol";
 
 library DeployTipping {
     function selectors() internal pure returns (bytes4[] memory res) {
-        res = new bytes4[](5);
+        res = new bytes4[](7);
         res[0] = ITipping.tip.selector;
         res[1] = ITipping.tipsByCurrencyAndTokenId.selector;
         res[2] = ITipping.tippingCurrencies.selector;
         res[3] = ITipping.totalTipsByCurrency.selector;
         res[4] = ITipping.tipAmountByCurrency.selector;
+        res[5] = ITipping.tipApp.selector;
+        res[6] = ITipping.tipsByCurrencyAndApp.selector;
     }
 
     function makeCut(

--- a/packages/contracts/src/spaces/facets/tipping/ITipping.sol
+++ b/packages/contracts/src/spaces/facets/tipping/ITipping.sol
@@ -15,6 +15,15 @@ interface ITippingBase {
         bytes32 channelId;
     }
 
+    struct TipAppRequest {
+        address appAddress;
+        address currency;
+        uint256 amount;
+        bytes32 messageId;
+        bytes32 channelId;
+        bytes metadata; // Optional metadata for the app to process
+    }
+
     // =============================================================
     //                           Events
     // =============================================================
@@ -29,6 +38,16 @@ interface ITippingBase {
         bytes32 channelId
     );
 
+    event TipApp(
+        address indexed appAddress,
+        address indexed currency,
+        address indexed sender,
+        uint256 amount,
+        bytes32 messageId,
+        bytes32 channelId,
+        bytes metadata
+    );
+
     // =============================================================
     //                           Errors
     // =============================================================
@@ -40,6 +59,9 @@ interface ITippingBase {
     error CurrencyIsZero();
     error MsgValueMismatch();
     error UnexpectedETH();
+
+    error InvalidReceiver();
+    error AppNotAllowed();
 }
 
 interface ITipping is ITippingBase {
@@ -51,12 +73,30 @@ interface ITipping is ITippingBase {
     /// @dev Emits Tip event
     function tip(TipRequest calldata tipRequest) external payable;
 
+    /// @notice Sends a tip to an app contract
+    /// @param tipAppRequest The tip request containing app address, currency, amount, message ID,
+    /// channel ID and optional metadata
+    /// @dev Requires sender to be a member of the space
+    /// @dev Requires amount > 0 and valid currency address
+    /// @dev Requires app address to be a contract
+    /// @dev Emits TipApp event
+    function tipApp(TipAppRequest calldata tipAppRequest) external payable;
+
     /// @notice Gets the total tips received for a token ID in a specific currency
     /// @param tokenId The token ID to get tips for
     /// @param currency The currency address to get tips in
     /// @return The total amount of tips received in the specified currency
     function tipsByCurrencyAndTokenId(
         uint256 tokenId,
+        address currency
+    ) external view returns (uint256);
+
+    /// @notice Gets the total tips received by an app in a specific currency
+    /// @param appAddress The app address to get tips for
+    /// @param currency The currency address to get tips in
+    /// @return The total amount of tips received in the specified currency
+    function tipsByCurrencyAndApp(
+        address appAddress,
         address currency
     ) external view returns (uint256);
 

--- a/packages/contracts/src/spaces/facets/tipping/TippingBase.sol
+++ b/packages/contracts/src/spaces/facets/tipping/TippingBase.sol
@@ -2,15 +2,18 @@
 pragma solidity ^0.8.23;
 
 // interfaces
+import {ITippingBase} from "./ITipping.sol";
 
 // libraries
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {CurrencyTransfer} from "../../../utils/libraries/CurrencyTransfer.sol";
+import {CustomRevert} from "../../../utils/libraries/CustomRevert.sol";
 
 // contracts
 
-library TippingBase {
+abstract contract TippingBase is ITippingBase {
     using EnumerableSet for EnumerableSet.AddressSet;
+    using CustomRevert for bytes4;
 
     // keccak256(abi.encode(uint256(keccak256("spaces.facets.tipping.storage")) - 1)) &
     // ~bytes32(uint256(0xff))
@@ -26,49 +29,95 @@ library TippingBase {
         EnumerableSet.AddressSet currencies;
         mapping(uint256 tokenId => mapping(address currency => uint256 amount)) tipsByCurrencyByTokenId;
         mapping(address currency => TippingStats) tippingStatsByCurrency;
+        mapping(address appAddress => mapping(address currency => uint256 amount)) tipsByCurrencyByApp;
     }
 
-    function layout() internal pure returns (Layout storage l) {
+    function _getLayout() internal pure returns (Layout storage $) {
         assembly {
-            l.slot := STORAGE_SLOT
+            $.slot := STORAGE_SLOT
         }
     }
 
-    function tip(
+    function _tipMember(
         address sender,
         address receiver,
         uint256 tokenId,
         address currency,
         uint256 amount
     ) internal {
-        Layout storage ds = layout();
+        Layout storage $ = _getLayout();
 
-        ds.currencies.add(currency);
-        ds.tipsByCurrencyByTokenId[tokenId][currency] += amount;
+        $.currencies.add(currency);
+        $.tipsByCurrencyByTokenId[tokenId][currency] += amount;
 
-        TippingStats storage stats = ds.tippingStatsByCurrency[currency];
+        TippingStats storage stats = $.tippingStatsByCurrency[currency];
         stats.tipAmount += amount;
         stats.totalTips += 1;
 
         CurrencyTransfer.transferCurrency(currency, sender, receiver, amount);
     }
 
-    function totalTipsByCurrency(address currency) internal view returns (uint256) {
-        return layout().tippingStatsByCurrency[currency].totalTips;
+    function _tipApp(
+        address sender,
+        address appAddress,
+        address currency,
+        uint256 amount
+    ) internal {
+        Layout storage $ = _getLayout();
+
+        $.currencies.add(currency);
+        $.tipsByCurrencyByApp[appAddress][currency] += amount;
+
+        TippingStats storage stats = $.tippingStatsByCurrency[currency];
+        stats.tipAmount += amount;
+        stats.totalTips += 1;
+
+        CurrencyTransfer.transferCurrency(currency, sender, appAddress, amount);
     }
 
-    function tipAmountByCurrency(address currency) internal view returns (uint256) {
-        return layout().tippingStatsByCurrency[currency].tipAmount;
+    function _totalTipsByCurrency(address currency) internal view returns (uint256) {
+        return _getLayout().tippingStatsByCurrency[currency].totalTips;
     }
 
-    function tipsByCurrencyByTokenId(
+    function _tipAmountByCurrency(address currency) internal view returns (uint256) {
+        return _getLayout().tippingStatsByCurrency[currency].tipAmount;
+    }
+
+    function _tipsByCurrencyByTokenId(
         uint256 tokenId,
         address currency
     ) internal view returns (uint256) {
-        return layout().tipsByCurrencyByTokenId[tokenId][currency];
+        return _getLayout().tipsByCurrencyByTokenId[tokenId][currency];
     }
 
-    function tippingCurrencies() internal view returns (address[] memory) {
-        return layout().currencies.values();
+    function _tippingCurrencies() internal view returns (address[] memory) {
+        return _getLayout().currencies.values();
+    }
+
+    function _tipsByCurrencyByApp(
+        address appAddress,
+        address currency
+    ) internal view returns (uint256) {
+        return _getLayout().tipsByCurrencyByApp[appAddress][currency];
+    }
+
+    function _validateTipRequest(
+        address sender,
+        address receiver,
+        address currency,
+        uint256 amount
+    ) internal pure {
+        if (currency == address(0)) CurrencyIsZero.selector.revertWith();
+        if (receiver == address(0)) InvalidReceiver.selector.revertWith();
+        if (sender == receiver) CannotTipSelf.selector.revertWith();
+        if (amount == 0) AmountIsZero.selector.revertWith();
+    }
+
+    function _validateReceiverIsContract(address receiver) internal view {
+        bool isContract;
+        assembly ("memory-safe") {
+            isContract := gt(extcodesize(receiver), 0)
+        }
+        if (!isContract) InvalidReceiver.selector.revertWith();
     }
 }


### PR DESCRIPTION
### Description

This PR adds app tipping functionality to the Tipping facet, allowing users to send tips to app contracts in addition to tipping individual members. The implementation includes new methods for tipping apps, tracking app tips, and retrieving app tip statistics.

### Changes

- Added `tipApp` function to allow users to send tips to app contracts
- Added `tipsByCurrencyAndApp` function to retrieve app tip statistics
- Created new `TipAppRequest` struct with app-specific parameters including metadata
- Added `TipApp` event for tracking app tips
- Refactored `TippingBase` from a library to an abstract contract for better code organization
- Added validation to ensure app addresses are valid contracts
- Added comprehensive tests for the new app tipping functionality
- Updated selectors in deployment script to include new functions

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines