### PR TITLE
fix(bots): filter `getCreate/RegisterAppEvent` by sender

### DIFF
--- a/packages/bot/src/bot.test.ts
+++ b/packages/bot/src/bot.test.ts
@@ -158,7 +158,7 @@ describe('Bot', { sequential: true }, () => {
             31536000n,
         )
         const receipt = await tx.wait()
-        const { app: address } = appRegistryDapp.getCreateAppEvent(receipt)
+        const { app: address } = await appRegistryDapp.getCreateAppEvent(receipt, bob.userId)
         const fundingAppTx = await bob.signer.sendTransaction({
             to: address,
             value: ethers.utils.parseEther('0.5').toBigInt(),

--- a/packages/playground/src/components/dialog/create-bot/index.tsx
+++ b/packages/playground/src/components/dialog/create-bot/index.tsx
@@ -201,6 +201,7 @@ export const CreateBotDialog = ({ open, onOpenChange }: CreateBotDialogProps) =>
             const botWallet = ethers.Wallet.createRandom()
             const appRegistryDapp = new AppRegistryDapp(townsConfig.base.chainConfig, baseProvider)
             let appAddress: Address
+            const signerAddress = (await signer.getAddress()) as Address
             if (botKind === 'simple') {
                 const tx = await appRegistryDapp.createApp(
                     signer,
@@ -214,7 +215,10 @@ export const CreateBotDialog = ({ open, onOpenChange }: CreateBotDialogProps) =>
                 if (!receipt) {
                     throw new Error('Transaction failed')
                 }
-                const { app: foundAppAddress } = appRegistryDapp.getCreateAppEvent(receipt)
+                const { app: foundAppAddress } = await appRegistryDapp.getCreateAppEvent(
+                    receipt,
+                    signerAddress,
+                )
                 appAddress = foundAppAddress as Address
             } else if (botKind === 'contract' && contractAddress) {
                 const tx = await appRegistryDapp.registerApp(
@@ -227,7 +231,10 @@ export const CreateBotDialog = ({ open, onOpenChange }: CreateBotDialogProps) =>
                     throw new Error('Transaction failed')
                 }
 
-                const { app: foundAppAddress } = appRegistryDapp.getRegisterAppEvent(receipt)
+                const { app: foundAppAddress } = await appRegistryDapp.getRegisterAppEvent(
+                    receipt,
+                    signerAddress,
+                )
                 appAddress = foundAppAddress as Address
             } else {
                 throw new Error('Invalid bot kind or contract address')

--- a/packages/sdk/src/tests/multi/botEntitlements.test.ts
+++ b/packages/sdk/src/tests/multi/botEntitlements.test.ts
@@ -41,7 +41,10 @@ describe('bot entitlements tests', () => {
             31536000n,
         )
         const receipt = await tx.wait()
-        const { app: foundAppAddress } = appRegistryDapp.getCreateAppEvent(receipt)
+        const { app: foundAppAddress } = await appRegistryDapp.getCreateAppEvent(
+            receipt,
+            botWallet.address as Address,
+        )
         expect(foundAppAddress).toBeDefined()
 
         // Create bot user streams
@@ -169,7 +172,10 @@ describe('bot entitlements tests', () => {
             31536000n,
         )
         const receipt1 = await tx1.wait()
-        const { app: readOnlyBotAddress } = appRegistryDapp.getCreateAppEvent(receipt1)
+        const { app: readOnlyBotAddress } = await appRegistryDapp.getCreateAppEvent(
+            receipt1,
+            botWithoutWriteWallet.address as Address,
+        )
         expect(readOnlyBotAddress).toBeDefined()
 
         // Create second bot app contract with both READ and WRITE permissions
@@ -182,7 +188,10 @@ describe('bot entitlements tests', () => {
             31536000n,
         )
         const receipt2 = await tx2.wait()
-        const { app: readWriteBotAddress } = appRegistryDapp.getCreateAppEvent(receipt2)
+        const { app: readWriteBotAddress } = await appRegistryDapp.getCreateAppEvent(
+            receipt2,
+            botWithWriteWallet.address as Address,
+        )
         expect(readWriteBotAddress).toBeDefined()
 
         // Create bot user streams for both bots
@@ -309,7 +318,10 @@ describe('bot entitlements tests', () => {
             31536000n,
         )
         const receipt = await tx.wait()
-        const { app: foundAppAddress } = appRegistryDapp.getCreateAppEvent(receipt)
+        const { app: foundAppAddress } = await appRegistryDapp.getCreateAppEvent(
+            receipt,
+            botWallet.address as Address,
+        )
         expect(foundAppAddress).toBeDefined()
 
         // Create bot user streams

--- a/packages/sdk/src/tests/multi/botMembership.test.ts
+++ b/packages/sdk/src/tests/multi/botMembership.test.ts
@@ -49,7 +49,10 @@ describe('bot membership tests', () => {
             31536000n,
         )
         const receipt = await tx.wait()
-        const { app: foundAppAddress } = appRegistryDapp.getCreateAppEvent(receipt)
+        const { app: foundAppAddress } = await appRegistryDapp.getCreateAppEvent(
+            receipt,
+            botWallet.address as Address,
+        )
         expect(foundAppAddress).toBeDefined()
 
         // Create bot user streams
@@ -146,7 +149,10 @@ describe('bot membership tests', () => {
             31536000n,
         )
         const receipt = await tx.wait()
-        const { app: foundAppAddress } = appRegistryDapp.getCreateAppEvent(receipt)
+        const { app: foundAppAddress } = await appRegistryDapp.getCreateAppEvent(
+            receipt,
+            botWallet.address as Address,
+        )
         expect(foundAppAddress).toBeDefined()
 
         // Create bot user streams
@@ -257,7 +263,10 @@ describe('bot membership tests', () => {
             31536000n,
         )
         const receipt = await tx.wait()
-        const { app: foundAppAddress } = appRegistryDapp.getCreateAppEvent(receipt)
+        const { app: foundAppAddress } = await appRegistryDapp.getCreateAppEvent(
+            receipt,
+            botWallet.address as Address,
+        )
         expect(foundAppAddress).toBeDefined()
 
         // Create bot user streams
@@ -323,7 +332,10 @@ describe('bot membership tests', () => {
             31536000n,
         )
         const receipt = await tx.wait()
-        const { app: foundAppAddress } = appRegistryDapp.getCreateAppEvent(receipt)
+        const { app: foundAppAddress } = await appRegistryDapp.getCreateAppEvent(
+            receipt,
+            botWallet.address as Address,
+        )
         expect(foundAppAddress).toBeDefined()
 
         // Create bot user streams
@@ -456,7 +468,10 @@ describe('bot membership tests', () => {
             31536000n,
         )
         const receipt = await tx.wait()
-        const { app: foundAppAddress } = appRegistryDapp.getCreateAppEvent(receipt)
+        const { app: foundAppAddress } = await appRegistryDapp.getCreateAppEvent(
+            receipt,
+            botWallet.address as Address,
+        )
         expect(foundAppAddress).toBeDefined()
 
         // Create bot user streams
@@ -564,7 +579,10 @@ describe('bot membership tests', () => {
             31536000n,
         )
         const receipt = await tx.wait()
-        const { app: foundAppAddress } = appRegistryDapp.getCreateAppEvent(receipt)
+        const { app: foundAppAddress } = await appRegistryDapp.getCreateAppEvent(
+            receipt,
+            botWallet.address as Address,
+        )
         expect(foundAppAddress).toBeDefined()
 
         const everyoneMembership = await everyoneMembershipStruct(carolSpaceDapp, carol)

--- a/packages/sdk/src/tests/multi/botStreamCreation.test.ts
+++ b/packages/sdk/src/tests/multi/botStreamCreation.test.ts
@@ -40,7 +40,10 @@ describe('bot stream creation tests', () => {
             31536000n,
         )
         const receipt1 = await tx1.wait()
-        const { app: bot1AppAddress } = appRegistryDapp.getCreateAppEvent(receipt1)
+        const { app: bot1AppAddress } = await appRegistryDapp.getCreateAppEvent(
+            receipt1,
+            bot1Wallet.address as Address,
+        )
         expect(bot1AppAddress).toBeDefined()
 
         // Create second bot app contract
@@ -53,7 +56,10 @@ describe('bot stream creation tests', () => {
             31536000n,
         )
         const receipt2 = await tx2.wait()
-        const { app: bot2AppAddress } = appRegistryDapp.getCreateAppEvent(receipt2)
+        const { app: bot2AppAddress } = await appRegistryDapp.getCreateAppEvent(
+            receipt2,
+            bot2Wallet.address as Address,
+        )
         expect(bot2AppAddress).toBeDefined()
 
         // Attempt to create user streams for bot1 using bot2's app address (should fail)
@@ -107,7 +113,10 @@ describe('bot stream creation tests', () => {
             31536000n,
         )
         const receipt = await tx.wait()
-        const { app: foundAppAddress } = appRegistryDapp.getCreateAppEvent(receipt)
+        const { app: foundAppAddress } = await appRegistryDapp.getCreateAppEvent(
+            receipt,
+            botWallet.address as Address,
+        )
         expect(foundAppAddress).toBeDefined()
 
         expect(await bot.initializeUser({ appAddress: foundAppAddress })).toBeDefined()

--- a/packages/sdk/src/tests/multi/channelScrubbing.test.ts
+++ b/packages/sdk/src/tests/multi/channelScrubbing.test.ts
@@ -103,7 +103,10 @@ describe('channelScrubbing', () => {
             31536000n,
         )
         const receipt = await tx.wait()
-        const { app: foundAppAddress } = appRegistryDapp.getCreateAppEvent(receipt)
+        const { app: foundAppAddress } = await appRegistryDapp.getCreateAppEvent(
+            receipt,
+            botWallet.address as Address,
+        )
         expect(foundAppAddress).toBeDefined()
 
         // Create bot user streams

--- a/packages/web3/src/app-registry/AppRegistryDapp.ts
+++ b/packages/web3/src/app-registry/AppRegistryDapp.ts
@@ -61,11 +61,19 @@ export class AppRegistryDapp {
         })
     }
 
-    public getCreateAppEvent(receipt: ContractReceipt): AppCreatedEventObject {
+    public async getCreateAppEvent(
+        receipt: ContractReceipt,
+        senderAddress: Address,
+    ): Promise<AppCreatedEventObject> {
         for (const log of receipt.logs) {
             try {
                 const parsedLog = this.factory.interface.parseLog(log)
                 if (parsedLog.name === 'AppCreated') {
+                    const app = await this.getAppById(parsedLog.args.uid as string)
+                    const isOwner = app.owner.toLowerCase() === senderAddress.toLowerCase()
+                    if (!isOwner) {
+                        continue
+                    }
                     return {
                         app: parsedLog.args.app,
                         uid: parsedLog.args.uid,
@@ -78,11 +86,19 @@ export class AppRegistryDapp {
         return { app: '', uid: '' }
     }
 
-    public getRegisterAppEvent(receipt: ContractReceipt): AppRegisteredEventObject {
+    public async getRegisterAppEvent(
+        receipt: ContractReceipt,
+        senderAddress: Address,
+    ): Promise<AppRegisteredEventObject> {
         for (const log of receipt.logs) {
             try {
                 const parsedLog = this.registry.interface.parseLog(log)
                 if (parsedLog.name === 'AppRegistered') {
+                    const app = await this.getAppById(parsedLog.args.uid as string)
+                    const isOwner = app.owner.toLowerCase() === senderAddress.toLowerCase()
+                    if (!isOwner) {
+                        continue
+                    }
                     return {
                         app: parsedLog.args.app,
                         uid: parsedLog.args.uid,


### PR DESCRIPTION
thats a problem in userops since many can appear in a tx

ideally, we would change `AppCreated(sender, app, appId)`, but we can do this hack for now

Should close TOWNS-31726 (requiring clientside change)