### PR TITLE
fix(bots): check if we have app address before parsing

### DIFF
--- a/packages/sdk/src/id.ts
+++ b/packages/sdk/src/id.ts
@@ -297,10 +297,9 @@ export const parseAppPrivateData = (encoded: string) => {
         appPrivateData = bin_fromBase64(encoded)
     }
     const raw = fromBinary(AppPrivateDataSchema, appPrivateData)
+    const hex_appAddress = bin_toHexString(raw.appAddress)
     return {
         ...raw,
-        appAddress: raw.appAddress
-            ? (getAddress(bin_toHexString(raw.appAddress)) as Address)
-            : undefined,
+        appAddress: hex_appAddress ? (getAddress(hex_appAddress) as Address) : undefined,
     }
 }


### PR DESCRIPTION
ethers `getAddress` throws if undefined.