### PR TITLE
node: pg_stream_store#lockStream now returns struct on success

### DIFF
--- a/core/node/storage/pg_stream_trimmer.go
+++ b/core/node/storage/pg_stream_trimmer.go
@@ -228,10 +228,12 @@ func (t *streamTrimmer) processTrimTaskTx(
 	task trimTask,
 ) error {
 	// Get the last snapshot miniblock number
-	lastSnapshotMiniblock, err := t.store.lockStream(ctx, tx, task.streamId, true)
+	lockStream, err := t.store.lockStream(ctx, tx, task.streamId, true)
 	if err != nil {
 		return err
 	}
+
+	lastSnapshotMiniblock := lockStream.LastSnapshotMiniblock
 
 	ranges, err := t.store.getMiniblockNumberRangesTxNoLock(ctx, tx, task.streamId)
 	if err != nil {


### PR DESCRIPTION
An anticipation on `PostgresStreamStore#lockStream` returning multiple values this PR changes the returned last miniblock snapshot index into a struct that will contain more returned values.