### PR TITLE
fix: resolve Docker build failures with contract artifact generation

### DIFF
--- a/packages/metrics-discovery/Dockerfile
+++ b/packages/metrics-discovery/Dockerfile
@@ -1,9 +1,17 @@
-FROM node:lts-alpine3.20 AS builder
+FROM ubuntu:24.04 AS builder
 
 WORKDIR /river
 
 # Install build dependencies
-RUN apk add --no-cache git curl
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    git curl ca-certificates build-essential && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 20
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Enable Corepack and install Yarn
 RUN corepack enable && \
@@ -16,6 +24,8 @@ COPY .yarn/plugins .yarn/plugins
 COPY packages/tsconfig.base.json ./packages/
 
 # Copy workspace package.json files for dependency resolution
+COPY packages/contracts/package.json ./packages/contracts/
+COPY packages/generated/package.json ./packages/generated/
 COPY packages/utils/package.json ./packages/utils/
 COPY packages/metrics-discovery/package.json ./packages/metrics-discovery/
 COPY packages/prettier-config/package.json ./packages/prettier-config/
@@ -23,14 +33,12 @@ COPY packages/proto/package.json ./packages/proto/
 COPY packages/web3/package.json ./packages/web3/
 COPY protocol/package.json ./protocol/
 
-# Copy packages needed for yarn install (preinstall scripts)
-COPY packages/contracts ./packages/contracts/
-COPY packages/generated ./packages/generated/
-
-# Install dependencies
-RUN yarn install
+# Install dependencies (prepare.js will install Foundry if needed)
+RUN yarn install && yarn cache clean
 
 # Copy remaining source code
+COPY packages/contracts ./packages/contracts/
+COPY packages/generated ./packages/generated/
 COPY packages/utils ./packages/utils/
 COPY packages/metrics-discovery ./packages/metrics-discovery/
 COPY packages/prettier-config ./packages/prettier-config/

--- a/packages/stream-metadata/Dockerfile
+++ b/packages/stream-metadata/Dockerfile
@@ -1,9 +1,17 @@
-FROM node:lts-alpine3.20 AS builder
+FROM ubuntu:24.04 AS builder
 
 WORKDIR /river
 
 # Install dependencies needed for Sharp and other native modules
-RUN apk add --no-cache git curl libc6-compat vips-dev
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    git curl ca-certificates build-essential libvips-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 20
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # monorepo root config
 COPY ./package.json ./package.json
@@ -39,7 +47,9 @@ COPY ./packages/stream-metadata /river/packages/stream-metadata
 # install dependencies and build
 RUN corepack enable && \
     corepack prepare yarn@3.8.0 --activate
-RUN yarn install
+
+# Install dependencies
+RUN yarn install && yarn cache clean
 RUN yarn run turbo build --filter @towns-protocol/stream-metadata
 
 # create runner image with only the necessary files
@@ -57,13 +67,10 @@ RUN yarn init --yes
 # We need to install @towns-protocol/olm here because esbuild
 # isnt smart enough to read the export field in package json
 # and get the node specific import in the bundle step
-RUN yarn add dd-trace@^5.19.0 @towns-protocol/olm@3.2.28 sharp@0.34.3
+RUN yarn add dd-trace@^5.19.0 @towns-protocol/olm@3.2.28 sharp@0.34.3 && yarn cache clean
 
-# Force rebuild sharp to ensure correct Linux binaries
-RUN yarn remove sharp && yarn add sharp@0.34.3
-
-# Clean yarn cache to reduce image size
-RUN yarn cache clean
+# Force rebuild sharp to ensure correct Linux binaries and clean cache
+RUN yarn remove sharp && yarn add sharp@0.34.3 && yarn cache clean
 
 # run the service
 ARG GIT_SHA

--- a/packages/xchain-monitor/Dockerfile
+++ b/packages/xchain-monitor/Dockerfile
@@ -1,6 +1,17 @@
-FROM node:lts-alpine3.20 AS builder
+FROM ubuntu:24.04 AS builder
 
 WORKDIR /river
+
+# Install build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    git curl ca-certificates build-essential && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 20
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # monorepo root config
 COPY ./package.json ./package.json
@@ -30,10 +41,11 @@ COPY ./packages/web3 /river/packages/web3
 COPY ./packages/xchain-monitor /river/packages/xchain-monitor
 
 # install dependencies and build
-RUN apk add --no-cache git curl
 RUN corepack enable && \
     corepack prepare yarn@3.8.0 --activate
-RUN yarn install
+
+# Install dependencies
+RUN yarn install && yarn cache clean
 RUN yarn run turbo build --filter @towns-protocol/xchain-monitor
 
 # create runner image with only the necessary files
@@ -44,7 +56,7 @@ COPY --from=builder /river/packages/xchain-monitor/dist /river/packages/xchain-m
 # install dd-trace again (because the bundler excludes some of the sub-dependencies)
 WORKDIR /river/packages/xchain-monitor
 RUN yarn init --yes
-RUN yarn add dd-trace@^5.19.0
+RUN yarn add dd-trace@^5.19.0 && yarn cache clean
 
 # run the service
 ARG GIT_SHA


### PR DESCRIPTION
### Description

Fixes Docker build failures caused by Foundry installation issues in Alpine Linux containers. The root cause was Alpine's musl libc being incompatible with Foundry's glibc-compiled binaries, preventing `prepare.js` from generating contract artifacts during builds.

This resulted in "generated artifacts mismatch" errors when Docker images were built with stale or missing contract typings.

### Changes

**Dockerfiles (stream-metadata, metrics-discovery, xchain-monitor):**
- Switch builder stage from Alpine to Ubuntu 24.04 (native glibc support for Foundry)
- Add Node.js 20 installation via NodeSource
- Add `yarn cache clean` to all yarn install commands
- Keep Alpine runtime stage for minimal final image size

**prepare.js:**
- Fix Docker detection: when git unavailable but contract source exists, force regeneration
- Fix fallback logic: properly attempt local generation when npm download fails
- Preserves npm package behavior (use existing artifacts when no source available)

**Impact:**
- ✅ Docker builds now successfully generate fresh contract artifacts
- ✅ Artifacts match current contract code (no more hash mismatches)
- ✅ prepare.js works in both local dev (with git) and Docker (without git)

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines
