### PR TITLE
chore(contracts): update foundry configuration to ignore linting in scripts and test directories

### DIFF
--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -54,5 +54,6 @@ sort_imports = true
 [lint]
 severity = ["high", "med", "low", "gas"]
 exclude_lints = ["asm-keccak256", "erc20-unchecked-transfer", "incorrect-shift"]
+ignore = ["scripts/**/*", "test/**/*"]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
### Description

Updated the Foundry configuration to ignore linting in the `scripts` and `test` directories, streamlining the development and testing process.

### Changes

- Updated Foundry configuration to exclude linting in `scripts` and `test` directories.

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines