### PR TITLE
refactor: move isAppEntitled from storage to base class and add banned app check

### DIFF
--- a/packages/contracts/src/spaces/facets/Entitled.sol
+++ b/packages/contracts/src/spaces/facets/Entitled.sol
@@ -14,13 +14,13 @@ import {CustomRevert} from "../../utils/libraries/CustomRevert.sol";
 import {EntitlementsManagerStorage} from "./entitlements/EntitlementsManagerStorage.sol";
 import {MembershipStorage} from "./membership/MembershipStorage.sol";
 import {BanningStorage} from "./banning/BanningStorage.sol";
-import {AppAccountStorage} from "./account/AppAccountStorage.sol";
+import {AppAccountBase} from "./account/AppAccountBase.sol";
 import {DependencyLib} from "./DependencyLib.sol";
 
 // contracts
 import {TokenOwnableBase} from "@towns-protocol/diamond/src/facets/ownable/token/TokenOwnableBase.sol";
 
-abstract contract Entitled is IEntitlementBase, TokenOwnableBase {
+abstract contract Entitled is IEntitlementBase, TokenOwnableBase, AppAccountBase {
     using EnumerableSet for EnumerableSet.AddressSet;
     using EnumerableSet for EnumerableSet.UintSet;
     using CustomRevert for bytes4;
@@ -135,7 +135,7 @@ abstract contract Entitled is IEntitlementBase, TokenOwnableBase {
         address app = DependencyLib.getAppRegistry().getAppByClient(client);
         if (app == address(0)) return false;
 
-        return AppAccountStorage.isAppEntitled(app, client, permission);
+        return _isAppEntitled(app, client, permission);
     }
 
     function _hasAnyBannedWallet(address[] memory wallets) internal view returns (bool) {

--- a/packages/contracts/src/spaces/facets/account/AppAccountStorage.sol
+++ b/packages/contracts/src/spaces/facets/account/AppAccountStorage.sol
@@ -37,27 +37,4 @@ library AppAccountStorage {
         if (appId == EMPTY_UID) return app;
         return DependencyLib.getAppRegistry().getAppById(appId);
     }
-
-    function isAppEntitled(
-        address module,
-        address client,
-        bytes32 permission
-    ) internal view returns (bool) {
-        IAppRegistry.App memory app = getApp(module);
-
-        if (app.appId == EMPTY_UID) return false;
-
-        (bool hasClientAccess, , bool isGroupActive) = ExecutorStorage.hasGroupAccess(
-            app.appId,
-            client
-        );
-        if (!hasClientAccess || !isGroupActive) return false;
-
-        uint256 permissionsLength = app.permissions.length;
-        for (uint256 i; i < permissionsLength; ++i) {
-            if (app.permissions[i] == permission) return true;
-        }
-
-        return false;
-    }
 }

--- a/packages/contracts/test/spaces/account/AppAccount.t.sol
+++ b/packages/contracts/test/spaces/account/AppAccount.t.sol
@@ -249,6 +249,13 @@ contract AppAccountTest is BaseSetup, IOwnableBase, IAppAccountBase, IAppRegistr
         });
     }
 
+    function test_revertWhen_isAppEntitled_bannedApp() external givenAppIsInstalled {
+        vm.prank(deployer);
+        registry.adminBanApp(address(mockModule));
+
+        assertEq(appAccount.isAppEntitled(address(mockModule), client, keccak256("Read")), false);
+    }
+
     function test_disableAndReEnableApp() external givenAppIsInstalled {
         // Disable app
         vm.prank(founder);


### PR DESCRIPTION
### Description

Refactored the app entitlement checking logic by moving the `isAppEntitled` implementation from `AppAccountStorage` library to the `AppAccountBase` contract. This change improves the inheritance structure by making `Entitled` inherit from `AppAccountBase` and using its internal method directly.

### Changes

- Moved `isAppEntitled` implementation from `AppAccountStorage` library to `AppAccountBase` contract
- Updated `Entitled` contract to inherit from `AppAccountBase` and use its `_isAppEntitled` method
- Added check for banned apps in the entitlement verification logic
- Added test case to verify that banned apps are not entitled to permissions

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines