### PR TITLE
fix: use vote count instead of node count in XChainCheckLib loops

### DIFF
--- a/packages/contracts/src/base/registry/facets/xchain/XChainCheckLib.sol
+++ b/packages/contracts/src/base/registry/facets/xchain/XChainCheckLib.sol
@@ -57,10 +57,10 @@ library XChainCheckLib {
         uint256 requestId,
         IEntitlementGatedBase.NodeVoteStatus result
     ) internal {
-        uint256 nodeCount = self.nodes[requestId].length();
+        uint256 voteCount = self.votes[requestId].length;
         bool voteRecorded = false;
 
-        for (uint256 i; i < nodeCount; ++i) {
+        for (uint256 i; i < voteCount; ++i) {
             IEntitlementGatedBase.NodeVote storage currentVote = self.votes[requestId][i];
 
             if (currentVote.node == msg.sender) {
@@ -82,9 +82,10 @@ library XChainCheckLib {
         XChainLib.Check storage self,
         uint256 requestId
     ) internal view returns (VoteResults memory results) {
+        uint256 voteCount = self.votes[requestId].length;
         results.totalNodes = self.nodes[requestId].length();
 
-        for (uint256 i; i < results.totalNodes; ++i) {
+        for (uint256 i; i < voteCount; ++i) {
             IEntitlementGatedBase.NodeVote storage vote = self.votes[requestId][i];
 
             if (vote.vote == IEntitlementGatedBase.NodeVoteStatus.PASSED) {


### PR DESCRIPTION
### Description

Fixed a bug in the cross-chain check voting mechanism by using the correct vote count instead of node count when iterating through votes.

### Changes

- Modified `recordVote` function to use `self.votes[requestId].length` instead of `self.nodes[requestId].length()` for iteration
- Updated `getVoteResults` function to iterate through actual votes rather than total nodes
- Added a `voteCount` variable to improve code clarity and consistency

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines