### PR TITLE
Bot tests - don’t sync the “botClient” it affects other tests

### DIFF
--- a/packages/bot/src/bot.test.ts
+++ b/packages/bot/src/bot.test.ts
@@ -201,7 +201,9 @@ describe('Bot', { sequential: true }, () => {
             cryptoStore,
             new MockEntitlementsDelegate(),
         )
-        await expect(botClient.initializeUser({ appAddress })).resolves.toBeDefined()
+        await expect(
+            botClient.initializeUser({ appAddress, skipSync: true }),
+        ).resolves.toBeDefined()
 
         await bobClient.riverConnection.call((client) => client.joinUser(spaceId, botClient.userId))
         await bobClient.riverConnection.call((client) =>
@@ -219,6 +221,7 @@ describe('Bot', { sequential: true }, () => {
             appAddress,
         )
         expect(appPrivateData).toBeDefined()
+        await botClient.stop()
     }
 
     const shouldRegisterBotInAppRegistry = async () => {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -488,6 +488,7 @@ export class Client
         spaceId?: Uint8Array | string
         encryptionDeviceInit?: EncryptionDeviceInitOpts
         appAddress?: Uint8Array | string
+        skipSync?: boolean
     }): Promise<{
         initCryptoTime: number
         initUserStreamTime: number
@@ -525,7 +526,9 @@ export class Client
         ])
         this.initUserJoinedStreams()
 
-        this.syncedStreamsExtensions.start()
+        if (!opts?.skipSync) {
+            this.syncedStreamsExtensions.start()
+        }
         const initializeUserEndTime = performance.now()
         const executionTime = initializeUserEndTime - initializeUserStartTime
         this.logCall('initializeUser::executionTime', executionTime)
@@ -2213,9 +2216,9 @@ export class Client
         },
     ): Promise<Stream> {
         this.logCall('joinStream', streamId)
-        check(isDefined(this.userStreamId))
+        check(isDefined(this.userStreamId), 'userStreamId not defined')
         const userStream = this.stream(this.userStreamId)
-        check(isDefined(userStream), 'userStream not found')
+        check(isDefined(userStream), 'userStream not defined')
         const streamIdStr = streamIdAsString(streamId)
         const stream = await this.initStream(streamId)
         // check your user stream for membership as that's the final source of truth


### PR DESCRIPTION
initializeUser starts syncing (yeah this is my bad i guess), so if you do this in the test you always have a user client in the background doing key exchange and it throws off the tests. for a sec i thought the bot server was already doing key exchange because alice was getting keys when there was no one but the bot there to send them to her. whoops.