### PR TITLE
node: stream reconciliation considers miniblock candidates

### DIFF
--- a/core/node/events/stream_reconciler_test.go
+++ b/core/node/events/stream_reconciler_test.go
@@ -946,3 +946,49 @@ func TestReconciler_ReconcileAndTrimEndToEnd(t *testing.T) {
 	}
 	assert.Equal(t, expectedSeqs, seqs)
 }
+
+// TestReconciler_NoRemotesNoCandidateFails verifies that when a non-replicated stream
+// has no remotes and no local candidate, reconciliation fails gracefully.
+// This test ensures the error handling path in tryPromoteLocalCandidate works correctly.
+func TestReconciler_NoRemotesNoCandidateFails(t *testing.T) {
+	cfg := config.GetDefaultConfig()
+	cfg.StreamReconciliation.InitialWorkerPoolSize = 0
+	cfg.StreamReconciliation.OnlineWorkerPoolSize = 0
+
+	ctx, tc := makeCacheTestContext(
+		t,
+		testParams{
+			config:                           cfg,
+			replFactor:                       1, // Non-replicated stream
+			numInstances:                     1,
+			disableStreamCacheCallbacks:      true,
+			recencyConstraintsGenerations:    5,
+			backwardsReconciliationThreshold: ptrUint64(20),
+		},
+	)
+	require := tc.require
+
+	tc.initCache(0, &MiniblockProducerOpts{TestDisableMbProdcutionOnBlock: true})
+	streamId, _, _ := tc.allocateStream()
+
+	inst := tc.instances[0]
+
+	// Get stream record
+	blockNum, err := inst.cache.params.Registry.Blockchain.GetBlockNumber(ctx)
+	require.NoError(err)
+	recordNoId, err := inst.cache.params.Registry.StreamRegistry.GetStreamOnBlock(ctx, streamId, blockNum)
+	require.NoError(err)
+	record := river.NewStreamWithId(streamId, recordNoId)
+
+	stream, err := inst.cache.getStreamImpl(ctx, streamId, true)
+	require.NoError(err)
+
+	// Reconciliation should fail - this is the same scenario as TestReconciler_NoRemotes
+	// but explicitly tests the new tryPromoteLocalCandidate code path
+	reconciler := newStreamReconciler(inst.cache, stream, record)
+	err = reconciler.reconcile()
+	require.Error(err)
+	require.True(IsRiverErrorCode(err, Err_UNAVAILABLE))
+
+	testfmt.Logf(t, "Correctly failed reconciliation with no remotes and no candidate")
+}


### PR DESCRIPTION
# Fix stream reconciliation to handle stuck miniblock candidates

## Problem

  Stream reconciliation could fail in edge cases where miniblock candidates were registered on-chain but never promoted locally. This occurred in two scenarios:

  1. Non-replicated streams (replication factor = 1): When a node sent the miniblock candidate registration transaction but missed the stream updated event, the candidate remained unpromoted. With no remotes to reconcile from, the stream became permanently stuck.
  2. All replicas missing events: When all replicas of a stream missed the stream update event, none promoted their candidates. Even though remotes existed, reconciliation would fetch data unnecessarily instead of using the locally available candidate. If none of the replicas promoted the candidate the stream became permanently stuck.

## Solution

  Added tryPromoteLocalCandidate() helper method that:
  - Attempts to read and promote local miniblock candidates
  - Properly distinguishes between NOT_FOUND (expected) and critical errors (database failures)
  - Returns clear success/failure states via (bool, error) tuple
  - Prevents unnecessary network operations when local data is available

  Integrated candidate promotion checks at two key points:
  1. Before failing with no remotes (stream_reconciler.go:179-196) - Tries to promote local candidate before giving up
  2. When 1 miniblock behind (stream_reconciler.go:218-232) - Opportunistically promotes candidate before fetching from remotes

## Changes

  - stream_reconciler.go:
    - Added tryPromoteLocalCandidate() method with proper error handling
    - Updated two reconciliation paths to check for local candidates
    - Fixed silent error handling bug (was using _ to ignore all errors)
    - Improved error messages and comments
  - stream_reconciler_test.go:
    - Added TestReconciler_NoRemotesNoCandidateFails to verify error handling
    - All existing tests continue to pass (15 total)

