### PR TITLE
Remove log when no bots installed in a channel

### DIFF
--- a/core/node/app_registry/sync/tracked_stream.go
+++ b/core/node/app_registry/sync/tracked_stream.go
@@ -125,8 +125,6 @@ func (b *AppRegistryTrackedStreamView) onNewEvent(ctx context.Context, view *Str
 			"eventCreator", hex.EncodeToString(event.Event.CreatorAddress),
 		)
 		b.listener.OnMessageEvent(ctx, *streamId, view.StreamParentId(), apps, event)
-	} else {
-		log.Infow("No forwardable apps found in channel members", "streamId", streamId)
 	}
 
 	return nil


### PR DESCRIPTION
### Description

We've added a log for every event for channels without bots in them. this is too much, and is removed in this PR.

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
