### PR TITLE
feat: move fee configuration from deployment script to FeeManagerFacet initialization

### DIFF
--- a/packages/contracts/scripts/interactions/InteractPostDeploy.s.sol
+++ b/packages/contracts/scripts/interactions/InteractPostDeploy.s.sol
@@ -51,14 +51,6 @@ contract InteractPostDeploy is Interaction {
         IImplementationRegistry(spaceFactory).addImplementation(baseRegistry);
         IImplementationRegistry(spaceFactory).addImplementation(riverAirdrop);
         IImplementationRegistry(spaceFactory).addImplementation(appRegistry);
-        IFeeManager(spaceFactory).setFeeConfig(
-            FeeTypesLib.TIP_MEMBER,
-            deployer,
-            FeeCalculationMethod.PERCENT,
-            50,
-            0,
-            true
-        );
         ISubscriptionModule(subscriptionModule).setSpaceFactory(spaceFactory);
         IMainnetDelegation(baseRegistry).setProxyDelegation(proxyDelegation);
         IRewardsDistribution(baseRegistry).setRewardNotifier(deployer, true);

--- a/packages/contracts/src/factory/facets/fee/FeeManagerFacet.sol
+++ b/packages/contracts/src/factory/facets/fee/FeeManagerFacet.sol
@@ -8,6 +8,9 @@ import {OwnableBase} from "@towns-protocol/diamond/src/facets/ownable/OwnableBas
 import {Facet} from "@towns-protocol/diamond/src/facets/Facet.sol";
 import {ReentrancyGuardTransient} from "solady/utils/ReentrancyGuardTransient.sol";
 
+// libraries
+import {FeeTypesLib} from "./FeeTypesLib.sol";
+
 /// @title FeeManagerFacet
 /// @notice Facet for unified fee management across the protocol
 contract FeeManagerFacet is
@@ -28,6 +31,7 @@ contract FeeManagerFacet is
 
     function __FeeManagerFacet__init_unchained(address protocolRecipient) internal {
         _setProtocolFeeRecipient(protocolRecipient);
+        _setInitialFeeConfigs(protocolRecipient);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -99,5 +103,37 @@ contract FeeManagerFacet is
     /// @inheritdoc IFeeManager
     function getProtocolFeeRecipient() external view returns (address recipient) {
         return _getProtocolFeeRecipient();
+    }
+
+    function _setInitialFeeConfigs(address protocolRecipient) internal {
+        // tipping fee
+        _setFeeConfig(
+            FeeTypesLib.TIP_MEMBER,
+            protocolRecipient,
+            FeeCalculationMethod.PERCENT,
+            50,
+            0,
+            true
+        );
+
+        // membership fee
+        _setFeeConfig(
+            FeeTypesLib.MEMBERSHIP,
+            protocolRecipient,
+            FeeCalculationMethod.HYBRID,
+            1000, // 10%
+            0.0005 ether,
+            true
+        );
+
+        // app installation fee
+        _setFeeConfig(
+            FeeTypesLib.APP_INSTALL,
+            protocolRecipient,
+            FeeCalculationMethod.HYBRID,
+            1000, // 10%
+            0.0005 ether,
+            true
+        );
     }
 }


### PR DESCRIPTION
### Description

Moved fee configuration from post-deployment script to the `FeeManagerFacet` initialization process and added additional fee configurations for membership and app installation.

### Changes

- Removed fee configuration for tipping from `InteractPostDeploy.s.sol` script
- Added `_setInitialFeeConfigs` method to `FeeManagerFacet.sol` that sets up default fee configurations
- Implemented three fee configurations in the initialization process:
  - Tipping fee: 50% with percentage calculation method
  - Membership fee: 10% OR 0.0005 ETH with hybrid calculation method
  - App installation fee: 10% OR 0.0005 ETH with hybrid calculation method
- Added call to `_setInitialFeeConfigs` in the facet initialization process