### PR TITLE
docs: add bot discovery endpoint to getting started guide

### DIFF
--- a/packages/docs/build/bots/getting-started.mdx
+++ b/packages/docs/build/bots/getting-started.mdx
@@ -75,7 +75,7 @@ app.get('/.well-known/agent-metadata.json', async (c) => {
 })
 ```
 
-This endpoint is **required** for bot directories to discover and index your bot.
+This endpoint is **required** for bot directories to discover and index your bot. After deploying your bot, go to the [developer dashboard](https://app.towns.com/developer/dashboard) and click the **Boost** button to submit your bot for indexing.
 
 ### Configure Environment
 


### PR DESCRIPTION
### Description

This PR adds documentation for the bot discovery endpoint to the Getting Started guide. The `/.well-known/agent-metadata.json` endpoint exposes a bot's identity metadata (username, display name, description, avatar) in a standardized format, allowing bot directories and discovery services to automatically index and display available bots.

### Changes

- Added "Add Bot Discovery Endpoint" section to `packages/docs/build/bots/getting-started.mdx`
- Positioned the new section after project initialization and before environment configuration
- Included clear code example showing how to implement the endpoint in `src/index.ts`
- Added explanation that this endpoint is required for bot discoverability

### Checklist

- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines
- [N/A] Tests added where required (documentation-only change)