### PR TITLE
fix(bots): use reply tag in `sendInteractionResponse`

### DIFF
--- a/packages/bot/src/bot.test.ts
+++ b/packages/bot/src/bot.test.ts
@@ -1519,7 +1519,7 @@ describe('Bot', { sequential: true }, () => {
     })
 
     it('user should be able to send form interaction response', async () => {
-        await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_ALL_MESSAGES)
+        await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_MENTIONS_REPLIES_REACTIONS)
         const recipient = bin_fromHexString(botClientAddress)
         const interactionResponsePayload: PlainMessage<InteractionResponsePayload> = {
             salt: genIdBlob(),

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -2164,7 +2164,13 @@ export class Client
             make_ChannelPayload_InteractionResponse(response),
             {
                 method: 'sendInteractionResponse',
-                tags: opts?.tags,
+                tags: {
+                    groupMentionTypes: opts?.tags?.groupMentionTypes ?? [],
+                    mentionedUserAddresses: opts?.tags?.mentionedUserAddresses ?? [],
+                    participatingUserAddresses: opts?.tags?.participatingUserAddresses ?? [],
+                    messageInteractionType:
+                        opts?.tags?.messageInteractionType ?? MessageInteractionType.REPLY,
+                },
                 ephemeral: opts?.ephemeral,
             },
         )


### PR DESCRIPTION
So bots with message behavior `mentions commands replies reactions` can receive interaction response.