### PR TITLE
feat: pause subscription for banned memberships

### DIFF
--- a/packages/contracts/src/apps/modules/subscription/ISubscriptionModule.sol
+++ b/packages/contracts/src/apps/modules/subscription/ISubscriptionModule.sol
@@ -40,6 +40,7 @@ interface ISubscriptionModuleBase {
     error SubscriptionModule__InvalidTokenOwner();
     error SubscriptionModule__InsufficientBalance();
     error SubscriptionModule__ActiveSubscription();
+    error SubscriptionModule__MembershipBanned();
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                           Events                           */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/


### PR DESCRIPTION
### Description

Added a check to prevent banned memberships from creating or renewing subscriptions. When a membership is banned, the subscription module will now pause the subscription and skip renewal attempts.

### Changes

- Added a new error `SubscriptionModule__MembershipBanned` to the interface
- Added a ban check during subscription module installation to prevent banned memberships from creating subscriptions
- Added a ban check during batch renewal to skip and pause subscriptions for banned memberships
- Added tests to verify the new ban-related functionality works correctly

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines