### PR TITLE
Add Cleanup Routine in Persistence Store when stores 95% full

### DIFF
--- a/packages/sdk/src/persistenceStore.ts
+++ b/packages/sdk/src/persistenceStore.ts
@@ -479,17 +479,15 @@ export class PersistenceStore extends Dexie implements IPersistenceStore {
                     log.info(
                         `Using ${usage.toFixed(1)} out of ${quota.toFixed(1)} MB (${usagePercentage}%)`,
                     )
-                    if (usage > quota * 0.95) {
+                    if (quota > 0 && usage > quota * 0.95) {
                         log.warn('Persistence storage is almost full, clearing cache...')
                         // drop the miniblocks, synced streams and snapshots
-                        this.miniblocks.clear().catch((e) => {
-                            log.error('Error clearing miniblocks: ', e)
-                        })
-                        this.syncedStreams.clear().catch((e) => {
-                            log.error('Error clearing synced streams: ', e)
-                        })
-                        this.snapshots.clear().catch((e) => {
-                            log.error('Error clearing snapshots: ', e)
+                        Promise.all([
+                            this.miniblocks.clear(),
+                            this.syncedStreams.clear(),
+                            this.snapshots.clear(),
+                        ]).catch((e) => {
+                            log.error('Error clearing cache: ', e)
                         })
                     }
                 })


### PR DESCRIPTION
It's been so long since we had a problem I kinda forgot about this. We only save small amounts of info, but we never clean up the stores. This is all local cache data, deleting it just causes us to re fetch it
Tested by checking the "Simulate custom stoarge quota" checkbox in chrome and watching the memory go way back down to reasonable levels