### PR TITLE
Add docstrings to the different user streams in protocol.proto

### DIFF
--- a/protocol/protocol.proto
+++ b/protocol/protocol.proto
@@ -408,6 +408,9 @@ message GdmChannelPayload {
 
 /**
 * UserPayload
+* A potentially large stream that contains all of a users memberships and is the entrypoint for 
+* many user interactions. For example, to join a space, the user posts a UserMembership event to this stream.
+* It is meant to be downloaded once by the user and updated via delta updates over sync.
 */
 message UserPayload {
     message Snapshot {
@@ -469,6 +472,8 @@ message UserPayload {
 /**
 * UserInboxPayload
 * messages to a user encrypted per deviceId
+* This is a write heavy stream. Anything encrypted to a single user/device pair is sent to this stream.
+* The snapshot keeps track of read markers for each of the user's devices so that the user can effeciently download all new events.
 */
 message UserInboxPayload {
     message Snapshot {
@@ -519,6 +524,8 @@ message UserInboxPayload {
 
 /**
 * UserSettingsPayload
+* blob storage for the user 
+* written to and read by the user
 */
 message UserSettingsPayload {
     message Snapshot {
@@ -571,6 +578,8 @@ message UserSettingsPayload {
 
 /**
 * UserMetadataPayload
+* A light stream containing the user's "public" data like public encryption keys and links to user profile info.
+* Should remain small so that it can be quickly read by other users.
 */
 message UserMetadataPayload {
     message Snapshot {


### PR DESCRIPTION
I should have done this a long time ago.