### PR TITLE
stop filtering out your own device when encrypting data

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -3225,10 +3225,7 @@ export class Client
         check(isDefined(this.cryptoBackend), 'crypto backend not initialized')
 
         // Don't encrypt to our own device
-        return this.cryptoBackend.encryptWithDeviceKeys(
-            payloadClearText,
-            deviceKeys.filter((key) => key.deviceKey !== this.userDeviceKey().deviceKey),
-        )
+        return this.cryptoBackend.encryptWithDeviceKeys(payloadClearText, deviceKeys)
     }
 
     // Used during testing


### PR DESCRIPTION
we actually want bots to encrypt any new keys they create to themselves so that they can download them later if needed