### PR TITLE
fix: upgrade Pino to v9 and fix logger argument order

### DIFF
--- a/packages/metrics-discovery/package.json
+++ b/packages/metrics-discovery/package.json
@@ -22,7 +22,7 @@
         "@towns-protocol/web3": "workspace:^",
         "esbuild-plugin-pino": "^2.2.0",
         "ethers": "^5.8.0",
-        "pino": "^8.17.1",
+        "pino": "^9.0.0",
         "pino-pretty": "^13.0.0",
         "zod": "^3.25.76"
     },

--- a/packages/stream-metadata/package.json
+++ b/packages/stream-metadata/package.json
@@ -43,7 +43,7 @@
 		"fastify": "^5.3.3",
 		"lru-cache": "^11.0.1",
 		"magic-bytes.js": "^1.10.0",
-		"pino": "^8.17.1",
+		"pino": "^9.0.0",
 		"pino-pretty": "^13.0.0",
 		"sharp": "0.34.3",
 		"uuid": "^8.3.2",

--- a/packages/stream-metadata/src/routes/spaceMemberMetadata.ts
+++ b/packages/stream-metadata/src/routes/spaceMemberMetadata.ts
@@ -88,7 +88,7 @@ const getSpaceMemberMetadata = async (
 			imageEventId = 'unregistered'
 		}
 	} catch (error) {
-		logger.error('Failed to get stream', { err: error, spaceAddress, tokenId })
+		logger.error({ err: error, spaceAddress, tokenId }, 'Failed to get stream')
 		imageEventId = 'unknown'
 	}
 

--- a/packages/stream-metadata/src/routes/spaceMetadata.ts
+++ b/packages/stream-metadata/src/routes/spaceMetadata.ts
@@ -85,7 +85,7 @@ export async function fetchSpaceMetadata(request: FastifyRequest, reply: Fastify
 		}
 	} catch (error) {
 		// no-op
-		logger.error('Failed to get stream', { err: error, spaceAddress })
+		logger.error({ err: error, spaceAddress }, 'Failed to get stream')
 		imageEventId = 'unknown'
 	}
 

--- a/packages/stress/package.json
+++ b/packages/stress/package.json
@@ -38,7 +38,7 @@
         "ethers": "^5.8.0",
         "fake-indexeddb": "^6.0.1",
         "ioredis": "^5.3.2",
-        "pino": "^8.17.1",
+        "pino": "^9.0.0",
         "pino-pretty": "^13.0.0"
     },
     "devDependencies": {

--- a/packages/stress/src/demo.ts
+++ b/packages/stress/src/demo.ts
@@ -69,14 +69,14 @@ async function sendAMessage() {
     const channel = await alice.streamsClient.waitForStream(defaultChannelId)
     logger.debug('=======================send a message - alice wait =======================')
     await waitFor(() => channel.view.timeline.filter(isChannelMessage).length > 0)
-    logger.debug('alices sees: ', channel.view.timeline.filter(isChannelMessage))
+    logger.debug({ timeline: channel.view.timeline.filter(isChannelMessage) }, 'alices sees')
     logger.debug('=======================send a message - alice sends =======================')
     await alice.sendMessage(defaultChannelId, 'hi bob')
     logger.debug('=======================send a message - alice sent =======================')
     const bobChannel = await bob.streamsClient.waitForStream(defaultChannelId)
     logger.debug('=======================send a message - bob wait =======================')
     await waitFor(() => bobChannel.view.timeline.filter(isChannelMessage).length > 0) // bob doesn't decrypt his own messages
-    logger.debug(bobChannel.view.timeline.filter(isChannelMessage), 'bob sees')
+    logger.debug({ timeline: bobChannel.view.timeline.filter(isChannelMessage) }, 'bob sees')
 
     await bob.stop()
     await alice.stop()

--- a/packages/xchain-monitor/package.json
+++ b/packages/xchain-monitor/package.json
@@ -14,7 +14,7 @@
         "@towns-protocol/web3": "workspace:^",
         "dotenv": "^16.4.7",
         "esbuild-plugin-pino": "^2.2.0",
-        "pino": "^8.17.1",
+        "pino": "^9.0.0",
         "pino-pretty": "^13.0.0",
         "typescript": "~5.8.3",
         "uuid": "^8.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9349,7 +9349,7 @@ __metadata:
     eslint: ^8.57.1
     eslint-plugin-import-x: ^4.10.2
     ethers: ^5.8.0
-    pino: ^8.17.1
+    pino: ^9.0.0
     pino-pretty: ^13.0.0
     prettier: ^3.5.3
     typescript: ~5.8.3
@@ -9632,7 +9632,7 @@ __metadata:
     fastify: ^5.3.3
     lru-cache: ^11.0.1
     magic-bytes.js: ^1.10.0
-    pino: ^8.17.1
+    pino: ^9.0.0
     pino-pretty: ^13.0.0
     prettier: ^3.5.3
     sharp: 0.34.3
@@ -9673,7 +9673,7 @@ __metadata:
     ethers: ^5.8.0
     fake-indexeddb: ^6.0.1
     ioredis: ^5.3.2
-    pino: ^8.17.1
+    pino: ^9.0.0
     pino-pretty: ^13.0.0
     typed-emitter: ^2.1.0
     typescript: ~5.8.3
@@ -9766,7 +9766,7 @@ __metadata:
     dotenv: ^16.4.7
     esbuild: ^0.25.9
     esbuild-plugin-pino: ^2.2.0
-    pino: ^8.17.1
+    pino: ^9.0.0
     pino-pretty: ^13.0.0
     tsx: ^4.7.1
     typescript: ~5.8.3
@@ -11549,7 +11549,7 @@ __metadata:
     source-map-support: ^0.5.19
     table: ^6.8.0
     typescript: ^4.3.5
-  checksum: bdca754160deb9b34a6b668bbcb80477c1c596cdaa90ed4966e0b557f32d26f1d973033a468dca016ad8e5d909c68f15859408208b70602bdee0619c6208bd02
+  checksum: 8be8f2e1f8dbdb9c35edddf1f919f6c09fe764e45ad5733c0d449869e6c9241de6eac9710576d025bb3934f3bb97d017198a7c5f31b88a68aee0dbc898e1de97
   languageName: node
   linkType: hard
 
@@ -25743,7 +25743,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pino@npm:^8.16.2, pino@npm:^8.17.1":
+"pino@npm:^8.16.2":
   version: 8.21.0
   resolution: "pino@npm:8.21.0"
   dependencies:


### PR DESCRIPTION
### Description

Upgrades Pino from v8 to v9 across all packages to match Fastify 5's requirement. Fastify 5.6.1 depends on Pino ^9.0.0, and Bun's stricter module resolution exposed a type mismatch where FastifyBaseLogger was typed against Pino 9 while the project used Pino 8.

### Changes

Package upgrades:
- @towns-protocol/stream-metadata: pino ^8.17.1 -> ^9.0.0
- @towns-protocol/stress: pino ^8.17.1 -> ^9.0.0
- @towns-protocol/metrics-discovery: pino ^8.17.1 -> ^9.0.0
- @towns-protocol/xchain-monitor: pino ^8.17.1 -> ^9.0.0

Code changes to follow Pino's argument order (object first, message second):
- packages/stream-metadata/src/routes/spaceMetadata.ts:88
- packages/stream-metadata/src/routes/spaceMemberMetadata.ts:91
- packages/stress/src/demo.ts:72
- packages/stress/src/demo.ts:79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines
