### PR TITLE
fix persist sync cookie log

### DIFF
--- a/core/node/track_streams/multi_sync_runner.go
+++ b/core/node/track_streams/multi_sync_runner.go
@@ -301,12 +301,12 @@ func (ssr *syncSessionRunner) applyUpdateToStream(
 				"persisting sync cookie",
 				"streamId",
 				streamId,
-				"cookie",
-				cookie,
+				"nodeAddress",
+				common.BytesToAddress(cookie.NodeAddress),
+				"minipoolGen",
+				cookie.MinipoolGen,
 				"syncId",
 				ssr.syncer.GetSyncId(),
-				"targetNode",
-				ssr.node,
 			)
 			if err := ssr.cookieStore.PersistSyncCookie(ssr.rootCtx, streamId, cookie); err != nil {
 				log.Warnw("Failed to persist sync cookie", "streamId", streamId, "error", err)


### PR DESCRIPTION
### Description

We printed the cookie with node address in byte array format. now we will print it in hex.
### Changes

<!-- List the specific changes made in this PR, for example:
- Added/modified feature X
- Fixed bug in component Y
- Refactored module Z
- Updated documentation
-->

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
