### PR TITLE
node: optimize sqlForStream replacement

### DIFF
--- a/core/node/storage/pg_stream_store.go
+++ b/core/node/storage/pg_stream_store.go
@@ -463,23 +463,13 @@ func CreatePartitionSuffix(streamId StreamId, numPartitions int) string {
 func (s *PostgresStreamStore) sqlForStream(sql string, streamId StreamId) string {
 	suffix := CreatePartitionSuffix(streamId, s.numPartitions)
 
-	sql = strings.ReplaceAll(
-		sql,
-		"{{miniblocks}}",
-		"miniblocks_"+suffix,
-	)
-	sql = strings.ReplaceAll(
-		sql,
-		"{{minipools}}",
-		"minipools_"+suffix,
-	)
-	sql = strings.ReplaceAll(
-		sql,
-		"{{miniblock_candidates}}",
-		"miniblock_candidates_"+suffix,
+	replacer := strings.NewReplacer(
+		"{{miniblocks}}", "miniblocks_"+suffix,
+		"{{minipools}}", "minipools_"+suffix,
+		"{{miniblock_candidates}}", "miniblock_candidates_"+suffix,
 	)
 
-	return sql
+	return replacer.Replace(sql)
 }
 
 func (s *PostgresStreamStore) lockStream(


### PR DESCRIPTION
# Optimize sqlForStream with strings.NewReplacer

## Summary

Refactored the `sqlForStream` method in `PostgresStreamStore` to use `strings.NewReplacer` instead of multiple sequential `strings.ReplaceAll` calls for improved performance and maintainability.

- ✅ **Performance**: Performs all replacements in a single pass through the string instead of three separate passes
- ✅ **Efficiency**: Reduces memory allocations by avoiding intermediate string copies
- ✅ **Maintainability**: All replacement pairs are defined together, making it easier to add or modify substitutions
- ✅ **Readability**: More idiomatic Go code that clearly expresses intent

## Technical Details

The `sqlForStream` function is called extensively throughout the storage layer to map SQL queries containing partition placeholders (`{{miniblocks}}`, `{{minipools}}`, `{{miniblock_candidates}}`) to their actual partition-specific table names.

While the performance improvement per individual call is modest, this function is invoked on every database operation involving streams, making the cumulative effect across all storage operations meaningful.

## Testing

- ✅ No behavioral changes - purely internal refactoring
- ✅ All existing unit tests continue to pass
- ✅ No changes to public API or contracts

## Type

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Performance

**Component**: Storage Layer  
**Impact**: Low (internal optimization)