### PR TITLE
chore: add 30 minute timeout to Docker build workflow

### DIFF
--- a/.github/workflows/_build-docker-arch.yml
+++ b/.github/workflows/_build-docker-arch.yml
@@ -68,6 +68,7 @@ jobs:
     build:
         name: Build ${{ inputs.architecture }} image
         runs-on: ${{ inputs.runner }}
+        timeout-minutes: 30
 
         permissions:
             contents: write


### PR DESCRIPTION
## Summary
Add a 30-minute timeout to the build job in the reusable Docker build workflow to prevent indefinite execution of Docker builds.

## Changes
- Added `timeout-minutes: 30` to the `build` job in `.github/workflows/_build-docker-arch.yml`

This ensures that if a Docker build hangs or takes longer than expected, the workflow will automatically cancel after 30 minutes.