### PR TITLE
bots: move away from Hono, prefer `Response/Request` API

### DIFF
--- a/packages/bot/AGENTS.md
+++ b/packages/bot/AGENTS.md
@@ -184,8 +184,26 @@ bot.onMessage((handler, { message }) => {
     // ...
 })
 
-// Start bot
-const { handler } = await bot.start()
+// Bot is ready to use - bot.fetch is available immediately
+```
+
+## Using the Bot
+
+After creating a bot with `makeTownsBot`, the webhook handler is available as `bot.fetch`:
+
+```typescript
+const bot = await makeTownsBot(privateData, jwtSecret, { commands })
+
+// With Hono
+app.post('/webhook', async (c) => {
+  return await bot.fetch(c.req.raw)
+})
+
+// With Bun
+Bun.serve({ fetch: bot.fetch, port: 3000 })
+
+// With Cloudflare Workers
+export default { fetch: bot.fetch }
 ```
 
 ## Common Development Tasks

--- a/packages/bot/README.md
+++ b/packages/bot/README.md
@@ -6,6 +6,7 @@ A bot framework for Towns.
 
 ```ts
 import { makeTownsBot } from "@towns-protocol/bot";
+import { Hono } from "hono";
 import { serve } from "@hono/node-server";
 
 const bot = await makeTownsBot("<app-private-data-base64>", "<jwt-secret>");
@@ -16,8 +17,12 @@ bot.onMessage((client, { channelId, isMentioned }) => {
   }
 });
 
-const { fetch } = await bot.start();
-serve({ fetch });
+const app = new Hono();
+app.post('/webhook', async (c) => {
+  return await bot.fetch(c.req.raw);
+});
+
+serve({ fetch: app.fetch, port: 3000 });
 ```
 
 ## Running Bots

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -51,9 +51,6 @@
     "files": [
         "/dist"
     ],
-    "peerDependencies": {
-        "hono": "^4.7.11"
-    },
     "publishConfig": {
         "access": "public"
     }

--- a/packages/bot/src/bot.test.ts
+++ b/packages/bot/src/bot.test.ts
@@ -226,10 +226,10 @@ describe('Bot', { sequential: true }, () => {
         bot = await makeTownsBot(appPrivateData, jwtSecretBase64, { commands: SLASH_COMMANDS })
         expect(bot).toBeDefined()
         expect(bot.botId).toBe(botClientAddress)
-        const { jwtMiddleware, handler } = await bot.start()
         const app = new Hono()
-        app.use(jwtMiddleware)
-        app.post('/webhook', handler)
+        app.post('/webhook', async (c) => {
+            return await bot.fetch(c.req.raw)
+        })
         serve({
             port: Number(process.env.BOT_PORT!),
             fetch: app.fetch,

--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -22,8 +22,6 @@ import {
     make_ChannelPayload_Redaction,
     parseAppPrivateData,
 } from '@towns-protocol/sdk'
-import { type Context, type Env, type Next } from 'hono'
-import { createMiddleware } from 'hono/factory'
 import { default as jwt } from 'jsonwebtoken'
 import { createNanoEvents, type Emitter } from 'nanoevents'
 import imageSize from 'image-size'
@@ -78,7 +76,6 @@ import {
     type WriteContractParameters,
 } from 'viem/actions'
 import { base, baseSepolia } from 'viem/chains'
-import type { BlankEnv } from 'hono/types'
 import { SnapshotGetter } from './snapshot-getter'
 
 type BotActions = ReturnType<typeof buildBotActions>
@@ -224,10 +221,7 @@ type BasePayload = {
     createdAt: Date
 }
 
-export class Bot<
-    Commands extends PlainMessage<SlashCommand>[] = [],
-    HonoEnv extends Env = BlankEnv,
-> {
+export class Bot<Commands extends PlainMessage<SlashCommand>[] = []> {
     private readonly client: ClientV2<BotActions>
     botId: string
     viemClient: ViemClient
@@ -254,22 +248,12 @@ export class Bot<
         this.snapshot = clientV2.snapshot
     }
 
-    async start() {
-        await this.client.uploadDeviceKeys()
-        const jwtMiddleware = createMiddleware<HonoEnv>(this.jwtMiddleware.bind(this))
-        debug('start')
-
-        return {
-            jwtMiddleware,
-            handler: this.webhookHandler.bind(this),
-        }
-    }
-
-    private async jwtMiddleware(c: Context<HonoEnv>, next: Next): Promise<Response | void> {
-        const authHeader = c.req.header('Authorization')
+    public fetch = async (request: Request): Promise<Response> => {
+        // 1. JWT validation
+        const authHeader = request.headers.get('Authorization')
 
         if (!authHeader || !authHeader.startsWith('Bearer ')) {
-            return c.text('Unauthorized: Missing or malformed token', 401)
+            return new Response('Unauthorized: Missing or malformed token', { status: 401 })
         }
 
         const tokenString = authHeader.substring(7)
@@ -287,17 +271,14 @@ export class Bot<
             } else if (err instanceof jwt.JsonWebTokenError) {
                 errorMessage = `Unauthorized: Invalid token (${err.message})`
             }
-            return c.text(errorMessage, 401)
+            return new Response(errorMessage, { status: 401 })
         }
 
-        await next()
-    }
-
-    private async webhookHandler(c: Context<HonoEnv>) {
-        const body = await c.req.arrayBuffer()
+        // 2. Process webhook
+        const body = await request.arrayBuffer()
         const encryptionDevice = this.client.crypto.getUserDevice()
-        const request = fromBinary(AppServiceRequestSchema, new Uint8Array(body))
-        debug('webhook', request)
+        const appRequest = fromBinary(AppServiceRequestSchema, new Uint8Array(body))
+        debug('webhook', appRequest)
         const statusResponse = create(AppServiceResponseSchema, {
             payload: {
                 case: 'status',
@@ -309,7 +290,7 @@ export class Bot<
             },
         })
         let response: AppServiceResponse = statusResponse
-        if (request.payload.case === 'initialize') {
+        if (appRequest.payload.case === 'initialize') {
             response = create(AppServiceResponseSchema, {
                 payload: {
                     case: 'initialize',
@@ -318,17 +299,19 @@ export class Bot<
                     },
                 },
             })
-        } else if (request.payload.case === 'events') {
-            for (const event of request.payload.value.events) {
+        } else if (appRequest.payload.case === 'events') {
+            for (const event of appRequest.payload.value.events) {
                 await this.handleEvent(event)
             }
             response = statusResponse
-        } else if (request.payload.case === 'status') {
+        } else if (appRequest.payload.case === 'status') {
             response = statusResponse
         }
 
-        c.header('Content-Type', 'application/x-protobuf')
-        return c.body(toBinary(AppServiceResponseSchema, response), 200)
+        return new Response(toBinary(AppServiceResponseSchema, response), {
+            status: 200,
+            headers: { 'Content-Type': 'application/x-protobuf' },
+        })
     }
 
     // TODO: onTip
@@ -850,10 +833,7 @@ export class Bot<
     }
 }
 
-export const makeTownsBot = async <
-    Commands extends PlainMessage<SlashCommand>[] = [],
-    HonoEnv extends Env = BlankEnv,
->(
+export const makeTownsBot = async <Commands extends PlainMessage<SlashCommand>[] = []>(
     appPrivateData: string,
     jwtSecretBase64: string,
     opts: {
@@ -886,7 +866,8 @@ export const makeTownsBot = async <
         },
         ...clientOpts,
     }).then((x) => x.extend((townsClient) => buildBotActions(townsClient, viemClient, spaceDapp)))
-    return new Bot<Commands, HonoEnv>(client, viemClient, jwtSecretBase64, opts.commands)
+    await client.uploadDeviceKeys()
+    return new Bot<Commands>(client, viemClient, jwtSecretBase64, opts.commands)
 }
 
 const buildBotActions = (client: ClientV2, viemClient: ViemClient, spaceDapp: SpaceDapp) => {

--- a/packages/examples/bot-quickstart/AGENTS.md
+++ b/packages/examples/bot-quickstart/AGENTS.md
@@ -985,8 +985,9 @@ bot.onSlashCommand("setup-github-here", async (handler, event) => {
 })
 
 // 2. Towns webhook endpoint (required for bot to work)
-const { jwtMiddleware, handler } = await bot.start()
-app.post('/webhook', jwtMiddleware, handler)
+app.post('/webhook', async (c) => {
+  return await bot.fetch(c.req.raw)
+})
 
 // 3. GitHub webhook endpoint (separate from Towns webhook)
 app.post('/github-webhook', async (c) => {
@@ -1016,6 +1017,28 @@ app.post('/github-webhook', async (c) => {
 })
 
 serve({ fetch: app.fetch, port: 3000 })
+```
+
+### Framework Integration Examples
+
+The `bot.fetch` property works with any framework that supports Web API Request/Response:
+
+**Hono:**
+```typescript
+const app = new Hono()
+app.post('/webhook', async (c) => {
+  return await bot.fetch(c.req.raw)
+})
+```
+
+**Cloudflare Workers:**
+```typescript
+export default { fetch: bot.fetch }
+```
+
+**Bun:**
+```typescript
+Bun.serve({ fetch: bot.fetch, port: 3000 })
 ```
 
 ### Health Check Monitoring Example

--- a/packages/examples/bot-quickstart/src/index.ts
+++ b/packages/examples/bot-quickstart/src/index.ts
@@ -51,11 +51,11 @@ async function main() {
         }
     })
 
-    const { jwtMiddleware, handler } = await bot.start()
-
     const app = new Hono()
     app.use(logger())
-    app.post('/webhook', jwtMiddleware, handler)
+    app.post('/webhook', async (c) => {
+        return await bot.fetch(c.req.raw)
+    })
 
     serve({ fetch: app.fetch, port: parseInt(process.env.PORT!) })
     console.log(`✅ Quickstart Bot is running on https://localhost:${process.env.PORT}`)


### PR DESCRIPTION
This PR moves the bot framework from being built on top of Hono to being built on top of WebAPI (https://wintertc.org/)

Maybe that's not really needed, Hono is already WebAPI compatible, users can already call `Bun.serve({ fetch: honoApp.fetch })` 

Still need to think more about it.
