### PR TITLE
refactor(contracts): optimize space creation with calldata and conver…

### DIFF
--- a/packages/contracts/src/factory/facets/architect/IArchitect.sol
+++ b/packages/contracts/src/factory/facets/architect/IArchitect.sol
@@ -2,22 +2,16 @@
 pragma solidity ^0.8.23;
 
 // interfaces
+import {IRuleEntitlement, IRuleEntitlementV2} from "../../../spaces/entitlements/rule/IRuleEntitlement.sol";
+import {IUserEntitlement} from "../../../spaces/entitlements/user/IUserEntitlement.sol";
+import {IMembershipBase} from "../../../spaces/facets/membership/IMembership.sol";
+import {ISpaceOwner} from "../../../spaces/facets/owner/ISpaceOwner.sol";
+import {ISpaceProxyInitializer} from "../../../spaces/facets/proxy/ISpaceProxyInitializer.sol";
 
-// libraries
-
-import {IRuleEntitlement} from "src/spaces/entitlements/rule/IRuleEntitlement.sol";
-import {IRuleEntitlementV2} from "src/spaces/entitlements/rule/IRuleEntitlement.sol";
-import {IUserEntitlement} from "src/spaces/entitlements/user/IUserEntitlement.sol";
-import {IMembershipBase} from "src/spaces/facets/membership/IMembership.sol";
-
-import {ISpaceOwner} from "src/spaces/facets/owner/ISpaceOwner.sol";
-import {ISpaceProxyInitializer} from "src/spaces/facets/proxy/ISpaceProxyInitializer.sol";
-
-// contracts
 interface IArchitectBase {
-    // =============================================================
-    //                           STRUCTS
-    // =============================================================
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           STRUCTS                          */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     struct MembershipRequirementsOld {
         bool everyone;
@@ -46,10 +40,6 @@ interface IArchitectBase {
         Membership membership;
         ChannelInfo channel;
     }
-
-    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
-    /*                           CreateSpace                      */
-    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     struct MembershipRequirements {
         bool everyone;
@@ -85,22 +75,21 @@ interface IArchitectBase {
         ChannelInfo channel;
         Prepay prepay;
     }
-    /**
-     * @notice Options for creating a space
-     * @param to Address that will receive the space NFT (defaults to msg.sender if not specified)
-     */
 
+    /// @notice Options for creating a space
+    /// @param to Address that will receive the space NFT (defaults to msg.sender if not specified)
     struct SpaceOptions {
         address to;
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
-    /*                           Events                           */
+    /*                           EVENTS                           */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
     event SpaceCreated(address indexed owner, uint256 indexed tokenId, address indexed space);
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
-    /*                           Errors                           */
+    /*                           ERRORS                           */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     error Architect__InvalidStringLength();
@@ -116,6 +105,7 @@ interface IArchitect is IArchitectBase {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                           Registry                         */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
     function getSpaceByTokenId(uint256 tokenId) external view returns (address space);
 
     function getTokenIdBySpace(address space) external view returns (uint256);
@@ -144,6 +134,7 @@ interface IArchitect is IArchitectBase {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                           Proxy Initializer                */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
     /// @notice Retrieves the current proxy initializer
     /// @return The address of the current ISpaceProxyInitializer contract
     function getProxyInitializer() external view returns (ISpaceProxyInitializer);

--- a/packages/contracts/src/factory/facets/create/CreateSpace.sol
+++ b/packages/contracts/src/factory/facets/create/CreateSpace.sol
@@ -5,12 +5,12 @@ pragma solidity ^0.8.23;
 import {ICreateSpace} from "./ICreateSpace.sol";
 
 // libraries
-import {CreateSpaceLib} from "./CreateSpaceLib.sol";
 
 // contracts
 import {Facet} from "@towns-protocol/diamond/src/facets/Facet.sol";
 import {PausableBase} from "@towns-protocol/diamond/src/facets/pausable/PausableBase.sol";
 import {ReentrancyGuard} from "solady/utils/ReentrancyGuard.sol";
+import {CreateSpaceBase} from "./CreateSpaceBase.sol";
 
 /// @title CreateSpaceFacet
 /// @notice Facet for creating new spaces with various configurations
@@ -19,7 +19,7 @@ import {ReentrancyGuard} from "solady/utils/ReentrancyGuard.sol";
 /// - PausableBase: Allows pausing of space creation functionality
 /// - ReentrancyGuard: Prevents reentrancy attacks during space creation
 /// - Facet: Base contract for diamond facets
-contract CreateSpaceFacet is ICreateSpace, PausableBase, ReentrancyGuard, Facet {
+contract CreateSpaceFacet is ICreateSpace, PausableBase, ReentrancyGuard, CreateSpaceBase, Facet {
     function __CreateSpace_init() external onlyInitializing {
         _addInterface(type(ICreateSpace).interfaceId);
     }
@@ -30,19 +30,39 @@ contract CreateSpaceFacet is ICreateSpace, PausableBase, ReentrancyGuard, Facet 
     ) external payable nonReentrant whenNotPaused returns (address) {
         SpaceOptions memory spaceOptions = SpaceOptions({to: msg.sender});
         if (action == Action.CreateBasic) {
-            SpaceInfo memory spaceInfo = abi.decode(data, (SpaceInfo));
-            return CreateSpaceLib.createSpace(spaceInfo, spaceOptions);
+            // equivalent: abi.decode(data, (SpaceInfo))
+            SpaceInfo calldata spaceInfo;
+            assembly {
+                // this is a variable length struct, so data.offset contains
+                // the offset from data.offset at which the struct begins
+                spaceInfo := add(data.offset, calldataload(data.offset))
+            }
+            return _createSpace(spaceInfo, spaceOptions);
         } else if (action == Action.CreateWithPrepay) {
-            CreateSpace memory spaceInfo = abi.decode(data, (CreateSpace));
-            return CreateSpaceLib.createSpaceWithPrepay(spaceInfo, spaceOptions);
+            // equivalent: abi.decode(data, (CreateSpace))
+            CreateSpace calldata spaceInfo;
+            assembly {
+                spaceInfo := add(data.offset, calldataload(data.offset))
+            }
+            return _createSpaceWithPrepay(spaceInfo, spaceOptions);
         } else if (action == Action.CreateWithOptions) {
-            CreateSpace memory spaceInfo;
-            (spaceInfo, spaceOptions) = abi.decode(data, (CreateSpace, SpaceOptions));
-            return CreateSpaceLib.createSpaceWithPrepay(spaceInfo, spaceOptions);
+            // equivalent: abi.decode(data, (CreateSpace, SpaceOptions))
+            CreateSpace calldata spaceInfo;
+            SpaceOptions calldata _spaceOptions;
+            assembly {
+                // data.offset contains the offset of spaceInfo
+                // SpaceOptions is fixed length and starts at add(data.offset, 0x20)
+                spaceInfo := add(data.offset, calldataload(data.offset))
+                _spaceOptions := add(data.offset, 0x20)
+            }
+            return _createSpaceWithPrepay(spaceInfo, _spaceOptions);
         } else if (action == Action.CreateLegacy) {
-            CreateSpaceOld memory spaceInfo = abi.decode(data, (CreateSpaceOld));
-            CreateSpace memory newSpaceInfo = _convertLegacySpace(spaceInfo);
-            return CreateSpaceLib.createSpaceWithPrepay(newSpaceInfo, spaceOptions);
+            // equivalent: abi.decode(data, (CreateSpaceOld))
+            CreateSpaceOld calldata spaceInfo;
+            assembly {
+                spaceInfo := add(data.offset, calldataload(data.offset))
+            }
+            return _createSpaceWithPrepayFromLegacy(spaceInfo, spaceOptions);
         } else {
             revert CreateSpaceFacet__InvalidAction();
         }
@@ -50,58 +70,33 @@ contract CreateSpaceFacet is ICreateSpace, PausableBase, ReentrancyGuard, Facet 
 
     /// @inheritdoc ICreateSpace
     function createSpace(
-        SpaceInfo memory spaceInfo
+        SpaceInfo calldata spaceInfo
     ) external nonReentrant whenNotPaused returns (address) {
         SpaceOptions memory spaceOptions = SpaceOptions({to: msg.sender});
-        return CreateSpaceLib.createSpace(spaceInfo, spaceOptions);
+        return _createSpace(spaceInfo, spaceOptions);
     }
 
     /// @inheritdoc ICreateSpace
     function createSpaceV2(
-        CreateSpace memory spaceInfo,
-        SpaceOptions memory options
+        CreateSpace calldata spaceInfo,
+        SpaceOptions calldata options
     ) external payable nonReentrant whenNotPaused returns (address) {
-        return CreateSpaceLib.createSpaceWithPrepay(spaceInfo, options);
+        return _createSpaceWithPrepay(spaceInfo, options);
     }
 
     /// @inheritdoc ICreateSpace
     function createSpaceWithPrepay(
-        CreateSpace memory spaceInfo
+        CreateSpace calldata spaceInfo
     ) external payable nonReentrant whenNotPaused returns (address) {
         SpaceOptions memory spaceOptions = SpaceOptions({to: msg.sender});
-        return CreateSpaceLib.createSpaceWithPrepay(spaceInfo, spaceOptions);
+        return _createSpaceWithPrepay(spaceInfo, spaceOptions);
     }
 
     /// @inheritdoc ICreateSpace
     function createSpaceWithPrepay(
-        CreateSpaceOld memory spaceInfo
+        CreateSpaceOld calldata spaceInfo
     ) external payable nonReentrant whenNotPaused returns (address) {
-        CreateSpace memory newSpaceInfo = _convertLegacySpace(spaceInfo);
         SpaceOptions memory spaceOptions = SpaceOptions({to: msg.sender});
-        return CreateSpaceLib.createSpaceWithPrepay(newSpaceInfo, spaceOptions);
-    }
-
-    /// @dev Converts CreateSpaceOld format to CreateSpace format
-    function _convertLegacySpace(
-        CreateSpaceOld memory spaceInfo
-    ) private pure returns (CreateSpace memory) {
-        MembershipRequirements memory requirements = MembershipRequirements({
-            everyone: spaceInfo.membership.requirements.everyone,
-            users: spaceInfo.membership.requirements.users,
-            ruleData: spaceInfo.membership.requirements.ruleData,
-            syncEntitlements: false
-        });
-        Membership memory membership = Membership({
-            settings: spaceInfo.membership.settings,
-            requirements: requirements,
-            permissions: spaceInfo.membership.permissions
-        });
-        return
-            CreateSpace({
-                metadata: spaceInfo.metadata,
-                membership: membership,
-                channel: spaceInfo.channel,
-                prepay: spaceInfo.prepay
-            });
+        return _createSpaceWithPrepayFromLegacy(spaceInfo, spaceOptions);
     }
 }

--- a/packages/contracts/src/factory/facets/create/ICreateSpace.sol
+++ b/packages/contracts/src/factory/facets/create/ICreateSpace.sol
@@ -37,7 +37,7 @@ interface ICreateSpace is IArchitectBase, ICreateSpaceBase {
     /// @param SpaceInfo Struct containing space metadata, membership settings, and channel
     /// configuration
     /// @return address The address of the newly created space contract
-    function createSpace(SpaceInfo memory SpaceInfo) external returns (address);
+    function createSpace(SpaceInfo calldata SpaceInfo) external returns (address);
 
     /// @notice Creates a new space with prepaid memberships
     /// @param createSpace Struct containing space metadata, membership settings, channel config and
@@ -45,7 +45,7 @@ interface ICreateSpace is IArchitectBase, ICreateSpaceBase {
     /// @return address The address of the newly created space contract
     /// @dev The msg.value must cover the cost of prepaid memberships
     function createSpaceWithPrepay(
-        CreateSpace memory createSpace
+        CreateSpace calldata createSpace
     ) external payable returns (address);
 
     /// @notice Creates a new space with prepaid memberships and custom deployment options
@@ -55,8 +55,8 @@ interface ICreateSpace is IArchitectBase, ICreateSpaceBase {
     /// @return address The address of the newly created space contract
     /// @dev The msg.value must cover the cost of prepaid memberships
     function createSpaceV2(
-        CreateSpace memory createSpace,
-        SpaceOptions memory options
+        CreateSpace calldata createSpace,
+        SpaceOptions calldata options
     ) external payable returns (address);
 
     /// @notice Legacy function for backwards compatibility with older space creation format
@@ -65,6 +65,6 @@ interface ICreateSpace is IArchitectBase, ICreateSpaceBase {
     /// @dev This function converts the old format to the new format internally
     /// @dev The msg.value must cover the cost of prepaid memberships
     function createSpaceWithPrepay(
-        CreateSpaceOld memory spaceInfo
+        CreateSpaceOld calldata spaceInfo
     ) external payable returns (address);
 }

--- a/packages/contracts/src/spaces/entitlements/rule/RuleEntitlement.sol
+++ b/packages/contracts/src/spaces/entitlements/rule/RuleEntitlement.sol
@@ -16,20 +16,18 @@
  */
 pragma solidity ^0.8.0;
 
-// contracts
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
-import {ERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
+// interfaces
+import {IEntitlement} from "../IEntitlement.sol";
+import {IRuleEntitlement} from "./IRuleEntitlement.sol";
 
 // libraries
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-// interfaces
-
-import {IRuleEntitlement} from "./IRuleEntitlement.sol";
-import {IEntitlement} from "src/spaces/entitlements/IEntitlement.sol";
+// contracts
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
+import {ERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 
 contract RuleEntitlement is
     Initializable,
@@ -47,13 +45,6 @@ contract RuleEntitlement is
     string public constant name = "Rule Entitlement";
     string public constant description = "Entitlement for crosschain rules";
     string public constant moduleType = "RuleEntitlement";
-
-    // Separate storage arrays for CheckOperation and LogicalOperation
-    //CheckOperation[] private checkOperations;
-    //LogicalOperation[] private logicalOperations;
-
-    // Dynamic array to store Operation instances
-    //Operation[] private operations;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -107,9 +98,8 @@ contract RuleEntitlement is
         // equivalent: abi.decode(entitlementData, (RuleData))
         RuleData calldata data;
         assembly {
-            // this is a variable length struct, so calldataload(entitlementData.offset) contains
-            // the
-            // offset from entitlementData.offset at which the struct begins
+            // this is a variable length struct, so entitlementData.offset contains
+            // the offset from entitlementData.offset at which the struct begins
             data := add(entitlementData.offset, calldataload(entitlementData.offset))
         }
 

--- a/packages/contracts/src/spaces/entitlements/rule/RuleEntitlementV2.sol
+++ b/packages/contracts/src/spaces/entitlements/rule/RuleEntitlementV2.sol
@@ -16,19 +16,15 @@
  */
 pragma solidity ^0.8.0;
 
+// interfaces
+import {IEntitlement} from "../IEntitlement.sol";
+import {IRuleEntitlementV2} from "./IRuleEntitlement.sol";
+
 // contracts
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
 import {ERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
-
-// libraries
-
-// interfaces
-
-import {IRuleEntitlementV2} from "./IRuleEntitlement.sol";
-import {IEntitlement} from "src/spaces/entitlements/IEntitlement.sol";
 
 contract RuleEntitlementV2 is
     Initializable,
@@ -120,9 +116,8 @@ contract RuleEntitlementV2 is
         // equivalent: abi.decode(entitlementData, (RuleDataV2))
         RuleDataV2 calldata data;
         assembly {
-            // this is a variable length struct, so calldataload(entitlementData.offset) contains
-            // the
-            // offset from entitlementData.offset at which the struct begins
+            // this is a variable length struct, so entitlementData.offset contains
+            // the offset from entitlementData.offset at which the struct begins
             data := add(entitlementData.offset, calldataload(entitlementData.offset))
         }
 

--- a/packages/contracts/src/spaces/facets/owner/ISpaceOwner.sol
+++ b/packages/contracts/src/spaces/facets/owner/ISpaceOwner.sol
@@ -51,11 +51,11 @@ interface ISpaceOwner is ISpaceOwnerBase {
     /// @param longDescription The long description of the space
     /// @return tokenId The token id of the minted space
     function mintSpace(
-        string memory name,
-        string memory uri,
+        string calldata name,
+        string calldata uri,
         address space,
-        string memory shortDescription,
-        string memory longDescription
+        string calldata shortDescription,
+        string calldata longDescription
     ) external returns (uint256 tokenId);
 
     /// @notice Get the space info
@@ -77,9 +77,9 @@ interface ISpaceOwner is ISpaceOwnerBase {
     /// @param longDescription The long description of the space
     function updateSpaceInfo(
         address space,
-        string memory name,
-        string memory uri,
-        string memory shortDescription,
-        string memory longDescription
+        string calldata name,
+        string calldata uri,
+        string calldata shortDescription,
+        string calldata longDescription
     ) external;
 }

--- a/packages/contracts/src/spaces/facets/owner/SpaceOwner.sol
+++ b/packages/contracts/src/spaces/facets/owner/SpaceOwner.sol
@@ -2,22 +2,19 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-
-import {ISpaceOwner} from "./ISpaceOwner.sol";
 import {IERC4906} from "@openzeppelin/contracts/interfaces/IERC4906.sol";
-import {IMembershipMetadata} from "src/spaces/facets/membership/metadata/IMembershipMetadata.sol";
+import {IMembershipMetadata} from "../membership/metadata/IMembershipMetadata.sol";
+import {ISpaceOwner} from "./ISpaceOwner.sol";
 
 // libraries
 
 // contracts
-
-import {SpaceOwnerBase} from "./SpaceOwnerBase.sol";
-
-import {SpaceOwnerUriBase} from "./SpaceOwnerUriBase.sol";
 import {OwnableBase} from "@towns-protocol/diamond/src/facets/ownable/OwnableBase.sol";
-import {Votes} from "src/diamond/facets/governance/votes/Votes.sol";
-import {ERC721A} from "src/diamond/facets/token/ERC721A/ERC721A.sol";
-import {GuardianBase} from "src/spaces/facets/guardian/GuardianBase.sol";
+import {Votes} from "../../../diamond/facets/governance/votes/Votes.sol";
+import {ERC721A} from "../../../diamond/facets/token/ERC721A/ERC721A.sol";
+import {GuardianBase} from "../guardian/GuardianBase.sol";
+import {SpaceOwnerBase} from "./SpaceOwnerBase.sol";
+import {SpaceOwnerUriBase} from "./SpaceOwnerUriBase.sol";
 
 contract SpaceOwner is
     ISpaceOwner,
@@ -57,11 +54,11 @@ contract SpaceOwner is
 
     /// @inheritdoc ISpaceOwner
     function mintSpace(
-        string memory name,
-        string memory uri,
+        string calldata name,
+        string calldata uri,
         address space,
-        string memory shortDescription,
-        string memory longDescription
+        string calldata shortDescription,
+        string calldata longDescription
     ) external onlyFactory returns (uint256 tokenId) {
         tokenId = _nextTokenId();
         _mintSpace(name, uri, tokenId, space, shortDescription, longDescription);
@@ -81,10 +78,10 @@ contract SpaceOwner is
     /// @inheritdoc ISpaceOwner
     function updateSpaceInfo(
         address space,
-        string memory name,
-        string memory uri,
-        string memory shortDescription,
-        string memory longDescription
+        string calldata name,
+        string calldata uri,
+        string calldata shortDescription,
+        string calldata longDescription
     ) external {
         _onlySpaceOwner(space);
         _updateSpace(space, name, uri, shortDescription, longDescription);

--- a/packages/contracts/src/spaces/facets/owner/SpaceOwnerBase.sol
+++ b/packages/contracts/src/spaces/facets/owner/SpaceOwnerBase.sol
@@ -5,8 +5,8 @@ pragma solidity ^0.8.23;
 import {ISpaceOwnerBase} from "./ISpaceOwner.sol";
 
 // libraries
-import {SpaceOwnerStorage} from "./SpaceOwnerStorage.sol";
 import {Validator} from "../../../utils/libraries/Validator.sol";
+import {SpaceOwnerStorage} from "./SpaceOwnerStorage.sol";
 
 // contracts
 
@@ -40,12 +40,12 @@ abstract contract SpaceOwnerBase is ISpaceOwnerBase {
     // =============================================================
 
     function _mintSpace(
-        string memory name,
-        string memory uri,
+        string calldata name,
+        string calldata uri,
         uint256 tokenId,
         address space,
-        string memory shortDescription,
-        string memory longDescription
+        string calldata shortDescription,
+        string calldata longDescription
     ) internal {
         Validator.checkLength(name, 2);
         // if the space uri is empty, it will default to `${defaultUri}/${spaceAddress}`
@@ -69,10 +69,10 @@ abstract contract SpaceOwnerBase is ISpaceOwnerBase {
 
     function _updateSpace(
         address space,
-        string memory name,
-        string memory uri,
-        string memory shortDescription,
-        string memory longDescription
+        string calldata name,
+        string calldata uri,
+        string calldata shortDescription,
+        string calldata longDescription
     ) internal {
         Validator.checkLength(name, 2);
         // if the space uri is empty, it will default to `${defaultUri}/${spaceAddress}`

--- a/packages/contracts/src/spaces/facets/owner/SpaceOwnerStorage.sol
+++ b/packages/contracts/src/spaces/facets/owner/SpaceOwnerStorage.sol
@@ -1,12 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-// interfaces
-
-// libraries
-
-// contracts
-
 library SpaceOwnerStorage {
     // keccak256(abi.encode(uint256(keccak256("spaces.facets.owner.storage")) - 1)) &
     // ~bytes32(uint256(0xff))

--- a/packages/contracts/test/spaces/integration/createSpace/createSpace.t.sol
+++ b/packages/contracts/test/spaces/integration/createSpace/createSpace.t.sol
@@ -22,6 +22,7 @@ import {Permissions} from "src/spaces/facets/Permissions.sol";
 import {Validator} from "src/utils/libraries/Validator.sol";
 
 // contracts
+import {Test} from "forge-std/Test.sol";
 import {BaseSetup} from "test/spaces/BaseSetup.sol";
 import {MockERC721} from "test/mocks/MockERC721.sol";
 
@@ -31,6 +32,7 @@ contract IntegrationCreateSpace is
     IPausableBase,
     IRolesBase,
     IRuleEntitlementBase,
+    Test,
     BaseSetup
 {
     using LibString for string;
@@ -44,11 +46,11 @@ contract IntegrationCreateSpace is
         createSpaceFacet = ICreateSpace(spaceFactory);
     }
 
-    function test_fuzz_createEveryoneSpace(
+    function test_createEveryoneSpace(
         string memory spaceId,
         address founder,
         address user
-    ) external assumeEOA(founder) {
+    ) public assumeEOA(founder) {
         vm.assume(bytes(spaceId).length > 2 && bytes(spaceId).length < 100);
 
         SpaceInfo memory spaceInfo = _createEveryoneSpaceInfo(spaceId);
@@ -61,11 +63,15 @@ contract IntegrationCreateSpace is
         assertTrue(IEntitlementsManager(newSpace).isEntitledToSpace(user, Permissions.JoinSpace));
     }
 
-    function test_fuzz_createUserGatedSpace(
+    function test_createEveryoneSpace_gas() external {
+        test_createEveryoneSpace("TestSpace", makeAddr("founder"), makeAddr("user"));
+    }
+
+    function test_createUserGatedSpace(
         string memory spaceId,
         address founder,
         address user
-    ) external assumeEOA(founder) assumeEOA(user) {
+    ) public assumeEOA(founder) assumeEOA(user) {
         vm.assume(bytes(spaceId).length > 2 && bytes(spaceId).length < 100);
 
         address[] memory users = new address[](1);
@@ -94,11 +100,15 @@ contract IntegrationCreateSpace is
         );
     }
 
-    function test_fuzz_createTokenGatedSpace(
+    function test_createUserGatedSpace_gas() external {
+        test_createUserGatedSpace("UserSpace", makeAddr("founder"), makeAddr("user"));
+    }
+
+    function test_createTokenGatedSpace(
         string memory spaceId,
         address founder,
         address user
-    ) external assumeEOA(founder) assumeEOA(user) {
+    ) public assumeEOA(founder) assumeEOA(user) {
         vm.assume(bytes(spaceId).length > 2 && bytes(spaceId).length < 100);
 
         address mock = address(new MockERC721());
@@ -136,11 +146,15 @@ contract IntegrationCreateSpace is
         MockERC721(mock).mint(user, 1);
     }
 
+    function test_createTokenGatedSpace_gas() external {
+        test_createTokenGatedSpace("TokenSpace", makeAddr("founder"), makeAddr("user"));
+    }
+
     // =============================================================
     //                           Channels
     // =============================================================
 
-    function test_fuzz_createEveryoneSpace_with_separate_channels(
+    function test_createEveryoneSpace_with_separate_channels(
         string memory spaceId,
         address founder,
         address member
@@ -240,11 +254,11 @@ contract IntegrationCreateSpace is
         assertTrue(isEntitledToChannelAfter, "Member should be able to access the channel");
     }
 
-    function test_fuzz_createSpaceWithPrepay(
+    function test_createSpaceWithPrepay(
         string memory spaceId,
         address founder,
         address member
-    ) external assumeEOA(founder) assumeEOA(member) {
+    ) public assumeEOA(founder) assumeEOA(member) {
         vm.assume(bytes(spaceId).length > 2 && bytes(spaceId).length < 100);
         vm.assume(founder != member);
 
@@ -264,6 +278,10 @@ contract IntegrationCreateSpace is
         uint256 prepaidSupply = IPrepay(newSpace).prepaidMembershipSupply();
         assertTrue(prepaidSupply == spaceInfo.prepay.supply, "Prepaid supply should match");
         assertTrue(IEntitlementsManager(newSpace).isEntitledToSpace(member, Permissions.JoinSpace));
+    }
+
+    function test_createSpaceWithPrepay_gas() external {
+        test_createSpaceWithPrepay("PrepaySpace", makeAddr("founder"), makeAddr("member"));
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -289,11 +307,11 @@ contract IntegrationCreateSpace is
         createSpaceFacet.createSpaceV2(spaceInfo, SpaceOptions({to: address(0)}));
     }
 
-    function test_fuzz_createSpaceV2(
+    function test_createSpaceV2(
         string memory spaceId,
         address founder,
         address recipient
-    ) external assumeEOA(founder) assumeEOA(recipient) {
+    ) public assumeEOA(founder) assumeEOA(recipient) {
         vm.assume(bytes(spaceId).length > 2 && bytes(spaceId).length < 100);
         vm.assume(founder != recipient);
 
@@ -310,15 +328,19 @@ contract IntegrationCreateSpace is
         assertTrue(IERC173(newSpace).owner() == recipient);
     }
 
+    function test_createSpaceV2_gas() external {
+        test_createSpaceV2("V2Space", makeAddr("founder"), makeAddr("recipient"));
+    }
+
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                     Unified createSpace                    */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
-    function test_fuzz_createSpace_CreateBasic(
+    function test_createSpace_CreateBasic(
         string memory spaceId,
         address founder,
         address user
-    ) external assumeEOA(founder) {
+    ) public assumeEOA(founder) {
         vm.assume(bytes(spaceId).length > 2 && bytes(spaceId).length < 100);
 
         SpaceInfo memory spaceInfo = _createEveryoneSpaceInfo(spaceId);
@@ -333,11 +355,15 @@ contract IntegrationCreateSpace is
         assertTrue(IEntitlementsManager(newSpace).isEntitledToSpace(user, Permissions.JoinSpace));
     }
 
-    function test_fuzz_createSpace_CreateWithPrepay(
+    function test_createSpace_CreateBasic_gas() external {
+        test_createSpace_CreateBasic("BasicSpace", makeAddr("founder"), makeAddr("user"));
+    }
+
+    function test_createSpace_CreateWithPrepay(
         string memory spaceId,
         address founder,
         address user
-    ) external assumeEOA(founder) assumeEOA(user) {
+    ) public assumeEOA(founder) assumeEOA(user) {
         vm.assume(bytes(spaceId).length > 2 && bytes(spaceId).length < 100);
 
         address[] memory users = new address[](1);
@@ -362,11 +388,15 @@ contract IntegrationCreateSpace is
         assertTrue(IEntitlementsManager(newSpace).isEntitledToSpace(user, Permissions.JoinSpace));
     }
 
-    function test_fuzz_createSpace_CreateWithOptions(
+    function test_createSpace_CreateWithPrepay_gas() external {
+        test_createSpace_CreateWithPrepay("PrepayUnified", makeAddr("founder"), makeAddr("user"));
+    }
+
+    function test_createSpace_CreateWithOptions(
         string memory spaceId,
         address founder,
         address recipient
-    ) external assumeEOA(founder) assumeEOA(recipient) {
+    ) public assumeEOA(founder) assumeEOA(recipient) {
         vm.assume(bytes(spaceId).length > 2 && bytes(spaceId).length < 100);
         vm.assume(founder != recipient);
 
@@ -384,11 +414,19 @@ contract IntegrationCreateSpace is
         assertTrue(IERC173(newSpace).owner() == recipient, "Recipient should own the space");
     }
 
-    function test_fuzz_createSpace_CreateLegacy(
+    function test_createSpace_CreateWithOptions_gas() external {
+        test_createSpace_CreateWithOptions(
+            "OptionsSpace",
+            makeAddr("founder"),
+            makeAddr("recipient")
+        );
+    }
+
+    function test_createSpace_CreateLegacy(
         string memory spaceId,
         address founder,
         address user
-    ) external assumeEOA(founder) {
+    ) public assumeEOA(founder) {
         vm.assume(bytes(spaceId).length > 2 && bytes(spaceId).length < 100);
 
         // Use SpaceHelper to create legacy format space info
@@ -405,6 +443,10 @@ contract IntegrationCreateSpace is
 
         // Verify space creation and legacy conversion
         assertTrue(IEntitlementsManager(newSpace).isEntitledToSpace(user, Permissions.JoinSpace));
+    }
+
+    function test_createSpace_CreateLegacy_gas() external {
+        test_createSpace_CreateLegacy("LegacySpace", makeAddr("founder"), makeAddr("user"));
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/


### PR DESCRIPTION
…t to abstract contract

- Change external parameters to calldata for gas optimization (ICreateSpace, ISpaceOwner)
- Convert CreateSpaceLib to CreateSpaceBase abstract contract for inheritance
- Move legacy conversion logic to base contract
- Convert IArchitect imports to relative paths
- Add 9 gas measurement tests with fixed parameters for benchmarking

🤖 Generated with [Claude Code](https://claude.com/claude-code)
