### PR TITLE
Disable cookie store in app registry service

### DIFF
--- a/core/node/app_registry/service.go
+++ b/core/node/app_registry/service.go
@@ -110,8 +110,9 @@ func NewService(
 		listener = NewAppMessageProcessor(ctx, cache)
 	}
 
-	// Create the cookie store for stream resumption using the store's connection pool
-	cookieStore := track_streams.NewPostgresStreamCookieStore(store.Pool(), "stream_sync_cookies")
+	// TODO: Cookie persistence is disabled until we fix the sync session runner to handle
+	// non-reset responses when resuming from a persisted cookie position.
+	// cookieStore := track_streams.NewPostgresStreamCookieStore(store.Pool(), "stream_sync_cookies")
 
 	tracker, err := sync.NewAppRegistryStreamsTracker(
 		ctx,
@@ -122,7 +123,7 @@ func NewService(
 		metrics,
 		listener,
 		cache,
-		cookieStore,
+		nil, // cookieStore disabled
 		otelTracer,
 	)
 	if err != nil {


### PR DESCRIPTION
### Description

We've implemented cookie persistence wrong.
Currently we are persisting the cookie every time we apply a new block.
There are two cases when the service restarts:
1. if the minipoolGen is after the snapshot - we fail to sync since the sync session runner expects a reset cookie as the first update
2. if the minipoolGen is before the snapshot - we will get a reset cookie, but we are missing events from the snapshot and back until our minipoolGen

I am disabling the persistence for now, until we fix those issues

### Checklist

- [ ] Tests added where required
- [ ] Documentation updated where applicable
- [ ] Changes adhere to the repository's contribution guidelines
