### PR TITLE
Forward interaction responses to bots when setting is Reply only

### DIFF
--- a/packages/bot/src/bot.test.ts
+++ b/packages/bot/src/bot.test.ts
@@ -1410,7 +1410,7 @@ describe('Bot', { sequential: true }, () => {
     })
 
     it('bot should be able to send encrypted interaction request and user should send encrypted response', async () => {
-        await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_ALL_MESSAGES)
+        await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_MENTIONS_REPLIES_REACTIONS)
         const requestId = randomUUID()
         const interactionRequestContent: PlainMessage<InteractionRequestPayload['content']> = {
             case: 'signature',
@@ -1537,7 +1537,7 @@ describe('Bot', { sequential: true }, () => {
     })
 
     it('user should be able to send form interaction response', async () => {
-        await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_ALL_MESSAGES)
+        await setForwardSetting(ForwardSettingValue.FORWARD_SETTING_MENTIONS_REPLIES_REACTIONS)
         const recipient = bin_fromHexString(botClientAddress)
         const interactionResponsePayload: PlainMessage<InteractionResponsePayload> = {
             salt: genIdBlob(),

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -2159,7 +2159,7 @@ export class Client
             encryptionAlgorithm as GroupEncryptionAlgorithmId,
         )
 
-        // Create the request matching InteractionResponse structure
+        // Create the request matching InteractionResquest structure
         const request: PlainMessage<InteractionRequest> = {
             recipient: recipient,
             encryptedData: encryptedData,
@@ -2206,12 +2206,24 @@ export class Client
                 deviceKey: toUserDevice.deviceKey,
             } satisfies PlainMessage<EncryptedData>,
         }
+        const tags = {
+            groupMentionTypes: [],
+            mentionedUserAddresses: [],
+            ...(opts?.tags ?? {}),
+            messageInteractionType:
+                opts?.tags?.messageInteractionType ?? MessageInteractionType.REPLY,
+            participatingUserAddresses: [
+                ...(opts?.tags?.participatingUserAddresses ?? []),
+                recipient,
+            ],
+        } satisfies PlainMessage<Tags>
+
         return this.makeEventAndAddToStream(
             streamId,
             make_ChannelPayload_InteractionResponse(response),
             {
                 method: 'sendInteractionResponse',
-                tags: opts?.tags,
+                tags,
                 ephemeral: opts?.ephemeral,
             },
         )


### PR DESCRIPTION
fixes TOWNS-31894
I spent kinda a lot of time trying to extend the go test for this, but it never worked and I couldn’t figure out why. I tried overloading the sendMessage helper so that i could send an interaction response, which caused me to need to update a bunch of other things, and then the message just never got to the event processer. idk.

Test plan:
updated existing typescript tests to use the more restrictive forward type, they failed, fixed the tags, they succeeded.