### PR TITLE
fix(dlog): import.meta causing issues outside modules

### DIFF
--- a/packages/dlog/src/envUtils.ts
+++ b/packages/dlog/src/envUtils.ts
@@ -8,22 +8,13 @@ export function safeEnv(keys: string[]): string | undefined {
     for (const key of keys) {
         // look for the key in process.env
         if (typeof process === 'object' && 'env' in process) {
-            if (process.env[key]) {
+            if (key in process.env) {
                 return process.env[key]
             }
-        }
-        // look for the key in process.env.VITE_ for vite apps
-        if (typeof import.meta === 'object' && 'env' in import.meta) {
-            // first check if the key is directly set in the import.meta.env
-            // for server side rendering it could be passed in,
-            // or perhaps somehow you specified the vite in the key alread for some reason
-            if (import.meta.env[key]) {
-                return import.meta.env[key]
-            }
-            // otherwise check for the vite prefix, this is the only way to pass env variables to the web client
+            // check for the vite prefix, this is the only way to pass env variables to the web client
             const viteKey = `VITE_${key}`
-            if (import.meta.env[viteKey]) {
-                return import.meta.env[viteKey]
+            if (viteKey in process.env) {
+                return process.env[viteKey]
             }
         }
     }


### PR DESCRIPTION
the change in https://github.com/towns-protocol/towns/commit/72bd75cc8e2ddc19d8d04782266370463fc58bfc is causing some builds (service-worker) to fail with the message `import.meta cannot be called outside of a module`. 

it seems like the safeEnv isn't directly used from the client (one reference in dlog, and another in riverConfig) so the following change feels pretty safe.

### Changes

- reverting https://github.com/towns-protocol/towns/commit/72bd75cc8e2ddc19d8d04782266370463fc58bfc#diff-e0054c58c430914b6178008cd526b258e1864a7530c083b8ef1bb297b22ca8edL13
- check for `key in env` instead of `env[key]`
### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
