### PR TITLE
fix: include build script in contract hash calculation

### DIFF
--- a/packages/contracts/scripts/build-contract-types.sh
+++ b/packages/contracts/scripts/build-contract-types.sh
@@ -29,9 +29,11 @@ done
 
 # Generate contract hash for this artifact build
 echo "Generating contract hash..."
-CONTRACTS_HASH=$(git rev-parse HEAD:./src 2>/dev/null || echo "")
+SRC_HASH=$(git rev-parse HEAD:./src 2>/dev/null || echo "")
+BUILD_SCRIPT_HASH=$(git rev-parse HEAD:./scripts/build-contract-types.sh 2>/dev/null || echo "")
 
-if [ -n "$CONTRACTS_HASH" ]; then
+if [ -n "$SRC_HASH" ] && [ -n "$BUILD_SCRIPT_HASH" ]; then
+  CONTRACTS_HASH="$SRC_HASH:$BUILD_SCRIPT_HASH"
   echo "$CONTRACTS_HASH" > "$PARENT_DIR/generated/dev/.contracts-hash"
   echo "Contract hash: $CONTRACTS_HASH"
 else

--- a/packages/generated/scripts/prepare.js
+++ b/packages/generated/scripts/prepare.js
@@ -39,14 +39,22 @@ function generatedFilesExist() {
 
 // Get git hash of contracts directory
 function getContractsHash() {
-  if (!existsSync(resolve(contractsDir, 'src'))) return null;
+  if (!existsSync(contractsDir)) return null;
   
   try {
-    return execSync('git rev-parse HEAD:./src', {
+    const srcHash = execSync('git rev-parse HEAD:./src', {
       cwd: contractsDir,
       encoding: 'utf8',
       stdio: 'pipe'
     }).trim();
+    
+    const buildScriptHash = execSync('git rev-parse HEAD:./scripts/build-contract-types.sh', {
+      cwd: contractsDir,
+      encoding: 'utf8',
+      stdio: 'pipe'
+    }).trim();
+    
+    return `${srcHash}:${buildScriptHash}`;
   } catch (error) {
     return null; // Not in git repo or other error
   }


### PR DESCRIPTION
- generated: compute hash from both src and build-contract-types.sh
- contracts: write combined hash to .contracts-hash file
- prevents stale npm artifacts when build script changes (e.g., adding/removing contracts)
