### PR TITLE
fix: update tokenId-based tracking for all Member tips regardless of tokenId value

### DIFF
--- a/packages/contracts/src/spaces/facets/tipping/TippingBase.sol
+++ b/packages/contracts/src/spaces/facets/tipping/TippingBase.sol
@@ -193,7 +193,7 @@ abstract contract TippingBase is ITippingBase, PointsBase {
         $.tippingStatsByCurrencyByWallet[receiver][currency].totalTips += 1;
 
         // Update tokenId-based tracking (backwards compatibility, only for Member tips)
-        if (recipientType == TipRecipientType.Member && tokenId != 0) {
+        if (recipientType == TipRecipientType.Member) {
             $.tipsByCurrencyByTokenId[tokenId][currency] += amount;
         }
 


### PR DESCRIPTION
### Description

Removed the `tokenId != 0` condition when updating token-based tip tracking for Member recipients. This change ensures that token-based tip tracking is performed for all Member tips regardless of whether the tokenId is zero.

### Changes

- Modified the condition in `TippingBase.sol` to track tips by tokenId for all Member recipients, not just those with non-zero tokenIds

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines