### PR TITLE
fix eslint on save in subgraph

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
     "./packages/sdk",
     "./packages/stream-metadata",
     "./packages/stress",
+    "./packages/subgraph",
     "./packages/web3",
   ],
   "[solidity]": {

--- a/packages/subgraph/.eslintrc.json
+++ b/packages/subgraph/.eslintrc.json
@@ -1,3 +1,27 @@
 {
-    "extends": ["ponder"]
+    "root": true,
+    "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:prettier/recommended",
+        "ponder"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "project": ["./tsconfig.json"]
+    },
+    "plugins": ["@typescript-eslint"],
+    "rules": {
+        "no-console": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unused-vars": [
+            "error",
+            {
+                "argsIgnorePattern": "^_",
+                "destructuredArrayIgnorePattern": "^_",
+                "caughtErrors": "none"
+            }
+        ],
+        "@typescript-eslint/ban-ts-comment": "off"
+    }
 }


### PR DESCRIPTION
Super annoying to work in the Subgraph since it doesn't lint on save and I keep hitting prettier checks in CI.
i just picked a few rules from the SDK now, maybe we should symlink all of these to one central `.eslintrc.json` or something