### PR TITLE
bump CI runners to 32vcpu to test flaky unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
     Common_CI:
         permissions: write-all
         if: github.event_name != 'workflow_dispatch' || !inputs.skip_common_ci
-        runs-on: blacksmith-16vcpu-ubuntu-2404
+        runs-on: blacksmith-32vcpu-ubuntu-2404
         timeout-minutes: 30
         needs: [Build_Anvil_Docker]
 


### PR DESCRIPTION
### Description

Increase github runner specs from `16 vCPU, 64 GB` to `32 vCPU, 128 GB` to test the impact on flaky tests in the Common_CI job
