### PR TITLE
node: skip tests if required config isn't provided

### DIFF
--- a/core/node/storage/pg_stream_store_external_storage_test.go
+++ b/core/node/storage/pg_stream_store_external_storage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -36,6 +37,9 @@ import (
 func TestExternalMediaStreamStorage(t *testing.T) {
 	t.Parallel()
 
+	s3Enabled := os.Getenv("RIVER_EXTERNAL_MEDIA_STREAM_STORAGE_AWS_S3_REGION") != ""
+	gcsEnabled := os.Getenv("RIVER_EXTERNAL_MEDIA_STREAM_STORAGE_GCS_STORAGE_BUCKET") != ""
+
 	ctx := t.Context()
 	cfg := config.GetDefaultConfig()
 	bld, err := builder.NewConfigBuilder(cfg, "RIVER")
@@ -52,6 +56,10 @@ func TestExternalMediaStreamStorage(t *testing.T) {
 		t.Parallel()
 
 		require := require.New(t)
+
+		if !s3Enabled {
+			t.Skip("AWS S3 Storage not enabled")
+		}
 
 		// ensure that GC Storage is disabled for AWS S3 tests
 		extStorageConfig := cfg.ExternalMediaStreamStorage
@@ -191,6 +199,10 @@ func TestExternalMediaStreamStorage(t *testing.T) {
 
 	t.Run("Google Cloud Storage", func(t *testing.T) {
 		t.Parallel()
+
+		if !gcsEnabled {
+			t.Skip("Google Cloud storage not enabled")
+		}
 
 		// ensure that AWS S3 is disabled for GCS tests
 		gcsConfig := &config.ExternalMediaStreamStorageConfig{
@@ -336,6 +348,10 @@ func TestExternalMediaStreamStorage(t *testing.T) {
 	})
 
 	t.Run("Migrate existing streams", func(t *testing.T) {
+		if !gcsEnabled {
+			t.Skip("Google Cloud storage not enabled")
+		}
+
 		gcsConfig := &config.ExternalMediaStreamStorageConfig{
 			Gcs: config.ExternalMediaStreamStorageGCStorageConfig{
 				Bucket:          cfg.ExternalMediaStreamStorage.Gcs.Bucket,


### PR DESCRIPTION
Summary

  - Skip external storage tests (AWS S3 and GCS) when required configuration environment variables are not provided
  - Prevents test failures in environments without cloud storage credentials configured

  Test plan

  - Run go test ./core/node/storage/... -run TestExternalMediaStreamStorage without cloud credentials - tests should skip
  - Run with S3 credentials set - AWS S3 tests should execute
  - Run with GCS credentials set - Google Cloud Storage tests should execute

  🤖 Generated with https://claude.com/claude-code

  ---
  The change checks for RIVER_EXTERNAL_MEDIA_STREAM_STORAGE_AWS_S3_REGION and
  RIVER_EXTERNAL_MEDIA_STREAM_STORAGE_GCS_STORAGE_BUCKET environment variables at the start of the test, then uses t.Skip() to
   gracefully skip the relevant subtests when credentials aren't available.
