### PR TITLE
chore(bots): make `handleChannelMessage` private

### DIFF
--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -655,7 +655,11 @@ export class Bot<
         }
     }
 
-    async handleChannelMessage(streamId: string, parsed: ParsedEvent, { payload }: ChannelMessage) {
+    private async handleChannelMessage(
+        streamId: string,
+        parsed: ParsedEvent,
+        { payload }: ChannelMessage,
+    ) {
         if (!payload.case) {
             return
         }


### PR DESCRIPTION
This function doesnt need to be public