### PR TITLE
feat(bots): createChannel & getRoles

### DIFF
--- a/packages/bot/src/bot.test.ts
+++ b/packages/bot/src/bot.test.ts
@@ -55,6 +55,7 @@ import { Hono } from 'hono'
 import { randomUUID } from 'crypto'
 import { getBalance, readContract, waitForTransactionReceipt } from 'viem/actions'
 import townsAppAbi from '@towns-protocol/generated/dev/abis/ITownsApp.abi'
+import channelsFacetAbi from '@towns-protocol/generated/dev/abis/Channels.abi'
 import { parseEther } from 'viem'
 import { execute } from 'viem/experimental/erc7821'
 
@@ -1408,6 +1409,82 @@ describe('Bot', { sequential: true }, () => {
             { timeoutMS: 20000 },
         )
     })
+
+    it.for(['app', 'bot'] as const)(
+        'bob creates role, bot creates channel (wallet: %s), channel has the role, bob joins and sends message, bot receives message',
+        async (wallet) => {
+            await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_ALL_MESSAGES)
+
+            const receivedMessages: OnMessageType[] = []
+            bot.onMessage((_h, e) => {
+                receivedMessages.push(e)
+            })
+
+            const spaceDapp = bobClient.riverConnection.spaceDapp
+            const testNft1Address = await TestERC721.getContractAddress('TestNFT1')
+            const ruleData = getNftRuleData(testNft1Address)
+            const permissions = [Permission.Read, Permission.Write]
+            const roleName = `TestRole for bot channel ${wallet} wallet`
+
+            // Bob creates a role with Read permission
+            const txn = await spaceDapp.createRole(
+                spaceId,
+                roleName,
+                permissions,
+                [],
+                ruleData,
+                bob.signer,
+            )
+
+            const { roleId, error: roleError } = await waitForRoleCreated(spaceDapp, spaceId, txn)
+            expect(roleError).toBeUndefined()
+            check(isDefined(roleId), 'roleId is defined')
+            log('bob created role', roleId)
+
+            // Bot creates a new channel
+            const newChannelId = await bot.createChannel(spaceId, {
+                name: `test-channel-with-role-${wallet}`,
+                description: `Channel with role created by bot with ${wallet} wallet`,
+                wallet,
+            })
+
+            log(`bot created channel with ${wallet} wallet`, newChannelId)
+
+            // Query the roles assigned to the channel
+            const channelRoles = await readContract(bot.viem, {
+                address: SpaceAddressFromSpaceId(spaceId),
+                abi: channelsFacetAbi,
+                functionName: 'getRolesByChannel',
+                args: [`0x${newChannelId}`],
+            })
+
+            log('channel roles', channelRoles)
+
+            // Verify the created role is included in the channel's roles
+            expect(channelRoles).toContain(roleId)
+
+            // Bob joins the new channel
+            await bobClient.riverConnection.call((client) => client.joinStream(newChannelId))
+
+            // Bob gets the channel
+            const bobNewChannel = bobClient.spaces.getSpace(spaceId).getChannel(newChannelId)
+            await waitFor(() => bobNewChannel.value.status !== 'loading', { timeoutMS: 10000 })
+
+            // Bob sends a message in the new channel
+            const testMessage = `Hello bot in new channel with ${wallet} wallet!`
+            const { eventId } = await bobNewChannel.sendMessage(testMessage)
+            log('bob sent message in new channel', eventId)
+
+            // Wait for bot to receive the message
+            await waitFor(() => receivedMessages.length > 0, { timeoutMS: 15000 })
+
+            const receivedEvent = receivedMessages.find((x) => x.eventId === eventId)
+            expect(receivedEvent).toBeDefined()
+            expect(receivedEvent?.message).toBe(testMessage)
+            expect(receivedEvent?.channelId).toBe(newChannelId)
+            expect(receivedEvent?.userId).toBe(bobClient.userId)
+        },
+    )
 
     it('bot should be able to send interaction request and user should send encrypted response', async () => {
         await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_ALL_MESSAGES)

--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -28,7 +28,6 @@ import {
     unsafe_makeTags,
     townsEnv,
     spaceIdFromChannelId,
-    type CreateTownsClientParams,
     make_ChannelPayload_Redaction,
     parseAppPrivateData,
     makeEvent,
@@ -42,6 +41,10 @@ import {
     unpackEnvelope,
     make_UserPayload_BlockchainTransaction,
     makeUserStreamId,
+    makeUniqueChannelStreamId,
+    make_ChannelPayload_Inception,
+    make_MemberPayload_Membership2,
+    type CreateTownsClientParams,
 } from '@towns-protocol/sdk'
 import { type Context, type Env, type Next } from 'hono'
 import { createMiddleware } from 'hono/factory'
@@ -98,7 +101,7 @@ import {
     zeroAddress,
     parseEventLogs,
 } from 'viem'
-import { readContract, waitForTransactionReceipt } from 'viem/actions'
+import { readContract, waitForTransactionReceipt, writeContract } from 'viem/actions'
 import { base, baseSepolia, foundry } from 'viem/chains'
 import type { BlankEnv } from 'hono/types'
 import packageJson from '../package.json' with { type: 'json' }
@@ -106,6 +109,8 @@ import { privateKeyToAccount } from 'viem/accounts'
 import appRegistryAbi from '@towns-protocol/generated/dev/abis/IAppRegistry.abi'
 import { execute } from 'viem/experimental/erc7821'
 import { getSmartAccountFromUserIdImpl } from './getSmartAccountFromUserId'
+import channelsFacetAbi from '@towns-protocol/generated/dev/abis/Channels.abi'
+import rolesFacetAbi from '@towns-protocol/generated/dev/abis/Roles.abi'
 
 type BotActions = ReturnType<typeof buildBotActions>
 
@@ -176,6 +181,14 @@ export type PostMessageOpts = MessageOpts & {
 export type DecryptedInteractionResponse = {
     recipient: Uint8Array
     payload: PlainMessage<InteractionResponsePayload>
+}
+
+export type CreateChannelParams = {
+    name: string
+    description?: string
+    wallet?: 'bot' | 'app'
+    autojoin?: boolean
+    hideUserJoinLeaveEvents?: boolean
 }
 
 export type BotEvents<Commands extends PlainMessage<SlashCommand>[] = []> = {
@@ -1069,6 +1082,26 @@ export class Bot<
         const result = await this.client.sendTip(params, this.currentMessageTags)
         this.currentMessageTags = undefined
         return result
+    }
+
+    /**
+     * Create a channel in a space
+     * All users with Permission.Read will be able to join the channel.
+     * @param spaceId - The space ID to create the channel in
+     * @param params - The parameters for the channel creation
+     * @returns The channel ID
+     */
+    async createChannel(spaceId: string, params: CreateChannelParams) {
+        return this.client.createChannel(spaceId, params)
+    }
+
+    /**
+     * Get the roles for a space
+     * @param spaceId - The space ID to get the roles for
+     * @returns The roles
+     */
+    async getRoles(spaceId: string) {
+        return this.client.getRoles(spaceId)
     }
 
     /**
@@ -2034,6 +2067,85 @@ const buildBotActions = (
         )
     }
 
+    const getRoles = async (spaceId: string) => {
+        const roles = await readContract(viem, {
+            address: SpaceAddressFromSpaceId(spaceId),
+            abi: rolesFacetAbi,
+            functionName: 'getRoles',
+        })
+        return roles.filter((role) => role.name !== 'Owner')
+    }
+
+    const createChannelTx = async (
+        spaceId: string,
+        channelId: string,
+        params: CreateChannelParams,
+    ) => {
+        const roles = await getRoles(spaceId)
+        const allRolesThatCanRead = roles.filter((role) =>
+            role.permissions.includes(Permission.Read),
+        )
+        const args = [
+            `0x${channelId}`,
+            JSON.stringify({ name: params.name, description: params.description ?? '' }),
+            allRolesThatCanRead.map((role) => role.id),
+        ] as const
+
+        if (params.wallet === 'bot') {
+            return writeContract(viem, {
+                address: SpaceAddressFromSpaceId(spaceId),
+                abi: channelsFacetAbi,
+                functionName: 'createChannel',
+                args,
+            })
+        } else {
+            return execute(viem, {
+                address: appAddress,
+                calls: [
+                    {
+                        to: SpaceAddressFromSpaceId(spaceId),
+                        abi: channelsFacetAbi,
+                        functionName: 'createChannel',
+                        args,
+                    },
+                ],
+            })
+        }
+    }
+
+    const createChannel = async (spaceId: string, params: CreateChannelParams) => {
+        const channelId = makeUniqueChannelStreamId(spaceId)
+        const hash = await createChannelTx(spaceId, channelId, params)
+        await waitForTransactionReceipt(viem, { hash })
+        const events = await Promise.all([
+            makeEvent(
+                client.signerContext,
+                make_ChannelPayload_Inception({
+                    streamId: streamIdAsBytes(channelId),
+                    spaceId: streamIdAsBytes(spaceId),
+                    settings: undefined,
+                    channelSettings: {
+                        autojoin: params.autojoin ?? false,
+                        hideUserJoinLeaveEvents: params.hideUserJoinLeaveEvents ?? false,
+                    },
+                }),
+            ),
+            makeEvent(
+                client.signerContext,
+                make_MemberPayload_Membership2({
+                    userId: client.userId,
+                    op: MembershipOp.SO_JOIN,
+                    initiatorId: client.userId,
+                }),
+            ),
+        ])
+        await client.rpc.createStream({
+            streamId: streamIdAsBytes(channelId),
+            events: events,
+        })
+        return channelId
+    }
+
     return {
         sendMessage,
         editMessage,
@@ -2052,6 +2164,8 @@ const buildBotActions = (
         getChannelSettings,
         sendTip,
         sendBlockchainTransaction,
+        createChannel,
+        getRoles,
     }
 }
 


### PR DESCRIPTION
This PR adds support for bots calling `createChannel`
```ts
bot.createChannel(spaceId, { name: 'fun-stuff', autojoin: true })
```