### PR TITLE
bots: export bot handler type

### DIFF
--- a/packages/bot/AGENTS.md
+++ b/packages/bot/AGENTS.md
@@ -102,6 +102,16 @@ The bot framework provides these event handlers:
 
 Methods available on the `handler` parameter in event callbacks:
 
+#### Exported Types for Building Abstractions
+
+The `@towns-protocol/bot` package exports several types useful for building abstractions:
+
+**`BotHandler`** - Type representing all methods available on the `handler` parameter. Use this when building helper functions, middleware, or utilities that need to accept a handler as a parameter.
+
+**`BasePayload`** - Type containing common fields present in all event payloads (`userId`, `spaceId`, `channelId`, `eventId`, `createdAt`). Use this when building generic event processing utilities that work across different event types.
+
+**`MessageOpts`** - Type defining options for sending messages (threadId, replyId, mentions, attachments, ephemeral). Use this when building message utilities that need to accept or manipulate message sending options.
+
 **Message Operations:**
 - `sendMessage(streamId, message, opts?, tags?)` - Send to channel
   - `opts.ephemeral`: Send ephemeral message (won't persist after refresh)

--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -83,6 +83,8 @@ import { SnapshotGetter } from './snapshot-getter'
 
 type BotActions = ReturnType<typeof buildBotActions>
 
+export type BotHandler = ReturnType<typeof buildBotActions>
+
 const debug = dlog('csb:bot')
 
 export type BotPayload<
@@ -96,7 +98,7 @@ type ImageAttachment = {
     url: string
 }
 
-type MessageOpts = {
+export type MessageOpts = {
     threadId?: string
     replyId?: string
     mentions?: PlainMessage<ChannelMessage_Post_Mention>[]
@@ -211,7 +213,7 @@ export type BotEvents<Commands extends PlainMessage<SlashCommand>[] = []> = {
     ) => Promise<void> | void
 }
 
-type BasePayload = {
+export type BasePayload = {
     /** The user ID of the user that triggered the event */
     userId: string
     /** The space ID that the event was triggered in */

--- a/packages/examples/bot-quickstart/AGENTS.md
+++ b/packages/examples/bot-quickstart/AGENTS.md
@@ -480,6 +480,16 @@ bot.onMessage(async (handler, event) => {
 
 All handlers receive a `handler` parameter with these methods:
 
+### Exported Types for Building Abstractions
+
+The `@towns-protocol/bot` package exports several types useful for building abstractions:
+
+**`BotHandler`** - Type representing all methods available on the `handler` parameter. Use this when building helper functions, middleware, or utilities that need to accept a handler as a parameter.
+
+**`BasePayload`** - Type containing common fields present in all event payloads (`userId`, `spaceId`, `channelId`, `eventId`, `createdAt`). Use this when building generic event processing utilities that work across different event types.
+
+**`MessageOpts`** - Type defining options for sending messages (threadId, replyId, mentions, attachments, ephemeral). Use this when building message utilities that need to accept or manipulate message sending options.
+
 ### Message Operations
 
 ```typescript


### PR DESCRIPTION
LLM is using `any` because we're not exporting it. 🤦‍♂️