### PR TITLE
Switch github runners to blacksmith

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ on:
 
 jobs:
     Build_Anvil_Docker:
-        runs-on: ubuntu-x64-16core
+        runs-on: blacksmith-16vcpu-ubuntu-2404
         outputs:
             image_tag: ${{ steps.output.outputs.tag }}
             build_hash: ${{ steps.hash.outputs.hash }}
@@ -150,7 +150,7 @@ jobs:
     Common_CI:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_common_ci
-        runs-on: ubuntu-x64-16core
+        runs-on: blacksmith-16vcpu-ubuntu-2404
         timeout-minutes: 30
         needs: [Build_Anvil_Docker]
 
@@ -337,7 +337,7 @@ jobs:
     Multinode:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_multinode
-        runs-on: ubuntu-x64-16core
+        runs-on: blacksmith-16vcpu-ubuntu-2404
         timeout-minutes: 30
         needs: [Build_Anvil_Docker]
         services:
@@ -509,7 +509,7 @@ jobs:
     Multinode_Ent:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_multinode_ent
-        runs-on: ubuntu-x64-16core
+        runs-on: blacksmith-16vcpu-ubuntu-2404
         timeout-minutes: 40
         needs: [Build_Anvil_Docker]
         services:
@@ -679,7 +679,7 @@ jobs:
     Multinode_Ent_Legacy:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_multinode_ent_legacy
-        runs-on: ubuntu-x64-16core
+        runs-on: blacksmith-16vcpu-ubuntu-2404
         timeout-minutes: 40
         needs: [Build_Anvil_Docker]
         services:
@@ -840,7 +840,7 @@ jobs:
     Go_Tests:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_go
-        runs-on: ubuntu-x64-16core
+        runs-on: blacksmith-16vcpu-ubuntu-2404
         timeout-minutes: 30
         needs: [Build_Anvil_Docker]
         services:
@@ -968,7 +968,7 @@ jobs:
     XChain_Integration:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_xchain_integration
-        runs-on: ubuntu-x64-16core
+        runs-on: blacksmith-16vcpu-ubuntu-2404
         timeout-minutes: 30
 
         steps:
@@ -1018,7 +1018,7 @@ jobs:
                 XChain_Integration,
             ]
         if: failure()
-        runs-on: ubuntu-x64-16core
+        runs-on: blacksmith-16vcpu-ubuntu-2404
         steps:
             - name: Slack notification
               if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of your changes and their purpose -->

### Changes

- Update the `ci.yml` github workflow to use blacksmith.sh runners instead of the default github runners for actions that require 16vCPU