### PR TITLE
feat: replace tokenId with generic data field in TipEvent

### DIFF
--- a/packages/contracts/src/spaces/facets/tipping/ITipping.sol
+++ b/packages/contracts/src/spaces/facets/tipping/ITipping.sol
@@ -60,7 +60,7 @@ interface ITippingBase {
         TipRecipientType indexed recipientType,
         address currency,
         uint256 amount,
-        uint256 tokenId // 0 if not a member tip
+        bytes data
     );
 
     // Maintain legacy event for backwards compatibility

--- a/packages/contracts/src/spaces/facets/tipping/TippingBase.sol
+++ b/packages/contracts/src/spaces/facets/tipping/TippingBase.sol
@@ -84,7 +84,7 @@ abstract contract TippingBase is ITippingBase, PointsBase {
             TipRecipientType.Member,
             tipRequest.currency,
             tipAmount,
-            tipRequest.tokenId
+            abi.encode(tipRequest.tokenId)
         );
     }
 
@@ -121,7 +121,7 @@ abstract contract TippingBase is ITippingBase, PointsBase {
             TipRecipientType.Member,
             params.currency,
             tipAmount,
-            params.tokenId
+            params.metadata.data
         );
 
         emit Tip(
@@ -165,7 +165,7 @@ abstract contract TippingBase is ITippingBase, PointsBase {
             TipRecipientType.Bot,
             params.currency,
             tipAmount,
-            0
+            params.metadata.data
         );
     }
 

--- a/packages/contracts/test/spaces/tipping/Tipping.t.sol
+++ b/packages/contracts/test/spaces/tipping/Tipping.t.sol
@@ -428,7 +428,7 @@ contract TippingTest is Test, BaseSetup, ITippingBase, IERC721ABase {
             TipRecipientType.Member,
             CurrencyTransfer.NATIVE_TOKEN,
             tipAmount,
-            tokenId
+            abi.encode(tokenId)
         );
         tipping.tip{value: amount}(
             TipRequest({


### PR DESCRIPTION
### Description

Updated the `TipEvent` to use a more flexible `bytes data` parameter instead of the limited `uint256 tokenId`, allowing for more versatile metadata to be included with tips.

### Changes

- Modified the `TipEvent` signature in `ITipping.sol` to replace `uint256 tokenId` with `bytes data`
- Updated all event emissions in `TippingBase.sol` to use the new parameter format
- For member tips, encoded the tokenId using `abi.encode()` to maintain backward compatibility
- Updated test cases to reflect the new event parameter structure

### Notes
- We will need to update nodes to use this event to validate against messages

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines