### PR TITLE
node: add support to dump the number of miniblocks produced in a time interval per stream type

### DIFF
--- a/core/cmd/miniblock_cmd.go
+++ b/core/cmd/miniblock_cmd.go
@@ -103,7 +103,7 @@ func runMiniblockProductionRateCmd(cmd *cobra.Command, args []string) error {
 
 	miniblockInterval, err := strconv.ParseUint(args[0], 10, 64)
 	if err != nil {
-		return fmt.Errorf("invalid miniblock interval value: %s", args[1])
+		return fmt.Errorf("invalid miniblock interval value: %s", args[0])
 	}
 
 	start, err := strconv.ParseUint(args[1], 10, 64)


### PR DESCRIPTION
  Summary

  - Add new miniblock production-rate CLI command to analyze miniblock production rates across different stream
  types over configurable time intervals
  - Fetches StreamUpdated events from the River chain in batches, decodes them, and outputs CSV data grouped by
  block intervals
  - Tracks miniblock counts per stream type (channels, DMs, GDMs, media, spaces, user streams, etc.)

  Test plan

  - Run river_node miniblock production-rate 30 <start-block> <end-block> against a River chain
  - Verify CSV output contains correct headers for all stream types
  - Verify miniblock counts are correctly aggregated per interval
  - Test with different interval sizes (e.g., 30, 60, 100 blocks)
  - Test with missing end block argument (should use latest block)

  🤖 Generated with https://claude.com/claude-code

  ---
  Example usage:
  # Dump miniblock production grouped by 30-block intervals (~1 minute)
  river_node miniblock production-rate 30 12000 12500

  Output format:
  riverBlockNum,riverBlockCreated,channel,dm_channel,gdm_channel,media,...
  12000,1701234567,5,2,1,10,...
  12030,1701234627,3,1,0,8,...
