### PR TITLE
Add Custom message type for unencrypted app integrations

### DIFF
--- a/protocol/protocol.proto
+++ b/protocol/protocol.proto
@@ -353,10 +353,16 @@ message ChannelPayload {
         bytes event_id = 1;
     }
 
+    message Custom {
+        string type_url = 1;      // e.g., "type.googleapis.com/game.PlayerMove"
+        optional bytes value = 2;  // serialized protobuf data
+    }
+
     oneof content {
         Inception inception = 1;
         EncryptedData message = 2;
         Redaction redaction = 3;
+        Custom custom = 4;  // unencrypted third-party app messages
     }
 }
 


### PR DESCRIPTION
## Summary

This PR introduces a `Custom` message type as an unencrypted counterpart to the existing `GM` (Generic Message) type in the Towns/River protocol.

## Context: GM Message Type

The protocol currently supports `GM` (Generic Message) for arbitrary typed data:

```protobuf
// In payloads.proto
message Content {
    message GM {
        string type_url = 1;
        optional bytes value = 2;
    }
}
```

However, GM messages are sent inside `EncryptedData` envelopes, meaning:
- They require decryption keys to be visible
- Only channel members can see the content
- They cannot be indexed or searched publicly

## Motivation for Custom Messages

Third-party applications need to post activities that are:
- **Publicly visible** - No decryption keys required
- **Transparent** - All channel participants can see activities like trades, bets, game moves
- **Indexable** - Can be searched and aggregated without decryption
- **Auditable** - Public record of application activities

Examples include:
- DeFi trading activities
- Game moves and state updates
- DAO proposals and voting

## Implementation

The `Custom` message type follows the exact same pattern as GM:

```protobuf
message ChannelPayload {
    message Custom {
        string type_url = 1;      // e.g., "type.googleapis.com/game.PlayerMove"
        optional bytes value = 2;  // serialized protobuf data
    }

    oneof content {
        Inception inception = 1;
        EncryptedData message = 2;  // GM lives here (encrypted)
        Redaction redaction = 3;
        Custom custom = 4;          // NEW: Custom lives here (unencrypted)
    }
}
```

## Design Decisions

- **Minimal structure**: Just `type_url` and `value`, identical to GM
- **Protocol layer**: Lives in `ChannelPayload` for unencrypted transport
- **No metadata**: Apps handle their own display/routing needs in payloads
- **Reactions/replies work**: Users can still react to Custom messages via encrypted messages

This provides a clean, minimal extension that enables transparent application integrations while maintaining the simplicity of the Towns protocol.