### PR TITLE
feat(WalletLink): unset default wallet on removal of linked wallet

### DIFF
--- a/packages/contracts/src/factory/facets/wallet-link/WalletLinkBase.sol
+++ b/packages/contracts/src/factory/facets/wallet-link/WalletLinkBase.sol
@@ -209,9 +209,10 @@ abstract contract WalletLinkBase is IWalletLinkBase, EIP712Base, Nonces {
             revert WalletLink__NotLinked(walletToRemove, rootWallet.addr);
         }
 
-        // Check that the wallet is not the default wallet
+        // If the wallet is the default wallet, unset it before removal
         if (ds.rootWalletByRootKey[rootWallet.addr].defaultWallet == walletToRemove) {
-            revert WalletLink__CannotRemoveDefaultWallet();
+            ds.rootWalletByRootKey[rootWallet.addr].defaultWallet = address(0);
+            emit SetDefaultWallet(rootWallet.addr, address(0));
         }
 
         // Verify that the root wallet signature contains the correct nonce and the correct wallet
@@ -246,9 +247,10 @@ abstract contract WalletLinkBase is IWalletLinkBase, EIP712Base, Nonces {
             revert WalletLink__NotLinked(walletToRemove, rootWallet);
         }
 
-        // check that the default wallet is not the wallet to remove
+        // If the wallet is the default wallet, unset it before removal
         if (ds.rootWalletByRootKey[rootWallet].defaultWallet == walletToRemove) {
-            revert WalletLink__CannotRemoveDefaultWallet();
+            ds.rootWalletByRootKey[rootWallet].defaultWallet = address(0);
+            emit SetDefaultWallet(rootWallet, address(0));
         }
 
         // Remove the link in the walletToRemove to root keys map


### PR DESCRIPTION
### Description

This PR modifies the wallet link removal behavior to automatically unset the default wallet when it's being removed, rather than preventing the removal. This improves user experience by allowing wallet removal operations to proceed without requiring a separate step to unset the default wallet first.

### Changes

- Modified `WalletLinkBase.sol` to automatically unset the default wallet when it's being removed instead of reverting with `WalletLink__CannotRemoveDefaultWallet`
- Added an event emission for `SetDefaultWallet` when the default wallet is automatically unset
- Added test cases to verify the new behavior for both `removeLink` and `removeCallerLink` functions

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines