### PR TITLE
fix: return MIN_RENEWAL_BUFFER when operator buffer is zero

### DIFF
--- a/packages/contracts/src/apps/modules/subscription/SubscriptionModuleStorage.sol
+++ b/packages/contracts/src/apps/modules/subscription/SubscriptionModuleStorage.sol
@@ -46,7 +46,7 @@ library SubscriptionModuleStorage {
 
     function getOperatorBuffer(address operator) internal view returns (uint256) {
         OperatorConfig storage config = getLayout().operatorConfig[operator];
-        if (config.interval == 0) return MIN_RENEWAL_BUFFER;
+        if (config.interval == 0 || config.buffer == 0) return MIN_RENEWAL_BUFFER;
         return config.buffer;
     }
 }


### PR DESCRIPTION
### Description

Fixed a bug in the `getOperatorBuffer` function to ensure the minimum renewal buffer is returned when the operator's buffer is set to zero, not just when the interval is zero.

### Changes

- Modified the condition in `getOperatorBuffer` to return `MIN_RENEWAL_BUFFER` when either `config.interval` or `config.buffer` is zero

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines