### PR TITLE
fix(contracts): correct diamond cut remove operations and protect Met…

### DIFF
--- a/packages/contracts/scripts/deployments/diamonds/DeployAppRegistry.s.sol
+++ b/packages/contracts/scripts/deployments/diamonds/DeployAppRegistry.s.sol
@@ -54,7 +54,6 @@ contract DeployAppRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
         facetHelper.add("DiamondLoupeFacet");
         facetHelper.add("IntrospectionFacet");
         facetHelper.add("OwnableFacet");
-        facetHelper.add("MetadataFacet");
 
         // Deploy the first batch of facets
         facetHelper.deployBatch(deployer);
@@ -87,26 +86,27 @@ contract DeployAppRegistry is IDiamondInitHelper, DiamondHelper, Deployer {
             facet,
             DeployOwnable.makeInitData(deployer)
         );
-
-        facet = facetHelper.predictAddress("MetadataFacet");
-        addFacet(
-            makeCut(facet, FacetCutAction.Add, DeployMetadata.selectors()),
-            facet,
-            DeployMetadata.makeInitData(bytes32("AppRegistry"), "")
-        );
     }
 
     function diamondInitParams(address deployer) public returns (Diamond.InitParams memory) {
         // Queue up feature facets for batch deployment
         facetHelper.add("MultiInit");
+        facetHelper.add("MetadataFacet");
         facetHelper.add("UpgradeableBeaconFacet");
         facetHelper.add("AppRegistryFacet");
         facetHelper.add("SimpleApp");
 
         facetHelper.deployBatch(deployer);
 
+        address facet = facetHelper.getDeployedAddress("MetadataFacet");
+        addFacet(
+            makeCut(facet, FacetCutAction.Add, DeployMetadata.selectors()),
+            facet,
+            DeployMetadata.makeInitData(bytes32("AppRegistry"), "")
+        );
+
         address simpleApp = facetHelper.getDeployedAddress("SimpleApp");
-        address facet = facetHelper.getDeployedAddress("UpgradeableBeaconFacet");
+        facet = facetHelper.getDeployedAddress("UpgradeableBeaconFacet");
 
         addFacet(
             makeCut(facet, FacetCutAction.Add, DeployUpgradeableBeacon.selectors()),

--- a/packages/contracts/scripts/deployments/diamonds/DeploySubscriptionModule.s.sol
+++ b/packages/contracts/scripts/deployments/diamonds/DeploySubscriptionModule.s.sol
@@ -62,13 +62,21 @@ contract DeploySubscriptionModule is DiamondHelper, Deployer, IDiamondInitHelper
     function diamondInitParams(address deployer) public returns (Diamond.InitParams memory) {
         // Queue up feature facets for batch deployment
         facetHelper.add("MultiInit");
+        facetHelper.add("MetadataFacet");
         facetHelper.add("SubscriptionModuleFacet");
 
         // Deploy all facets in a batch
         facetHelper.deployBatch(deployer);
 
         // Add feature facets
-        address facet = facetHelper.getDeployedAddress("SubscriptionModuleFacet");
+        address facet = facetHelper.getDeployedAddress("MetadataFacet");
+        addFacet(
+            makeCut(facet, FacetCutAction.Add, DeployMetadata.selectors()),
+            facet,
+            DeployMetadata.makeInitData(METADATA_NAME, "")
+        );
+
+        facet = facetHelper.getDeployedAddress("SubscriptionModuleFacet");
         addFacet(
             makeCut(facet, FacetCutAction.Add, DeploySubscriptionModuleFacet.selectors()),
             facet,
@@ -95,7 +103,6 @@ contract DeploySubscriptionModule is DiamondHelper, Deployer, IDiamondInitHelper
         facetHelper.add("DiamondLoupeFacet");
         facetHelper.add("IntrospectionFacet");
         facetHelper.add("OwnableFacet");
-        facetHelper.add("MetadataFacet");
 
         // Get predicted addresses
         address facet = facetHelper.predictAddress("DiamondCutFacet");
@@ -124,13 +131,6 @@ contract DeploySubscriptionModule is DiamondHelper, Deployer, IDiamondInitHelper
             makeCut(facet, FacetCutAction.Add, DeployOwnable.selectors()),
             facet,
             DeployOwnable.makeInitData(deployer)
-        );
-
-        facet = facetHelper.predictAddress("MetadataFacet");
-        addFacet(
-            makeCut(facet, FacetCutAction.Add, DeployMetadata.selectors()),
-            facet,
-            DeployMetadata.makeInitData(METADATA_NAME, "")
         );
     }
 

--- a/packages/contracts/scripts/interactions/helpers/AlphaHelper.sol
+++ b/packages/contracts/scripts/interactions/helpers/AlphaHelper.sol
@@ -8,6 +8,7 @@ import {IDiamondLoupe, IDiamondLoupeBase} from "@towns-protocol/diamond/src/face
 import {IERC173} from "@towns-protocol/diamond/src/facets/ownable/IERC173.sol";
 import {IOwnablePending} from "@towns-protocol/diamond/src/facets/ownable/pending/IOwnablePending.sol";
 import {IDiamondInitHelper} from "scripts/deployments/diamonds/IDiamondInitHelper.sol";
+import {IMetadata} from "src/diamond/facets/metadata/IMetadata.sol";
 
 // libraries
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
@@ -55,13 +56,14 @@ abstract contract AlphaHelper is Interaction, DiamondHelper, IDiamondLoupeBase {
     function getCoreFacetAddresses(
         address diamond
     ) internal view returns (address[] memory coreFacets) {
-        coreFacets = new address[](5);
+        coreFacets = new address[](6);
 
         coreFacets[0] = IDiamondLoupe(diamond).facetAddress(IDiamondCut.diamondCut.selector);
         coreFacets[1] = IDiamondLoupe(diamond).facetAddress(IDiamondLoupe.facets.selector);
         coreFacets[2] = IDiamondLoupe(diamond).facetAddress(IERC165.supportsInterface.selector);
         coreFacets[3] = IDiamondLoupe(diamond).facetAddress(IERC173.owner.selector);
         coreFacets[4] = IDiamondLoupe(diamond).facetAddress(IOwnablePending.currentOwner.selector);
+        coreFacets[5] = IDiamondLoupe(diamond).facetAddress(IMetadata.contractType.selector);
     }
 
     /// @notice Check if an address is a core facet that should not be removed
@@ -254,7 +256,7 @@ abstract contract AlphaHelper is Interaction, DiamondHelper, IDiamondLoupeBase {
             }
 
             if (removeSelectors.length() > 0) {
-                addCut(FacetCut(address(0), FacetCutAction.Remove, asBytes4Array(removeSelectors)));
+                addCut(FacetCut(facetAddr, FacetCutAction.Remove, asBytes4Array(removeSelectors)));
             }
         }
     }

--- a/packages/contracts/test/spaces/membership/unit/MembershipRenew.t.sol
+++ b/packages/contracts/test/spaces/membership/unit/MembershipRenew.t.sol
@@ -34,7 +34,7 @@ contract MembershipRenewTest is MembershipBaseSetup, IERC5643Base {
         return membership.getMembershipRenewalPrice(tokenId);
     }
 
-    function _setupMembershipPricing(uint256 freeAllocation, uint256 price) private {
+    function _setupMembershipPricing(uint256, uint256 price) private {
         vm.startPrank(founder);
         // membership.setMembershipFreeAllocation(freeAllocation);
         membership.setMembershipPrice(price);


### PR DESCRIPTION
…adataFacet

### Description

Fixed diamond upgrade system to use correct facet addresses for Remove operations and protect MetadataFacet from unintended removal during upgrades.

### Changes

- Fixed `addRemovalCuts()` to use actual facet address instead of `address(0)` for Remove operations
- Added MetadataFacet to core facet protection list in `getCoreFacetAddresses()`
- Moved MetadataFacet to `diamondInitParams()` in DeployAppRegistry and DeploySubscriptionModule to ensure inclusion in upgrade proposals
- Fixed unused parameter warning in MembershipRenew test

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines
