### PR TITLE
feat(bots): sending link attachment

### DIFF
--- a/packages/bot/AGENTS.md
+++ b/packages/bot/AGENTS.md
@@ -384,7 +384,7 @@ bot.onSlashCommand("ai", async (handler, { channelId, args }) => {
 
 ### Sending Attachments
 
-The bot supports two types of attachments:
+The bot supports three types of attachments:
 
 #### Image Attachments from URLs
 
@@ -414,6 +414,55 @@ bot.onSlashCommand("show", async (handler, { channelId, args }) => {
 - Invalid/non-image URLs are skipped gracefully (message still sends)
 - Non-image Content-Types trigger console warning and are skipped
 - Image dimensions are auto-detected for URL-based images
+- All attachments are end-to-end encrypted automatically
+
+#### Link Attachments (URL Unfurling)
+
+Use `type: 'link'` to send link attachments. Up for clients to unfurl the link.
+
+**This is the recommended way to share miniapps, frames, and any web content.**
+
+```typescript
+bot.onSlashCommand("share", async (handler, { channelId, args }) => {
+  const url = args[0]
+
+  await handler.sendMessage(channelId, "Check this out!", {
+    attachments: [
+      {
+        type: 'link',
+        url: url
+      }
+    ]
+  })
+})
+```
+
+**Multiple Link Attachments Example:**
+```typescript
+// Share multiple links in one message
+await handler.sendMessage(channelId, "Here are some useful resources:", {
+  attachments: [
+    {
+      type: 'link',
+      url: 'https://example.com/miniapp'
+    },
+    {
+      type: 'link',
+      url: 'https://docs.towns.com'
+    },
+    {
+      type: 'link',
+      url: 'https://github.com/townsprotocol'
+    }
+  ]
+})
+```
+
+**Important Notes:**
+- If the URL doesn't have Open Graph metadata, title/description will be extracted from standard HTML meta tags
+- Invalid URLs or fetch failures are handled gracefully (attachment is skipped, message still sends)
+- This is the preferred method for sharing miniapps and frames
+- You can send multiple link attachments in a single message
 - All attachments are end-to-end encrypted automatically
 
 #### Chunked Media Attachments (Binary Data)
@@ -501,9 +550,13 @@ bot.onSlashCommand("screenshot", async (handler, { channelId }) => {
 
 **Mixed Attachments Example:**
 ```typescript
-// Combine URL images with chunked media
+// Combine links, images, and chunked media
 await handler.sendMessage(channelId, "Product comparison:", {
   attachments: [
+    {
+      type: 'link',
+      url: 'https://example.com/product-page'
+    },
     {
       type: 'image',
       url: 'https://example.com/product-a.jpg',

--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -71,6 +71,7 @@ import {
     InteractionRequest,
     InteractionResponsePayload,
     InteractionResponsePayloadSchema,
+    ChannelMessage_Post_AttachmentSchema,
 } from '@towns-protocol/proto'
 import {
     bin_equal,
@@ -149,6 +150,11 @@ type ChunkedMediaAttachment =
           mimetype: string
       }
 
+type LinkAttachment = {
+    type: 'link'
+    url: string
+}
+
 export type MessageOpts = {
     threadId?: string
     replyId?: string
@@ -157,7 +163,7 @@ export type MessageOpts = {
 
 export type PostMessageOpts = MessageOpts & {
     mentions?: PlainMessage<ChannelMessage_Post_Mention>[]
-    attachments?: Array<ImageAttachment | ChunkedMediaAttachment>
+    attachments?: Array<ImageAttachment | ChunkedMediaAttachment | LinkAttachment>
 }
 
 export type DecryptedInteractionResponse = {
@@ -1412,6 +1418,16 @@ const buildBotActions = (
         }
     }
 
+    const createLinkAttachment = (
+        attachment: LinkAttachment,
+    ): PlainMessage<ChannelMessage_Post_Attachment> => {
+        return create(ChannelMessage_Post_AttachmentSchema, {
+            content: {
+                case: 'unfurledUrl',
+                value: { url: attachment.url },
+            },
+        })
+    }
     const ensureOutboundSession = async (
         streamId: string,
         encryptionAlgorithm: GroupEncryptionAlgorithmId,
@@ -1555,6 +1571,11 @@ const buildBotActions = (
                         processedAttachments.push(result)
                         break
                     }
+                    case 'link': {
+                        const result = createLinkAttachment(attachment)
+                        processedAttachments.push(result)
+                        break
+                    }
                     default:
                         logNever(attachment)
                 }
@@ -1601,6 +1622,11 @@ const buildBotActions = (
                     }
                     case 'chunked': {
                         const result = await createChunkedMediaAttachment(attachment)
+                        processedAttachments.push(result)
+                        break
+                    }
+                    case 'link': {
+                        const result = createLinkAttachment(attachment)
                         processedAttachments.push(result)
                         break
                     }

--- a/packages/docs/build/bots/events.mdx
+++ b/packages/docs/build/bots/events.mdx
@@ -168,7 +168,7 @@ Returns the `eventId` of the sent message.
 
 #### Sending attachments
 
-The bot framework supports two types of attachments with automatic validation and encryption.
+The bot framework supports three types of attachments with automatic validation and encryption.
 
 ##### Image Attachments from URLs
 
@@ -186,11 +186,36 @@ await bot.sendMessage(channelId, message, {
 })
 ```
 
+##### Link Attachments 
+
+Send link attachments. This is the recommended way to share miniapps, frames, and any web content.
+
+```ts
+await bot.sendMessage(channelId, "Check this out!", {
+  attachments: [{
+    type: 'link',
+    url: 'https://example.com/miniapp'
+  }]
+})
+```
+
+You can send multiple link attachments in a single message:
+
+```ts
+await bot.sendMessage(channelId, "Useful resources:", {
+  attachments: [
+    { type: 'link', url: 'https://example.com/miniapp' },
+    { type: 'link', url: 'https://docs.towns.com' },
+    { type: 'link', url: 'https://github.com/townsprotocol' }
+  ]
+})
+```
+
 Returns the `eventId` of the sent message.
 
 ##### Chunked Media Attachments
 
-Send binary data with a filename and MIME type. 
+Send binary data with a filename and MIME type.
 This allow you to send large files, videos, screenshots or even create images on the fly.
 
 ```ts


### PR DESCRIPTION
```ts
bot.sendMessage(channelId, "hey check this out", {
    attachments: [{
        type: "link", url: "https://myminiapp.com" 
   }]
})
```