### PR TITLE
feat: implement paid commands with x402 payment processing

### DIFF
--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -87,8 +87,6 @@ import {
     type AppMetadata,
     StreamEvent,
     ChannelMessage_Post_MentionSchema,
-    InteractionRequestPayload_SignatureSchema,
-    InteractionRequestPayload_Signature_SignatureType,
 } from '@towns-protocol/proto'
 import {
     bin_equal,
@@ -110,7 +108,6 @@ import type {
 import type { PendingPayment } from './payments'
 import { chainIdToNetwork, createPaymentRequest } from './payments'
 import { useFacilitator } from 'x402/verify'
-import { createPaymentHeader } from 'x402/client'
 
 import {
     http,
@@ -125,7 +122,6 @@ import {
     encodeAbiParameters,
     zeroAddress,
     parseEventLogs,
-    parseUnits,
     formatUnits,
 } from 'viem'
 import { readContract, waitForTransactionReceipt, writeContract } from 'viem/actions'


### PR DESCRIPTION
### Description

This PR adds payment functionality to the Towns bot framework, enabling developers to create paid commands that require USDC payments on Base or Base Sepolia networks. The implementation uses the x402 protocol for payment verification and settlement.

### Changes

- Added payment handling infrastructure to the Bot class
- Implemented payment request creation and signature verification flow
- Added support for USDC payments with EIP-712 typed data signatures
- Created payment tracking system with pending payments map
- Added payment verification and settlement process
- Modified slash command handling to support paid commands
- Added payment configuration options to bot constructor and factory function
- Created utilities for USDC price parsing and chain-specific configurations

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines