### PR TITLE
add indexes on totalAmountStaked, ownerId

### DIFF
--- a/packages/subgraph/ponder.schema.ts
+++ b/packages/subgraph/ponder.schema.ts
@@ -80,6 +80,7 @@ export const space = onchainTable(
     }),
     (table) => ({
         tokenIdIdx: index().on(table.tokenId),
+        totalAmountStakedIdx: index().on(table.totalAmountStaked),
     }),
 )
 
@@ -209,14 +210,20 @@ export const feeDistributionToSwapRouterSwap = relations(feeDistribution, ({ one
 }))
 
 // stakers
-export const stakers = onchainTable('stakers', (t) => ({
-    depositId: t.bigint().primaryKey(),
-    owner: t.hex().notNull(),
-    delegatee: t.hex().notNull(),
-    beneficiary: t.hex().notNull(),
-    amount: t.bigint().notNull(),
-    createdAt: t.bigint().notNull(),
-}))
+export const stakers = onchainTable(
+    'stakers',
+    (t) => ({
+        depositId: t.bigint().primaryKey(),
+        owner: t.hex().notNull(),
+        delegatee: t.hex().notNull(),
+        beneficiary: t.hex().notNull(),
+        amount: t.bigint().notNull(),
+        createdAt: t.bigint().notNull(),
+    }),
+    (table) => ({
+        ownerIdx: index().on(table.owner),
+    }),
+)
 
 // each staker can optionally belong to a space
 export const stakingToSpace = relations(stakers, ({ one }) => ({


### PR DESCRIPTION
The current hotspots for a _production_ instance (not historical index) with queries frequently requiring full table scans are:

```sql
select "id", "owner", "token_id", "name", "uri", "short_description", "long_description", "created_at", "paused", "total_amount_staked" from "omega-613363d"."spaces" "space" where "space"."total_amount_staked" > $1 order by "space"."total_amount_staked" desc, "space"."id" desc limit $2
```
```sql
select count(*) from "omega-613363d"."stakers" where "omega-613363d"."stakers"."owner" = $1
```
```sql
select "deposit_id", "owner", "delegatee", "beneficiary", "amount", "created_at" from "omega-613363d"."stakers" "stakers" where "stakers"."owner" = $1 order by "stakers"."deposit_id" asc limit $2
```

this PR fixes all three cases