### PR TITLE
app server: Reduce the wait time in TestAppRegistry_MessageForwardSettings

### DIFF
--- a/core/node/rpc/app_registry_test.go
+++ b/core/node/rpc/app_registry_test.go
@@ -1635,7 +1635,7 @@ func TestAppRegistry_MessageForwardSettings(t *testing.T) {
 					testCiphertexts,
 				)
 			} else {
-				participantClient.requireNoKeySolicitation(channelId, testBotEncryptionDevice(0).DeviceKey, "", 10*time.Second, 100*time.Millisecond)
+				participantClient.requireNoKeySolicitation(channelId, testBotEncryptionDevice(0).DeviceKey, "", 3*time.Second, 100*time.Millisecond)
 			}
 
 			if expectForwarding {


### PR DESCRIPTION
was consistantly seeing failed app registry tests from context cancellation

```
=== Failed
=== FAIL: node/rpc TestAppRegistry_MessageForwardSettings/NO_MESSAGES (11.84s)
    tester_test.go:1178:
        	Error Trace:	/home/runner/_work/towns/towns/core/node/rpc/tester_test.go:1178
        	            				/home/runner/_work/towns/towns/core/node/rpc/tester_test.go:1495
        	            				/opt/hostedtoolcache/go/1.25.1/x64/src/runtime/asm_amd64.s:1693
        	Error:      	Received unexpected error:
        	            	canceled: context canceled
        	Test:       	TestAppRegistry_MessageForwardSettings/NO_MESSAGES
    --- FAIL: TestAppRegistry_MessageForwardSettings/NO_MESSAGES (11.84s)

```