### PR TITLE
Enable high usage monitor by default

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -54,7 +54,7 @@ func GetDefaultConfig() *Config {
 			Enabled: true,
 		},
 		HighUsageDetection: HighUsageDetectionConfig{
-			Enabled:    false,
+			Enabled:    true,
 			MaxResults: 50,
 			Thresholds: HighUsageThresholdFields{
 				ThresholdAddEventWindow1:          time.Minute,


### PR DESCRIPTION
### Description

It's been active on our nodes on Omega for a week now, so it's ok to enable by default for everyone

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
