### PR TITLE
refactor: remove repeating AppUpdated event from IAppRegistryBase

### DIFF
--- a/packages/contracts/src/apps/facets/registry/IAppRegistry.sol
+++ b/packages/contracts/src/apps/facets/registry/IAppRegistry.sol
@@ -48,7 +48,6 @@ interface IAppRegistryBase {
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
     event AppRegistered(address indexed app, bytes32 uid);
     event AppUnregistered(address indexed app, bytes32 uid);
-    event AppUpdated(address indexed app, bytes32 uid);
     event AppBanned(address indexed app, bytes32 uid);
     event AppSchemaSet(bytes32 uid);
     event AppInstalled(address indexed app, address indexed account, bytes32 indexed appId);


### PR DESCRIPTION
### Description

Removed the unused `AppUpdated` event from the `IAppRegistryBase` interface.

### Changes

- Removed the `AppUpdated` event declaration from the `IAppRegistryBase` interface
- This event was not being used in the codebase

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines