### PR TITLE
Return the right error when adding an event fails and forwarding headers are off

### DIFF
--- a/core/node/rpc/forwarder.go
+++ b/core/node/rpc/forwarder.go
@@ -448,7 +448,7 @@ func (s *Service) addEventImpl(
 	if view != nil {
 		if resp, err := s.localAddEvent(ctx, req, streamId, stream, view); err == nil {
 			return resp, nil
-		} else if IsOperationRetriableOnRemotes(err) {
+		} else if IsOperationRetriableOnRemotes(err) && checkNoForward(req, err) == nil {
 			logging.FromCtx(ctx).Errorw("Failed to add event with local node, falling back to remotes",
 				"error", err, "nodeAddress", s.wallet.Address, "streamId", streamId)
 		} else {


### PR DESCRIPTION
was trying to add an event and was just seeing the check no forward error
this calls the checkNF function twice, but when i did something fancier the compiler couldn’t figure it out and it’s cheap