### PR TITLE
Flatten out how we share sessions (helps bots)

### DIFF
--- a/packages/encryption/src/groupEncryptionCrypto.ts
+++ b/packages/encryption/src/groupEncryptionCrypto.ts
@@ -10,6 +10,7 @@ import {
     DecryptionAlgorithm,
     DecryptionError,
     EncryptionAlgorithm,
+    EnsureOutboundSessionOpts,
     IGroupEncryptionClient,
 } from './base'
 import { GroupDecryption } from './groupDecryption'
@@ -148,7 +149,7 @@ export class GroupEncryptionCrypto {
     public async ensureOutboundSession(
         streamId: string,
         algorithm: GroupEncryptionAlgorithmId,
-        opts?: { awaitInitialShareSession: boolean },
+        opts?: EnsureOutboundSessionOpts,
     ): Promise<void> {
         return this.groupEncryption[algorithm].ensureOutboundSession(streamId, opts)
     }

--- a/packages/sdk/src/clientDecryptionExtensions.ts
+++ b/packages/sdk/src/clientDecryptionExtensions.ts
@@ -286,19 +286,18 @@ export class ClientDecryptionExtensions extends BaseDecryptionExtensions {
         algorithm,
     }: GroupSessionsData): Promise<void> {
         const chunked = chunk(sessions, 100)
-        for (const chunk of chunked) {
-            await this.client.encryptAndShareGroupSessions(
+        for (const sessionIds of chunked) {
+            await this.client.encryptAndShareGroupSessionsToDevice(
                 streamId,
-                chunk,
-                {
-                    [item.fromUserId]: [
-                        {
-                            deviceKey: item.solicitation.deviceKey,
-                            fallbackKey: item.solicitation.fallbackKey,
-                        },
-                    ],
-                },
+                sessionIds,
                 algorithm,
+                item.fromUserId,
+                [
+                    {
+                        deviceKey: item.solicitation.deviceKey,
+                        fallbackKey: item.solicitation.fallbackKey,
+                    },
+                ],
             )
         }
     }

--- a/packages/sdk/src/tests/multi_ne/clientCrypto.test.ts
+++ b/packages/sdk/src/tests/multi_ne/clientCrypto.test.ts
@@ -94,7 +94,6 @@ describe('clientCrypto', () => {
         await bobsClient.cryptoBackend.ensureOutboundSession(
             streamId,
             GroupEncryptionAlgorithmId.HybridGroupEncryption,
-            { awaitInitialShareSession: false },
         )
         hasSession = await bobsClient.cryptoBackend.hasHybridSession(streamId)
         expect(hasSession).toBe(true)

--- a/packages/sdk/src/tests/multi_ne/userInboxMessage.test.ts
+++ b/packages/sdk/src/tests/multi_ne/userInboxMessage.test.ts
@@ -5,7 +5,7 @@
 import { Client } from '../../client'
 import { makeDonePromise, makeTestClient, makeUniqueSpaceStreamId } from '../testUtils'
 import { dlog } from '@towns-protocol/utils'
-import { GroupEncryptionAlgorithmId, UserDeviceCollection } from '@towns-protocol/encryption'
+import { GroupEncryptionAlgorithmId } from '@towns-protocol/encryption'
 import { UserInboxPayload_GroupEncryptionSessions } from '@towns-protocol/proto'
 import { makeUniqueChannelStreamId, streamIdAsString } from '../../id'
 
@@ -59,12 +59,9 @@ describe('inboxMessageTest', () => {
                 },
             )
 
-            const recipients: UserDeviceCollection = {}
-            recipients[alicesClient.userId] = [alicesClient.userDeviceKey()]
-
             // bob sends a message to Alice's device.
             await expect(
-                bobsClient.encryptAndShareGroupSessions(
+                bobsClient.encryptAndShareGroupSessionsToDevice(
                     fakeStreamId,
                     [
                         {
@@ -74,8 +71,9 @@ describe('inboxMessageTest', () => {
                             algorithm,
                         },
                     ],
-                    recipients,
                     algorithm,
+                    alicesClient.userId,
+                    [alicesClient.userDeviceKey()],
                 ),
             ).resolves.not.toThrow()
             await aliceSelfInbox.expectToSucceed()

--- a/packages/sdk/src/tests/unit/decryptionExtensions.test.ts
+++ b/packages/sdk/src/tests/unit/decryptionExtensions.test.ts
@@ -455,16 +455,13 @@ class MockGroupEncryptionClient
         return Promise.resolve({})
     }
 
-    public encryptAndShareGroupSessions(
+    public encryptAndShareGroupSessionsToStream(
         _streamId: string,
         _sessions: GroupEncryptionSession[],
-        _devicesInRoom: UserDeviceCollection,
+        _algorithm: GroupEncryptionAlgorithmId,
+        _priorityUserIds: string[],
     ): Promise<void> {
         return Promise.resolve()
-    }
-
-    public getDevicesInStream(_streamId: string): Promise<UserDeviceCollection> {
-        return Promise.resolve({})
     }
 
     public getMiniblockInfo(

--- a/packages/stress/src/mode/chat/joinChat.ts
+++ b/packages/stress/src/mode/chat/joinChat.ts
@@ -74,7 +74,7 @@ export async function joinChat(client: StressClient, cfg: ChatConfig) {
     if (client.clientIndex === cfg.localClients.startIndex) {
         logger.info('sharing keys')
         await client.streamsClient.ensureOutboundSession(announceChannelId, {
-            awaitInitialShareSession: true,
+            shareShareSessionTimeoutMs: 50000,
         })
         logger.info('check in with root client')
         await client.sendMessage(
@@ -103,7 +103,7 @@ export async function joinChat(client: StressClient, cfg: ChatConfig) {
             await client.streamsClient.waitForStream(channelId)
         }
         await client.streamsClient.ensureOutboundSession(channelId, {
-            awaitInitialShareSession: true,
+            shareShareSessionTimeoutMs: 5000,
         })
         await client.sendMessage(
             channelId,

--- a/packages/stress/src/mode/chat/kickoffChat.ts
+++ b/packages/stress/src/mode/chat/kickoffChat.ts
@@ -26,7 +26,7 @@ export async function kickoffChat(rootClient: StressClient, cfg: ChatConfig) {
     logger.debug('share keys')
     const shareKeysStart = Date.now()
     await rootClient.streamsClient.ensureOutboundSession(announceChannelId, {
-        awaitInitialShareSession: true,
+        shareShareSessionTimeoutMs: 5000,
     })
     const shareKeysDuration = Date.now() - shareKeysStart
 


### PR DESCRIPTION
before: for each user devices, then for each user share sessions
after: for each user, download user devices and share sessions

This helps bots share sessions by ensuring they don’t time out the request before any keys get sent