### PR TITLE
node: introduce settings to configure the number of events per miniblock

### DIFF
--- a/core/node/crypto/config.go
+++ b/core/node/crypto/config.go
@@ -70,10 +70,25 @@ const (
 	StreamUserInboxStreamHistoryMiniblocksConfigKey    = "stream.historyminiblocks.a1"
 	StreamUserSettingsStreamHistoryMiniblocksConfigKey = "stream.historyminiblocks.a5"
 
+	// StreamMaxEventsPerMiniblockKey is the maximum number of events in a miniblock.
+	StreamMaxEventsPerMiniblockKey = "stream.maxeventsperminiblock"
+
+	// StreamMaxTotalEventsSizePerMiniblockKey is the maximum size (in bytes) of all protobuf encoded events
+	// combined in a miniblock.
+	StreamMaxTotalEventsSizePerMiniblockKey = "stream.maxtotaleventssizeperminiblock"
+
 	// StreamDistributionExtraCandidatesCountCountKey is the key for many extra nodes on top of
 	// replication factor must be picked as candidates to place a stream on. From these candidates
 	// the best replication factor nodes are picked.
 	StreamDistributionExtraCandidatesCountCountKey = "stream.distribution.extracandidatescount"
+
+	// MaxEventsPerMiniblockDefault defines the default (also the maximum) number of events in a miniblock
+	// if not overwritten by StreamMaxEventsPerMiniblockKey.
+	MaxEventsPerMiniblockDefault = 15_000
+
+	// StreamMaxTotalEventsSizePerMiniblockDefault defines the default (also the maximum) size of all protobuf encoded events
+	// combined in a miniblock if not overwritten by StreamMaxTotalEventsSizePerMiniblockKey.
+	StreamMaxTotalEventsSizePerMiniblockDefault = 10 * 1024 * 1024
 )
 
 var (
@@ -170,6 +185,12 @@ type OnChainSettings struct {
 	// Number of miniblocks to keep for each type of stream.
 	// 0 means keep all miniblocks.
 	StreamHistoryMiniblocks StreamHistoryMiniblocks `mapstructure:",squash"`
+
+	// StreamMaxEventsPerMiniblock is the maximum number of events that can be included in a miniblock.
+	StreamMaxEventsPerMiniblock uint64 `mapstructure:"stream.maxeventsperminiblock"`
+	// StreamMaxTotalEventsSizePerMiniblock is the maximum size (in bytes) of all protobuf encoded events
+	// combined in a miniblock.
+	StreamMaxTotalEventsSizePerMiniblock uint64 `mapstructure:"stream.maxtotaleventssizeperminiblock"`
 }
 
 type StreamHistoryMiniblocks struct {

--- a/core/node/events/replication_test.go
+++ b/core/node/events/replication_test.go
@@ -1,11 +1,191 @@
 package events
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/towns-protocol/towns/core/node/crypto"
+	"github.com/towns-protocol/towns/core/node/protocol"
+	"github.com/towns-protocol/towns/core/node/shared"
 )
+
+// TestReplicatedMbProductionWithTooManyEvents ensures that the miniblock producer does not produce miniblocks
+// with more events than the configured limit.
+func TestReplicatedMbProductionWithTooManyEvents(t *testing.T) {
+	t.Parallel()
+
+	runTest := func(t *testing.T, replFactor int, numInstances int) {
+		ctx, tc := makeCacheTestContext(t, testParams{replFactor: replFactor, numInstances: numInstances})
+		require := tc.require
+
+		const (
+			maxEventsPerMiniblock = 3
+			eventCount            = 7
+		)
+
+		tc.btc.SetConfigValue(
+			t,
+			ctx,
+			crypto.StreamReplicationFactorConfigKey,
+			crypto.ABIEncodeInt64(int64(replFactor)),
+		)
+
+		tc.btc.SetConfigValue(
+			t,
+			ctx,
+			crypto.StreamMaxEventsPerMiniblockKey,
+			crypto.ABIEncodeInt64(int64(maxEventsPerMiniblock)),
+		)
+
+		maxMiniblockEventsCount, maxMiniblockEventsSize := MiniblockEventLimits(tc.btc.OnChainConfig.Get())
+		require.EqualValues(maxEventsPerMiniblock, maxMiniblockEventsCount)
+
+		tc.initAllCaches(&MiniblockProducerOpts{TestDisableMbProdcutionOnBlock: true})
+
+		streamId, streamNodes, prevMb := tc.createReplStream()
+
+		// add several events and ensure that miniblocks contain maxEventsPerMiniblock events per miniblock
+		for range eventCount {
+			tc.addReplEvent(streamId, prevMb, streamNodes)
+		}
+
+		leaderAddr := streamNodes[0]
+		leader := tc.instancesByAddr[leaderAddr]
+
+		require.EventuallyWithT(func(collect *assert.CollectT) {
+			mbProductionWithEventMaxSizeCheck(
+				collect, leader, ctx, streamId, maxEventsPerMiniblock, maxMiniblockEventsSize, eventCount)
+		}, 10*time.Second, 50*time.Millisecond)
+	}
+
+	t.Run("non-replicated", func(t *testing.T) { runTest(t, 1, 1) })
+	t.Run("replicated", func(t *testing.T) { runTest(t, 3, 5) })
+}
+
+// TestReplicatedMbProductionWithTooBigEvents ensures that the miniblock producer does not produce miniblocks
+// with a total event size greater than the configured limit.
+func TestReplicatedMbProductionWithTooBigEvents(t *testing.T) {
+	t.Parallel()
+
+	runTest := func(t *testing.T, replFactor int, numInstances int) {
+		ctx, tc := makeCacheTestContext(t, testParams{replFactor: replFactor, numInstances: numInstances})
+		require := tc.require
+
+		const (
+			maxEventsPerMiniblock = 3
+			eventCount            = 7
+		)
+
+		tc.initAllCaches(&MiniblockProducerOpts{TestDisableMbProdcutionOnBlock: true})
+
+		streamId, streamNodes, prevMb := tc.createReplStream()
+
+		eventSize := 0
+		for range eventCount {
+			ev := tc.addReplEvent(streamId, prevMb, streamNodes)
+			eventSize = max(len(ev.Envelope.Event), eventSize)
+		}
+
+		// set the max event size times 3, this should result in max 3 events per miniblock
+		maxMiniblockEventsSize := maxEventsPerMiniblock * eventSize
+
+		tc.btc.SetConfigValue(
+			t,
+			ctx,
+			crypto.StreamReplicationFactorConfigKey,
+			crypto.ABIEncodeInt64(int64(replFactor)),
+		)
+
+		tc.btc.SetConfigValue(
+			t,
+			ctx,
+			crypto.StreamMaxTotalEventsSizePerMiniblockKey,
+			crypto.ABIEncodeInt64(int64(maxMiniblockEventsSize)),
+		)
+		require.EqualValues(maxMiniblockEventsSize, tc.btc.OnChainConfig.Get().StreamMaxTotalEventsSizePerMiniblock)
+
+		leaderAddr := streamNodes[0]
+		leader := tc.instancesByAddr[leaderAddr]
+
+		require.EventuallyWithT(func(collect *assert.CollectT) {
+			mbProductionWithEventMaxSizeCheck(
+				collect, leader, ctx, streamId, maxEventsPerMiniblock, maxMiniblockEventsSize, eventCount)
+		}, 10*time.Second, 50*time.Millisecond)
+	}
+
+	t.Run("non-replicated", func(t *testing.T) { runTest(t, 1, 1) })
+	t.Run("replicated", func(t *testing.T) { runTest(t, 3, 5) })
+}
+
+func mbProductionWithEventMaxSizeCheck(
+	collect *assert.CollectT,
+	leader *cacheTestInstance,
+	ctx context.Context,
+	streamId shared.StreamId,
+	maxEventsPerMiniblock int,
+	maxMiniblockEventsSize int,
+	eventCount int,
+) {
+	stream, err := leader.cache.getStreamImpl(ctx, streamId, true)
+	if err != nil {
+		collect.Errorf("get stream failed %s", err)
+		return
+	}
+	if !stream.IsLocal() {
+		collect.Errorf("stream not local")
+		return
+	}
+
+	job := leader.cache.mbProducer.trySchedule(ctx, stream, 0)
+	if job == nil {
+		collect.Errorf("try schedule returned nil job")
+		return
+	}
+
+	dbMiniblocks, err := leader.params.Storage.ReadMiniblocks(ctx, streamId, 1, 100, false)
+	if err != nil {
+		collect.Errorf("read miniblocks failed %s", err)
+		return
+	}
+
+	includedEvents := 0
+	for _, dbMiniblock := range dbMiniblocks {
+		var mb protocol.Miniblock
+		if err = proto.Unmarshal(dbMiniblock.Data, &mb); err != nil {
+			collect.Errorf("unmarshal miniblock failed %s", err)
+			return
+		}
+		if len(mb.GetEvents()) > maxEventsPerMiniblock {
+			collect.Errorf(
+				"got %d events in miniblock, expected <= %d events",
+				len(mb.GetEvents()),
+				maxEventsPerMiniblock,
+			)
+			return
+		}
+
+		totalEventsSize := 0
+		for _, ev := range mb.GetEvents() {
+			totalEventsSize += len(ev.Event)
+		}
+
+		if totalEventsSize > maxMiniblockEventsSize {
+			collect.Errorf("got total events size %d, expected <= %d", totalEventsSize, maxMiniblockEventsSize)
+			return
+		}
+
+		includedEvents += len(mb.GetEvents())
+	}
+
+	if includedEvents != eventCount {
+		collect.Errorf("got %d events in miniblocks, expected %d events", includedEvents, eventCount)
+		return
+	}
+}
 
 func TestReplicatedMbProduction(t *testing.T) {
 	ctx, tc := makeCacheTestContext(t, testParams{replFactor: 5, numInstances: 5})

--- a/core/node/events/stream.go
+++ b/core/node/events/stream.go
@@ -1038,6 +1038,7 @@ func (s *Stream) SaveMiniblockCandidate(ctx context.Context, candidate *Minibloc
 	if err != nil {
 		return err
 	}
+
 	if applied {
 		return nil
 	}
@@ -1050,12 +1051,13 @@ func (s *Stream) SaveMiniblockCandidate(ctx context.Context, candidate *Minibloc
 	return s.params.Storage.WriteMiniblockCandidate(ctx, s.streamId, storageMb)
 }
 
-// tryApplyCandidate tries to apply the miniblock candidate to the stream. It will apply iff
+// tryApplyCandidate tries to apply the miniblock candidate to the stream. It will apply if
 // it matches the first in the list of pending candidates, and then it will apply the entire
 // list of pending candidates. It will also return a true result if this block matches the
 // last block applied to the stream.
 // tryApplyCandidate is thread-safe.
 func (s *Stream) tryApplyCandidate(ctx context.Context, mb *MiniblockInfo) (bool, error) {
+	// try to apply the candidate
 	_, err := s.lockMuAndLoadView(ctx)
 	defer s.mu.Unlock()
 	if err != nil {

--- a/core/node/events/stream_view.go
+++ b/core/node/events/stream_view.go
@@ -348,36 +348,75 @@ func (r *StreamView) ProposeNextMiniblock(
 	}, nil
 }
 
+// proposeNextMiniblock creates a miniblock proposal from the local stream view that
+// respects the limits set in the given cfg.
 func (r *StreamView) proposeNextMiniblock(
 	ctx context.Context,
 	cfg *crypto.OnChainSettings,
 	forceSnapshot bool,
+	replicatedStream bool,
 ) *mbProposal {
+	var events []mbProposalEvent
+	// for replicated streams all events are included to prevent the situation that due to
+	// miniblock event limits, each replica has a different set of events and no quorum over
+	// which events to include could be reached. For replicated streams all gathered proposals
+	// are combined into a proposal used to create the next miniblock candidate. Miniblock
+	// event limits are respected during this step.
+	if replicatedStream {
+		events = r.minipool.proposalEvents()
+	} else {
+		events = r.minipool.proposalEventsWithMiniblockLimits(cfg)
+	}
+
 	return &mbProposal{
 		newMiniblockNum:   r.minipool.generation,
 		prevMiniblockHash: r.LastBlock().headerEvent.Hash,
 		shouldSnapshot:    forceSnapshot || r.shouldSnapshot(cfg),
-		eventHashes:       r.minipool.eventHashes(),
+		events:            events,
 	}
 }
 
+// mbProposalEvent contains details of an event that is included in a miniblock proposal.
+type mbProposalEvent struct {
+	// Hash is the event hash
+	Hash common.Hash
+	// Size is the length of the raw event envelope.
+	Size int
+}
+
+// mbProposal is a proposal created by a stream node that contains the details of the
+// next miniblock to be created. Proposals are used to create a candidate that is registered
+// in the StreamRegistry smart contract. If registered successful the candidate is promoted
+// to be the next miniblock in the stream.
 type mbProposal struct {
-	newMiniblockNum   int64
+	// newMiniblockNum is the miniblock number for this proposal.
+	newMiniblockNum int64
+	// prevMiniblockHash is the hash of the previous miniblock.
 	prevMiniblockHash common.Hash
-	shouldSnapshot    bool
-	eventHashes       []common.Hash
+	// shouldSnapshot is true if the node that created the proposal wants to create a snapshot
+	shouldSnapshot bool
+	// events contain the events included in the proposal. This is a slice to respect the ordering of events.
+	events []mbProposalEvent
 }
 
-func mbProposalFromProto(p *MiniblockProposal) *mbProposal {
-	hashes := make([]common.Hash, len(p.Hashes))
-	for i, h := range p.Hashes {
-		hashes[i].SetBytes(h)
+// mbProposalFromProto decodes the given p received from a remote replica node into
+// a mbProposal that can be combined to create the next miniblock candidate. The given
+// view is used to resolve the hashes to events to grab event details. Only events are
+// included in the returned proposal that are also present in the given view.
+func mbProposalFromProto(p *MiniblockProposal, view *StreamView) *mbProposal {
+	events := make([]mbProposalEvent, 0, len(p.Hashes))
+	for _, h := range p.Hashes {
+		eventHash := common.BytesToHash(h)
+		if event, ok := view.minipool.events.Get(eventHash); ok {
+			events = append(events, mbProposalEvent{Hash: eventHash, Size: len(event.Envelope.Event)})
+		}
 	}
+
 	return &mbProposal{
 		newMiniblockNum:   p.NewMiniblockNum,
-		prevMiniblockHash: common.Hash(p.PrevMiniblockHash),
+		prevMiniblockHash: common.BytesToHash(p.PrevMiniblockHash),
 		shouldSnapshot:    p.ShouldSnapshot,
-		eventHashes:       hashes,
+		events:            events,
 	}
 }
 
@@ -402,13 +441,13 @@ func (r *StreamView) makeMiniblockCandidate(
 	hashes := make([][]byte, 0, r.minipool.events.Len())
 	events := make([]*ParsedEvent, 0, r.minipool.events.Len())
 
-	for _, h := range proposal.eventHashes {
-		e, ok := r.minipool.events.Get(h)
+	for _, ev := range proposal.events {
+		e, ok := r.minipool.events.Get(ev.Hash)
 		if !ok {
 			return nil, RiverError(
 				Err_MINIPOOL_MISSING_EVENTS,
 				"proposal event not found in minipool",
-				"hash", h,
+				"hash", ev.Hash,
 				"streamId", r.streamId,
 				"generation", r.minipool.generation,
 				"minipoolLen", r.minipool.events.Len(),
@@ -1097,4 +1136,33 @@ func (r *StreamView) GetResetStreamAndCookieWithPrecedingMiniblocks(
 		SyncReset:              true,
 		SnapshotMiniblockIndex: snapshotIndexInResult,
 	}
+}
+
+// MiniblockEventLimits returns the maximum numbers of events per miniblock and the max total combined
+// size (in bytes) of all events in a miniblock as defined in the given cfg. It reads those from on-chain
+// settings and if not found, uses default values.
+//
+// It also ensures that settings read from on-chain are not too high, limiting them to the max allowed
+// by the protocol. This prevents misconfiguration or malicious on-chain values from causing excessive
+// miniblock sizes that could impact network performance or storage requirements.
+func MiniblockEventLimits(cfg *crypto.OnChainSettings) (maxEventsPerMiniblock, maxEventCombinedSize int) {
+	// limit the number of events that can be proposed in a single miniblock.
+	// use the default also as a max when settings are configured on-chain to prevent
+	// values that could cause performance issues or enable denial-of-service attacks.
+	maxEventsPerMiniblock = crypto.MaxEventsPerMiniblockDefault
+	if cfg.StreamMaxEventsPerMiniblock > 0 {
+		maxEventsPerMiniblock = int(min(crypto.MaxEventsPerMiniblockDefault, cfg.StreamMaxEventsPerMiniblock))
+	}
+
+	// limit the combined size of events that can be proposed in a single miniblock.
+	// use the default also as a max when settings are configured on-chain to prevent
+	// values that could cause performance issues or enable denial-of-service attacks.
+	maxEventCombinedSize = crypto.StreamMaxTotalEventsSizePerMiniblockDefault
+	if cfg.StreamMaxTotalEventsSizePerMiniblock > 0 {
+		maxEventCombinedSize = int(
+			min(crypto.StreamMaxTotalEventsSizePerMiniblockDefault, cfg.StreamMaxTotalEventsSizePerMiniblock),
+		)
+	}
+
+	return maxEventsPerMiniblock, maxEventCombinedSize
 }

--- a/core/node/events/stream_view_test.go
+++ b/core/node/events/stream_view_test.go
@@ -164,7 +164,7 @@ func TestLoad(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, resp.MissingEvents, view.minipool.events.Len())
-	mbCandidate, err := view.makeMiniblockCandidate(ctx, params, mbProposalFromProto(resp.Proposal))
+	mbCandidate, err := view.makeMiniblockCandidate(ctx, params, mbProposalFromProto(resp.Proposal, view))
 	require.NoError(t, err)
 	assert.Nil(t, mbCandidate.headerEvent.Event.GetMiniblockHeader().Snapshot)
 
@@ -195,7 +195,7 @@ func TestLoad(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, resp.MissingEvents, 0)
-	mbCandidate, err = view.makeMiniblockCandidate(ctx, params, mbProposalFromProto(resp.Proposal))
+	mbCandidate, err = view.makeMiniblockCandidate(ctx, params, mbProposalFromProto(resp.Proposal, view))
 	require.NoError(t, err)
 	miniblockHeader = mbCandidate.headerEvent.Event.GetMiniblockHeader()
 	assert.Nil(t, miniblockHeader.Snapshot)

--- a/core/node/events/util_test.go
+++ b/core/node/events/util_test.go
@@ -241,7 +241,7 @@ func (ctc *cacheTestContext) addReplEvent(
 	streamId StreamId,
 	prevMiniblock *MiniblockRef,
 	nodes []common.Address,
-) {
+) *ParsedEvent {
 	addr := crypto.GetTestAddress()
 	ev, err := MakeParsedEventWithPayload(
 		ctc.clientWallet,
@@ -265,6 +265,8 @@ func (ctc *cacheTestContext) addReplEvent(
 			assert.NoError(collect, err)
 		}, 3*time.Second, 5*time.Millisecond, "failed to add event to stream, node %d %s", i, n)
 	}
+
+	return ev
 }
 
 // TODO: rename to allocateStream
@@ -776,7 +778,7 @@ func (i *cacheTestInstance) makeMbCandidateForView(
 	ctx context.Context,
 	view *StreamView,
 ) (*MiniblockInfo, error) {
-	proposal := view.proposeNextMiniblock(ctx, i.params.ChainConfig.Get(), false)
+	proposal := view.proposeNextMiniblock(ctx, i.params.ChainConfig.Get(), false, true)
 	mbCandidate, err := view.makeMiniblockCandidate(ctx, i.params, proposal)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION

  ## Changes

  ### Configuration (`crypto/config.go`)
  - Added two new on-chain configuration keys:
    - `stream.maxEventsPerMiniblock` - Maximum number of events per miniblock
    - `stream.maxTotalEventsSizePerMiniblock` - Maximum combined size (in bytes) of all protobuf-encoded events
  - Defined protocol-level defaults that also serve as hard limits:
    - `MaxEventsPerMiniblockDefault = 15,000` events
    - `StreamMaxTotalEventsSizePerMiniblockDefault = 10 MB`
  - Added corresponding fields to `OnChainSettings` struct

  ### Event Selection (`minipool.go`)
  - Modified `eventHashes()` and `eventHashesAsBytes()` to enforce configured limits
  - Implemented dual-limit logic:
    - Stops at max event count, OR
    - Stops when cumulative event size exceeds max size
  - Events are selected in order until either limit is reached

  ### Proposal & Validation (`stream_view.go`, `stream.go`)
  - Added `MiniblockEventLimits()` helper function that:
    - Reads limits from on-chain settings
    - Falls back to defaults if not configured
    - Enforces protocol max limits even if on-chain values are higher
  - Enhanced `ProposeNextMiniblock()` to reject proposals exceeding limits
  - Added validation in `tryApplyCandidate()` to reject oversized candidates before applying

  ### Testing (`replication_test.go`)
  - Added `TestReplicatedMbProductionWithTooManyEvents` - validates max event count enforcement
  - Added `TestReplicatedMbProductionWithTooBigEvents` - validates max total size enforcement
  - Both tests verify that miniblocks are properly split when limits are exceeded

  ## Behavior

  **Before**: Miniblocks could contain unlimited events from the minipool, potentially creating very large blocks
  that impact network performance and blockchain transaction costs.

  **After**: Miniblocks are capped at:
  - Default: 15,000 events OR 10 MB total size (whichever is reached first)
  - Configurable via on-chain settings within protocol max limits
  - Events exceeding limits remain in the minipool for subsequent miniblocks

  ## Motivation

  - **Network efficiency**: Prevents oversized miniblocks that strain replication and storage
  - **Cost control**: Limits on-chain registration transaction sizes
  - **Configurability**: Operators can tune limits via on-chain settings without code changes
  - **Safety**: Hard-coded maximum limits prevent misconfiguration

  ## Testing

  - ✅ New tests verify both limit types are enforced correctly
  - ✅ Existing miniblock production tests still pass
  - ✅ Tests confirm events properly overflow into subsequent miniblocks
