### PR TITLE
Bots: call getMiniblockHash instead of getStream when sending messages

### DIFF
--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -1256,19 +1256,20 @@ const buildBotActions = (
         tags?: PlainMessage<Tags>
         ephemeral?: boolean
     }) => {
-        const stream = await client.getStream(streamId)
+        const miniblockInfo = await client.getMiniblockInfo(streamId)
         const eventTags = {
             ...unsafe_makeTags(payload),
             participatingUserAddresses: tags?.participatingUserAddresses || [],
             threadId: tags?.threadId || undefined,
         }
-        const encryptionAlgorithm = stream.snapshot.members?.encryptionAlgorithm?.algorithm
+        const encryptionAlgorithm = miniblockInfo.encryptionAlgorithm?.algorithm
+            ? (miniblockInfo.encryptionAlgorithm.algorithm as GroupEncryptionAlgorithmId)
+            : client.defaultGroupEncryptionAlgorithm
 
         const message = await client.crypto.encryptGroupEvent(
             streamId,
             toBinary(ChannelMessageSchema, payload),
-            (encryptionAlgorithm as GroupEncryptionAlgorithmId) ||
-                client.defaultGroupEncryptionAlgorithm,
+            encryptionAlgorithm,
         )
         message.refEventId = getRefEventIdFromChannelMessage(payload)
 

--- a/packages/sdk/src/client-v2.ts
+++ b/packages/sdk/src/client-v2.ts
@@ -29,6 +29,7 @@ import {
     make_UserInboxPayload_GroupEncryptionSessions,
     type ParsedEvent,
     type ParsedStreamResponse,
+    type MiniblockInfoResponse,
 } from './types'
 import {
     makeEvent,
@@ -69,6 +70,8 @@ type Client_Base = {
     disableSignatureValidation: boolean
     /** Get a stream by streamId and unpack it */
     getStream: (streamId: string) => Promise<ParsedStreamResponse>
+    /** Get the miniblock info for a stream */
+    getMiniblockInfo: (streamId: string) => Promise<MiniblockInfoResponse>
     /** Unpack envelope using client config */
     unpackEnvelope: (envelope: Envelope) => Promise<ParsedEvent>
     /** Unpack envelopes using client config */
@@ -156,13 +159,12 @@ export const createTownsClient = async (
     // eslint-disable-next-line prefer-const
     let crypto: GroupEncryptionCrypto
 
-    const getMiniblockInfo = async (
-        streamId: string,
-    ): Promise<{ miniblockNum: bigint; miniblockHash: Uint8Array }> => {
+    const getMiniblockInfo = async (streamId: string): Promise<MiniblockInfoResponse> => {
         const r = await client.rpc.getLastMiniblockHash({ streamId: streamIdAsBytes(streamId) })
         return {
             miniblockNum: r.miniblockNum,
             miniblockHash: r.hash,
+            encryptionAlgorithm: r.encryptionAlgorithm,
         }
     }
 
@@ -341,6 +343,7 @@ export const createTownsClient = async (
         disableHashValidation: !hashValidation,
         disableSignatureValidation: !signatureValidation,
         getStream,
+        getMiniblockInfo,
         sendEvent,
         unpackEnvelope,
         unpackEnvelopes,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -41,6 +41,7 @@ import {
     MembershipReason,
     PayloadCaseType,
     ContentCaseType,
+    MemberPayload_EncryptionAlgorithm,
 } from '@towns-protocol/proto'
 import { keccak256 } from 'ethereum-cryptography/keccak'
 import { bin_toHexString } from '@towns-protocol/utils'
@@ -231,6 +232,12 @@ export interface ParsedStreamResponse {
     streamAndCookie: ParsedStreamAndCookie
     prevSnapshotMiniblockNum: bigint
     eventIds: string[]
+}
+
+export interface MiniblockInfoResponse {
+    miniblockNum: bigint
+    miniblockHash: Uint8Array
+    encryptionAlgorithm: MemberPayload_EncryptionAlgorithm | undefined
 }
 
 export type ClientInitStatus = {


### PR DESCRIPTION
recently added the encryption type to getMininblock messages so that we don’t have to call the very expensive getStream every time.