### PR TITLE
refactor: move contract artifact generation to generated package

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -329,7 +329,7 @@
     {
       "label": "BuildContractTypes",
       "type": "shell",
-      "command": "yarn workspace @towns-protocol/contracts build-types",
+      "command": "yarn workspace @towns-protocol/generated build-types",
       "isBackground": true,
       "problemMatcher": [],
       "presentation": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.385",
   "packageManager": "yarn@3.8.0",
   "scripts": {
-    "build-types": "bash scripts/build-contract-types.sh",
     "clean": "forge clean",
     "compile": "forge build",
     "format": "yarn prettier:write",
@@ -36,14 +35,12 @@
     "@openzeppelin/merkle-tree": "^1.0.8",
     "@prb/test": "^0.6.4",
     "@towns-protocol/prettier-config": "workspace:^",
-    "@typechain/ethers-v5": "^11.1.2",
     "@wagmi/cli": "^2.2.0",
     "forge-std": "github:foundry-rs/forge-std#v1.10.0",
     "prettier": "^3.5.3",
     "prettier-plugin-solidity": "^1.4.2",
     "solhint": "^5.0.5",
-    "solidity-bytes-utils": "^0.8.4",
-    "typechain": "^8.3.2"
+    "solidity-bytes-utils": "^0.8.4"
   },
   "files": [
     "docs/**/*",

--- a/packages/generated/package.json
+++ b/packages/generated/package.json
@@ -5,6 +5,7 @@
     "type": "module",
     "scripts": {
         "build": "node ./scripts/prepare.js",
+        "build-types": "bash scripts/build-contract-types.sh",
         "make-config": "node ./scripts/make-config.js"
     },
     "dependencies": {
@@ -13,7 +14,9 @@
         "ethers": "^5.8.0"
     },
     "devDependencies": {
-        "@towns-protocol/contracts": "workspace:^"
+        "@towns-protocol/contracts": "workspace:^",
+        "@typechain/ethers-v5": "^11.1.2",
+        "typechain": "^8.3.2"
     },
     "files": [
         "config/**/*",

--- a/packages/generated/scripts/build-contract-types.sh
+++ b/packages/generated/scripts/build-contract-types.sh
@@ -1,25 +1,26 @@
- #!/bin/bash
+#!/bin/bash
 set -ueo pipefail
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")"
 cd ..
 
-# Assume contracts and generated are siblings under the same parent directory
-PARENT_DIR="$(dirname "$(pwd)")"
-ABI_DIR="$PARENT_DIR/generated/dev/abis"
-TYPINGS_DIR="$PARENT_DIR/generated/dev/typings"
+# Contracts package is a sibling directory
+CONTRACTS_DIR="../contracts"
+ABI_DIR="./dev/abis"
+TYPINGS_DIR="./dev/typings"
 
-forge build
+# Run forge build in contracts directory (needs foundry.toml)
+(cd "$CONTRACTS_DIR" && forge build)
 
 CONTRACT_INTERFACES="(IDiamond|IDiamondCut|IArchitect|Architect|ILegacyArchitect|MockLegacyArchitect|IProxyManager|IPausable|IEntitlementsManager|EntitlementsManager|IChannel|Channels|IRoles|Roles|IMulticall|IRuleEntitlement|IRuleEntitlementV2|IWalletLink|WalletLink|INodeRegistry|NodeRegistry|IOperatorRegistry|OperatorRegistry|IStreamRegistry|StreamRegistry|OwnableFacet|TokenPausableFacet|UserEntitlement|SpaceOwner|MockERC721A|MembershipFacet|IMembershipMetadata|Member|IBanning|IPricingModules|ICrossChainEntitlement|MockEntitlementGated|PrepayFacet|IERC721AQueryable|IEntitlementDataQueryable|PlatformRequirementsFacet|IERC721A|INodeOperator|ISpaceDelegation|IEntitlementChecker|IERC5267|ICreateSpace|IDropFacet|DropFacet|ITownsPoints|ITipping|IReview|ITreasury|ISwapRouter|ISwapFacet|IAppRegistry|IAppAccount|ISimpleApp|ITownsApp|Towns|RewardsDistributionV2|MainnetDelegation|GuardianFacet|SubscriptionModuleFacet|IAppInstaller|IAppFactory)"
 
 # Clean typings to avoid stale factories/interfaces lingering between runs
 rm -rf "$TYPINGS_DIR"
-yarn typechain --target=ethers-v5 "out/**/?${CONTRACT_INTERFACES}.json" --out-dir "$TYPINGS_DIR"
+yarn typechain --target=ethers-v5 "$CONTRACTS_DIR/out/**/?${CONTRACT_INTERFACES}.json" --out-dir "$TYPINGS_DIR"
 
 # Clean abis to avoid stale abi files lingering between runs
 rm -rf "$ABI_DIR"
 mkdir -p "$ABI_DIR"
-cp -a out/{Diamond,DiamondCutFacet,Architect,MockLegacyArchitect,ProxyManager,IPausable,EntitlementsManager,Channels,Roles,IMulticall,OwnableFacet,WalletLink,MockWalletLink,NodeRegistry,OperatorRegistry,StreamRegistry,TokenPausableFacet,IRuleEntitlement,UserEntitlement,SpaceOwner,MockERC721A,MembershipFacet,IMembershipMetadata,Member,MockRiverRegistry,IBanning,IPricingModules,ICrossChainEntitlement,MockCrossChainEntitlement,MockEntitlementGated,PrepayFacet,IERC721AQueryable,IEntitlementDataQueryable,PlatformRequirementsFacet,IERC721A,INodeOperator,ISpaceDelegation,IEntitlementChecker,IEntitlementGated,IERC5267,ICreateSpace,DropFacet,ITownsPoints,ITipping,IReview,ITreasury,ISwapRouter,ISwapFacet,IAppRegistry,IAppAccount,ISimpleApp,ITownsApp,Towns,RewardsDistributionV2,MainnetDelegation,GuardianFacet,SubscriptionModuleFacet,IAppInstaller,IAppFactory}.sol/*.abi.json "$ABI_DIR"
+cp -a $CONTRACTS_DIR/out/{Diamond,DiamondCutFacet,Architect,MockLegacyArchitect,ProxyManager,IPausable,EntitlementsManager,Channels,Roles,IMulticall,OwnableFacet,WalletLink,MockWalletLink,NodeRegistry,OperatorRegistry,StreamRegistry,TokenPausableFacet,IRuleEntitlement,UserEntitlement,SpaceOwner,MockERC721A,MembershipFacet,IMembershipMetadata,Member,MockRiverRegistry,IBanning,IPricingModules,ICrossChainEntitlement,MockCrossChainEntitlement,MockEntitlementGated,PrepayFacet,IERC721AQueryable,IEntitlementDataQueryable,PlatformRequirementsFacet,IERC721A,INodeOperator,ISpaceDelegation,IEntitlementChecker,IEntitlementGated,IERC5267,ICreateSpace,DropFacet,ITownsPoints,ITipping,IReview,ITreasury,ISwapRouter,ISwapFacet,IAppRegistry,IAppAccount,ISimpleApp,ITownsApp,Towns,RewardsDistributionV2,MainnetDelegation,GuardianFacet,SubscriptionModuleFacet,IAppInstaller,IAppFactory}.sol/*.abi.json "$ABI_DIR"
 
 # Copy the json abis to TS files for type inference
 for file in $ABI_DIR/*.abi.json; do
@@ -29,12 +30,12 @@ done
 
 # Generate contract hash for this artifact build
 echo "Generating contract hash..."
-SRC_HASH=$(git rev-parse HEAD:./src 2>/dev/null || echo "")
+SRC_HASH=$(git rev-parse HEAD:$CONTRACTS_DIR/src 2>/dev/null || echo "")
 BUILD_SCRIPT_HASH=$(git rev-parse HEAD:./scripts/build-contract-types.sh 2>/dev/null || echo "")
 
 if [ -n "$SRC_HASH" ] && [ -n "$BUILD_SCRIPT_HASH" ]; then
   CONTRACTS_HASH="$SRC_HASH:$BUILD_SCRIPT_HASH"
-  echo "$CONTRACTS_HASH" > "$PARENT_DIR/generated/dev/.contracts-hash"
+  echo "$CONTRACTS_HASH" > "./dev/.contracts-hash"
   echo "Contract hash: $CONTRACTS_HASH"
 else
   echo "Warning: Failed to generate contract hash (not in git repo or src not found)"

--- a/packages/generated/scripts/prepare.js
+++ b/packages/generated/scripts/prepare.js
@@ -49,7 +49,7 @@ function getContractsHash() {
     }).trim();
     
     const buildScriptHash = execSync('git rev-parse HEAD:./scripts/build-contract-types.sh', {
-      cwd: contractsDir,
+      cwd: packageRoot,
       encoding: 'utf8',
       stdio: 'pipe'
     }).trim();
@@ -167,7 +167,7 @@ function generateArtifacts() {
     }
   }
   
-  const buildScript = resolve(contractsDir, 'scripts/build-contract-types.sh');
+  const buildScript = resolve(packageRoot, 'scripts/build-contract-types.sh');
 
   if (!existsSync(buildScript)) {
     throw new Error(`Build script not found at ${buildScript}`);
@@ -180,7 +180,7 @@ function generateArtifacts() {
   };
 
   execSync(`bash ${buildScript}`, {
-    cwd: contractsDir,
+    cwd: packageRoot,
     stdio: 'inherit',
     env: envWithFoundry
   });

--- a/scripts/publish-to-npm.sh
+++ b/scripts/publish-to-npm.sh
@@ -45,7 +45,7 @@ fi
 
 # Generate contract types for publishing
 echo "Generating contract types for publishing..."
-yarn workspace @towns-protocol/contracts build-types
+yarn workspace @towns-protocol/generated build-types
 exit_status_contracts=$?
 
 if [ $exit_status_contracts -ne 0 ]; then

--- a/yarn.lock
+++ b/yarn.lock
@@ -10165,7 +10165,6 @@ __metadata:
     "@prb/test": ^0.6.4
     "@towns-protocol/diamond": ^0.6.3
     "@towns-protocol/prettier-config": "workspace:^"
-    "@typechain/ethers-v5": ^11.1.2
     "@uniswap/permit2": "github:towns-protocol/permit2#v1.0.0"
     "@wagmi/cli": ^2.2.0
     account-abstraction: "github:eth-infinitism/account-abstraction#v0.7.0"
@@ -10177,7 +10176,6 @@ __metadata:
     solady: ^0.1.24
     solhint: ^5.0.5
     solidity-bytes-utils: ^0.8.4
-    typechain: ^8.3.2
   languageName: unknown
   linkType: soft
 
@@ -10267,7 +10265,9 @@ __metadata:
     "@ethersproject/abi": ^5.8.0
     "@ethersproject/providers": ^5.8.0
     "@towns-protocol/contracts": "workspace:^"
+    "@typechain/ethers-v5": ^11.1.2
     ethers: ^5.8.0
+    typechain: ^8.3.2
   languageName: unknown
   linkType: soft
 
@@ -12437,7 +12437,7 @@ __metadata:
     source-map-support: ^0.5.19
     table: ^6.8.0
     typescript: ^4.3.5
-  checksum: bdca754160deb9b34a6b668bbcb80477c1c596cdaa90ed4966e0b557f32d26f1d973033a468dca016ad8e5d909c68f15859408208b70602bdee0619c6208bd02
+  checksum: 8be8f2e1f8dbdb9c35edddf1f919f6c09fe764e45ad5733c0d449869e6c9241de6eac9710576d025bb3934f3bb97d017198a7c5f31b88a68aee0dbc898e1de97
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Moves ownership of contract TypeScript artifact generation from the contracts package to the generated package, improving logical separation and encapsulation.

Previously, the contracts package owned both Solidity compilation (via Foundry) and TypeScript artifact generation (via typechain). This PR separates these concerns so that:
- **contracts package**: Owns Solidity source and compilation only
- **generated package**: Owns TypeScript artifact generation and typechain tooling

### Changes

- **Moved build-contract-types.sh** from `packages/contracts/scripts/` to `packages/generated/scripts/`
  - Updated script to run from generated/ directory with relative paths to contracts/
  - Script now uses `(cd "$CONTRACTS_DIR" && forge build)` to compile in contracts directory
  - Updated git hash paths to reference correct locations after move
- **Moved typechain dependencies** from contracts to generated package.json:
  - `@typechain/ethers-v5: ^11.1.2`
  - `typechain: ^8.3.2`
- **Moved build-types script** from contracts to generated package.json
- **Updated prepare.js** to reference new script location and updated working directory
- **Updated external references**:
  - `.vscode/tasks.json`: BuildContractTypes task now calls generated workspace
  - `scripts/publish-to-npm.sh`: Contract type generation now calls generated workspace

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines
