### PR TITLE
Jt/app registry subgraph 1

### DIFF
--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -11,6 +11,7 @@
         "find-paths": "tsx utils/findContractsPath.ts",
         "format": "prettier --write \"src/**/*.{ts,tsx}\" \"ponder.config.ts\" \"ponder.schema.ts\"",
         "lint": "eslint \"src/**/*.{ts,tsx}\" \"ponder.config.ts\" \"ponder.schema.ts\"",
+        "lint:fix": "eslint --fix \"src/**/*.{ts,tsx}\" \"ponder.config.ts\" \"ponder.schema.ts\"",
         "serve": "yarn typings && ponder serve",
         "start": "yarn typings && ponder start",
         "test:unit": "yarn typings && sh -c 'tsc --noEmit'",

--- a/packages/subgraph/ponder.schema.ts
+++ b/packages/subgraph/ponder.schema.ts
@@ -267,6 +267,7 @@ export const appInstallation = onchainTable(
         // Composite key: app + account uniquely identifies an installation
         app: t.hex().notNull(),
         account: t.hex().notNull(),
+        // versionId
         appId: t.hex().notNull(),
 
         // Lifecycle timestamps
@@ -295,7 +296,7 @@ export const appInstallation = onchainTable(
 export const appVersion = onchainTable(
     'app_versions',
     (t) => ({
-        versionId: t.hex().notNull(),
+        appId: t.hex().notNull(),
         app: t.hex().notNull(),
 
         // Version metadata
@@ -312,9 +313,9 @@ export const appVersion = onchainTable(
         isCurrent: t.boolean().default(true).notNull(),
     }),
     (table) => ({
-        pk: primaryKey({ columns: [table.app, table.versionId] }),
+        pk: primaryKey({ columns: [table.app, table.appId] }),
         appIdx: index().on(table.app),
-        versionIdIdx: index().on(table.versionId),
+        appIdIdx: index().on(table.appId),
         latestIdx: index().on(table.app, table.isLatest),
         currentIdx: index().on(table.isCurrent),
     }),

--- a/packages/subgraph/src/index.ts
+++ b/packages/subgraph/src/index.ts
@@ -748,7 +748,7 @@ ponder.on('AppRegistry:AppInstalled', async ({ event, context }) => {
 })
 
 ponder.on('AppRegistry:AppUninstalled', async ({ event, context }) => {
-    const { app, account, appId } = event.args
+    const { app, account } = event.args
     const { block } = event
     const blockNumber = event.block.number
 
@@ -861,14 +861,12 @@ ponder.on('AppRegistry:AppUpgraded', async ({ event, context }) => {
         await context.db.sql
             .update(schema.appVersion)
             .set({ isLatest: false, isCurrent: false })
-            .where(
-                and(eq(schema.appVersion.app, app), eq(schema.appVersion.versionId, oldVersionId)),
-            )
+            .where(and(eq(schema.appVersion.app, app), eq(schema.appVersion.appId, oldVersionId)))
 
         await context.db
             .insert(schema.appVersion)
             .values({
-                versionId: newVersionId,
+                appId: newVersionId,
                 app,
                 createdAt: block.timestamp,
                 upgradedFromId: oldVersionId,


### PR DESCRIPTION
### Description

This PR introduces some new entities around AppRegistry to allow us to to track App lifeycle within spaces correctly. Ive maintained backwards compat with installedIn array that is currently used in client code to fetch spaces an app is installed in.


### Changes

- normalizes app, space relations with a new table and adds an app version table to track version changes
- handles app installation, registration lifecycle tracking those on-chain emitted events. 

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
