### PR TITLE
node: introduce stream.media.maxStreamSizeBytes on-chain-config

### DIFF
--- a/core/node/crypto/config.go
+++ b/core/node/crypto/config.go
@@ -32,7 +32,11 @@ const (
 	StreamMediaMaxChunkCountConfigKey = "stream.media.maxChunkCount"
 	// StreamMediaMaxChunkSizeConfigKey defines the maximum size of a data chunk that is allowed to be added to a media
 	// stream in a single event.
-	StreamMediaMaxChunkSizeConfigKey             = "stream.media.maxChunkSize"
+	StreamMediaMaxChunkSizeConfigKey = "stream.media.maxChunkSize"
+	// StreamMediaMaxSizeBytesConfigKey defines the maximum total size of a media stream in bytes.
+	// (e.g. all chunks combined).
+	// It replaces StreamMediaMaxChunkCountConfigKey and StreamMediaMaxChunkSizeConfigKey
+	StreamMediaMaxSizeBytesConfigKey             = "stream.media.maxStreamSizeBytes"
 	StreamRecencyConstraintsAgeSecConfigKey      = "stream.recencyConstraints.ageSeconds"
 	StreamRecencyConstraintsGenerationsConfigKey = "stream.recencyConstraints.generations"
 	// StreamReplicationFactorConfigKey is the key for how often a stream is replicated over nodes
@@ -125,6 +129,9 @@ type OnChainSettings struct {
 
 	MediaMaxChunkCount uint64 `mapstructure:"stream.media.maxChunkCount"`
 	MediaMaxChunkSize  uint64 `mapstructure:"stream.media.maxChunkSize"`
+	// MediaMaxSizeBytes is the maximum allowed total size in bytes of all chunks combined in a media stream.
+	// It replaces MediaMaxChunkCount and MediaMaxChunkSize.
+	MediaMaxSizeBytes uint64 `mapstructure:"stream.media.maxStreamSizeBytes"`
 
 	RecencyConstraintsAge time.Duration `mapstructure:"stream.recencyConstraints.ageSeconds"`
 	RecencyConstraintsGen uint64        `mapstructure:"stream.recencyConstraints.generations"`
@@ -293,6 +300,7 @@ func DefaultOnChainSettings() *OnChainSettings {
 	return &OnChainSettings{
 		MediaMaxChunkCount: 21,
 		MediaMaxChunkSize:  1200000,
+		MediaMaxSizeBytes:  25 * 1024 * 1024, // 25MiB
 
 		RecencyConstraintsAge: 11 * time.Second,
 		RecencyConstraintsGen: 5,

--- a/core/node/crypto/config_test.go
+++ b/core/node/crypto/config_test.go
@@ -205,6 +205,7 @@ func TestSetOnChain(t *testing.T) {
 
 	btc.SetConfigValue(t, ctx, StreamReplicationFactorConfigKey, ABIEncodeUint64(3))
 	btc.SetConfigValue(t, ctx, StreamMediaMaxChunkCountConfigKey, ABIEncodeUint64(1000))
+	btc.SetConfigValue(t, ctx, StreamMediaMaxSizeBytesConfigKey, ABIEncodeUint64(1000))
 	btc.SetConfigValue(t, ctx, StreamCacheExpirationMsConfigKey, ABIEncodeUint64(3000))
 	btc.SetConfigValue(t, ctx, StreamRecencyConstraintsAgeSecConfigKey, ABIEncodeUint64(5))
 	btc.SetConfigValue(t, ctx, "unknown key is fine", ABIEncodeUint64(5))
@@ -221,6 +222,7 @@ func TestSetOnChain(t *testing.T) {
 	s := btc.OnChainConfig.Get()
 	assert.EqualValues(3, s.ReplicationFactor)
 	assert.EqualValues(1000, s.MediaMaxChunkCount)
+	assert.EqualValues(1000, s.MediaMaxSizeBytes)
 	assert.Equal(3*time.Second, s.StreamCacheExpiration)
 	assert.Equal(5*time.Second, s.RecencyConstraintsAge)
 	assert.EqualValues(5, s.MembershipLimits.DM)


### PR DESCRIPTION
## Summary

  - introduce the on-chain config key stream.media.maxStreamSizeBytes in core/node/crypto/config.go:35 so nodes can enforce a total media stream size cap instead of relying on chunk-based heuristics
  - default the new limit to 25 MiB in core/node/crypto/config.go:302, aligning with expected media payload sizes
  - extend TestSetOnChain in core/node/crypto/config_test.go:207 to confirm the configuration loader persists the value pulled from the chain
