### PR TITLE
sdk: add `appClientAddress` from tags in `TimelineEvent`

### DIFF
--- a/packages/sdk/src/views/models/timelineEvent.ts
+++ b/packages/sdk/src/views/models/timelineEvent.ts
@@ -102,6 +102,7 @@ export function toEvent(timelineEvent: StreamTimelineEvent, userId: string): Tim
     const isSender = sender.id === userId
     const fbc = `${content?.kind ?? '??'} ${getFallbackContent(sender.id, content, error)}`
     const sessionId = extractSessionId(timelineEvent)
+    const appClientAddress = extractAppClientAddress(timelineEvent)
 
     return {
         eventId: eventId,
@@ -127,6 +128,7 @@ export function toEvent(timelineEvent: StreamTimelineEvent, userId: string): Tim
         isRedacted: false, // redacted is handled in use timeline store when the redaction event is received
         sender,
         sessionId,
+        appClientAddress,
     }
 }
 
@@ -139,6 +141,14 @@ function extractSessionId(event: StreamTimelineEvent): string | undefined {
     return payload.value.content.value.sessionIdBytes.length > 0
         ? bin_toHexString(payload.value.content.value.sessionIdBytes)
         : payload.value.content.value.sessionId
+}
+
+function extractAppClientAddress(event: StreamTimelineEvent): string | undefined {
+    const tags = event.remoteEvent?.event.tags
+    if (!tags?.appClientAddress || tags.appClientAddress.length === 0) {
+        return undefined
+    }
+    return `0x${bin_toHexString(tags.appClientAddress)}`
 }
 
 function getSenderId(timelineEvent: StreamTimelineEvent): string {

--- a/packages/sdk/src/views/models/timelineTypes.ts
+++ b/packages/sdk/src/views/models/timelineTypes.ts
@@ -70,6 +70,7 @@ export interface TimelineEvent {
         id: string
     }
     sessionId?: string
+    appClientAddress?: string
 }
 
 /// a timeline event should have one or none of the following fields set


### PR DESCRIPTION
needed so we can
1. render the bot that the slash command is targetted to
2. edit message and still keep the slash command 

ideally, we would add this in local events too, but it touches a bunch of stuff that I don't want to bother atm