### PR TITLE
fix: correct app revocation logic in switchApp function

### DIFF
--- a/packages/contracts/src/spaces/facets/account/AppAccountBase.sol
+++ b/packages/contracts/src/spaces/facets/account/AppAccountBase.sol
@@ -141,11 +141,13 @@ abstract contract AppAccountBase is
         if (currentAppId == EMPTY_UID) AppNotInstalled.selector.revertWith();
         if (currentAppId == appId) AppAlreadyInstalled.selector.revertWith();
 
-        App memory app = _getAppRegistry().getAppById(appId);
+        App memory currentApp = _getAppRegistry().getAppById(currentAppId);
 
         // revoke the current app
-        _revokeGroupAccess(currentAppId, app.client);
+        _revokeGroupAccess(currentAppId, currentApp.client);
         _setGroupStatus(currentAppId, false);
+
+        App memory app = _getAppRegistry().getAppById(appId);
 
         // update the app
         _addApp(app.module, appId);


### PR DESCRIPTION
### Description

Fixed a bug in the app switching logic where the wrong app was being used to revoke group access. The code now correctly retrieves the current app's information before revoking its access.

### Changes

- Fixed the app switching logic in `AppAccountBase.sol` to properly retrieve the current app's information before revoking its access
- Reordered the app retrieval operations to ensure the correct app client is used when revoking group access

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines