### PR TITLE
feat: refactor Bot class to use extensible runtime architecture

### DIFF
--- a/packages/bot/src/extensions/builder.ts
+++ b/packages/bot/src/extensions/builder.ts
@@ -1,0 +1,247 @@
+import { ethers } from 'ethers'
+import { SpaceDapp } from '@towns-protocol/web3'
+import {
+    createTownsClient,
+    parseAppPrivateData,
+    townsEnv,
+    type CreateTownsClientParams,
+} from '@towns-protocol/sdk'
+import { bin_fromHexString } from '@towns-protocol/utils'
+import { http, type Hex, type Address, createWalletClient } from 'viem'
+import { readContract } from 'viem/actions'
+import { base, baseSepolia, foundry } from 'viem/chains'
+import { privateKeyToAccount } from 'viem/accounts'
+import appRegistryAbi from '@towns-protocol/generated/dev/abis/IAppRegistry.abi'
+
+import { EventDedup } from '../eventDedup'
+import type { BotExtension, BotBuildContext, BotRuntime, OnBuildContext } from './types'
+
+// Forward declaration - Bot class will be imported dynamically to avoid circular deps
+// Use BotCommand[] as the generic parameter for flexibility with extensions
+type BotInstance = import('../bot').Bot<import('../bot').BotCommand[]>
+
+/**
+ * Builder for constructing Bot instances with composable extensions.
+ *
+ * @example
+ * ```typescript
+ * const bot = await createBot()
+ *   .extend(dedup({ maxSizePerStream: 1000 }))
+ *   .extend(identity({ domain: 'bot.example.com', name: 'My Bot' }))
+ *   .extend(commands([{ name: 'help', description: 'Show help' }]))
+ *   .build(appPrivateData, jwtSecret)
+ * ```
+ */
+export class BotBuilder {
+    private extensions: BotExtension[] = []
+
+    /**
+     * Add an extension to the builder.
+     * Extensions are processed in order during build.
+     */
+    extend<E extends BotExtension>(ext: E): this {
+        this.extensions.push(ext)
+        return this
+    }
+
+    /**
+     * Build the bot with all configured extensions.
+     *
+     * @param appPrivateData - Base64-encoded app credentials
+     * @param jwtSecretBase64 - Base64-encoded JWT secret for webhook auth
+     * @param opts - Additional options for the Towns client
+     */
+    async build(
+        appPrivateData: string,
+        jwtSecretBase64: string,
+        opts: {
+            baseRpcUrl?: string
+        } & Partial<Omit<CreateTownsClientParams, 'env' | 'encryptionDevice'>> = {},
+    ): Promise<BotInstance> {
+        const { baseRpcUrl, ...clientOpts } = opts
+
+        // Parse credentials
+        let appAddress: Address | undefined
+        const {
+            privateKey,
+            encryptionDevice,
+            env,
+            appAddress: appAddressFromPrivateData,
+        } = parseAppPrivateData(appPrivateData)
+
+        if (!env) {
+            throw new Error('Failed to parse APP_PRIVATE_DATA')
+        }
+        if (appAddressFromPrivateData) {
+            appAddress = appAddressFromPrivateData
+        }
+
+        const account = privateKeyToAccount(privateKey as Hex)
+
+        // Set up chain config
+        const baseConfig = townsEnv().makeBaseChainConfig(env)
+        const getChain = (chainId: number) => {
+            if (chainId === base.id) return base
+            if (chainId === foundry.id) return foundry
+            return baseSepolia
+        }
+        const chain = getChain(baseConfig.chainConfig.chainId)
+
+        const viem = createWalletClient({
+            account,
+            transport: baseRpcUrl
+                ? http(baseRpcUrl, { batch: true })
+                : http(baseConfig.rpcUrl, { batch: true }),
+            chain,
+        })
+
+        const spaceDapp = new SpaceDapp(
+            baseConfig.chainConfig,
+            new ethers.providers.JsonRpcProvider(baseRpcUrl || baseConfig.rpcUrl),
+        )
+
+        // Get app address if not in credentials
+        if (!appAddress) {
+            appAddress = await readContract(viem, {
+                address: baseConfig.chainConfig.addresses.appRegistry,
+                abi: appRegistryAbi,
+                functionName: 'getAppByClient',
+                args: [account.address],
+            })
+        }
+
+        // Import Bot class dynamically to avoid circular deps
+        const { Bot, buildBotActions } = await import('../bot')
+
+        // Create Towns client
+        const client = await createTownsClient({
+            privateKey,
+            env,
+            encryptionDevice: {
+                fromExportedDevice: encryptionDevice,
+            },
+            ...clientOpts,
+        }).then((x) =>
+            x.extend((townsClient) => buildBotActions(townsClient, viem, spaceDapp, appAddress!)),
+        )
+
+        // Build phase: collect runtime slices from extensions
+        const buildContext: BotBuildContext = {}
+        const runtimeSlices: Record<string, unknown>[] = []
+
+        for (const ext of this.extensions) {
+            try {
+                const slice = ext.build(buildContext)
+                runtimeSlices.push(slice)
+            } catch (error) {
+                const errorMessage =
+                    error instanceof Error ? error.message : String(error)
+                throw new Error(
+                    `[@towns-protocol/bot] Extension "${ext.name}" failed to build: ${errorMessage}`,
+                    { cause: error },
+                )
+            }
+        }
+
+        // Merge runtime slices with conflict detection and property ownership tracking
+        const mergedRuntime: Record<string, unknown> = {}
+        const propertyOwners = new Map<string, string[]>()
+
+        for (let i = 0; i < runtimeSlices.length; i++) {
+            const slice = runtimeSlices[i]
+            const extName = this.extensions[i]?.name ?? `extension-${i}`
+
+            for (const [key, value] of Object.entries(slice)) {
+                if (key in mergedRuntime) {
+                    const owners = propertyOwners.get(key) ?? []
+                    owners.push(extName)
+                    propertyOwners.set(key, owners)
+
+                    throw new Error(
+                        `[@towns-protocol/bot] Conflicting extensions: "${owners.join(
+                            '" and "',
+                        )}" both add "${key}" property to runtime. Extensions must not conflict.`,
+                    )
+                }
+
+                mergedRuntime[key] = value
+                propertyOwners.set(key, [extName])
+            }
+        }
+
+        // Ensure dedup always exists (create default if not provided)
+        if (!('dedup' in mergedRuntime)) {
+            mergedRuntime.dedup = new EventDedup()
+        }
+
+        const runtime = mergedRuntime as BotRuntime
+
+        // Create Bot instance
+        // Cast to BotInstance since we can't preserve generic through dynamic import
+        const bot = new Bot(client, viem, jwtSecretBase64, appAddress!, runtime) as BotInstance
+
+        // onBuild phase: call hooks with full context
+        const onBuildContext: OnBuildContext = {
+            client,
+            viem,
+            appAddress: appAddress!,
+            botId: account.address,
+        }
+
+        // Collect async onBuild promises for parallel execution
+        const onBuildPromises: Promise<void>[] = []
+        for (const ext of this.extensions) {
+            if (ext.onBuild) {
+                try {
+                    const result = ext.onBuild(runtime, onBuildContext)
+                    if (result instanceof Promise) {
+                        onBuildPromises.push(
+                            result.catch(error => {
+                                const errorMessage =
+                                    error instanceof Error
+                                        ? error.message
+                                        : String(error)
+                                throw new Error(
+                                    `[@towns-protocol/bot] Extension "${ext.name}" hook onBuild failed: ${errorMessage}`,
+                                    { cause: error },
+                                )
+                            }),
+                        )
+                    }
+                } catch (error) {
+                    const errorMessage =
+                        error instanceof Error ? error.message : String(error)
+                    throw new Error(
+                        `[@towns-protocol/bot] Extension "${ext.name}" hook onBuild failed: ${errorMessage}`,
+                        { cause: error },
+                    )
+                }
+            }
+        }
+
+        // Wait for all async onBuild hooks to complete
+        if (onBuildPromises.length > 0) {
+            await Promise.all(onBuildPromises)
+        }
+
+        // Upload device keys
+        await client.uploadDeviceKeys()
+
+        return bot
+    }
+}
+
+/**
+ * Create a new bot builder for composing extensions.
+ *
+ * @example
+ * ```typescript
+ * const bot = await createBot()
+ *   .extend(dedup())
+ *   .extend(commands([{ name: 'help', description: 'Show help' }]))
+ *   .build(appPrivateData, jwtSecret)
+ * ```
+ */
+export function createBot(): BotBuilder {
+    return new BotBuilder()
+}

--- a/packages/bot/src/extensions/commands.ts
+++ b/packages/bot/src/extensions/commands.ts
@@ -1,0 +1,49 @@
+import { bin_fromHexString } from '@towns-protocol/utils'
+import type { BotExtension, BotBuildContext, BotRuntime, OnBuildContext, BotCommand } from './types'
+
+/**
+ * Slash commands extension.
+ *
+ * Registers slash commands with the Towns App Registry and makes them
+ * available for type-safe handling via `bot.onSlashCommand()`.
+ *
+ * @param cmds - Array of command definitions
+ *
+ * @example
+ * ```typescript
+ * const bot = await createBot()
+ *   .extend(commands([
+ *     { name: 'help', description: 'Show help' },
+ *     { name: 'status', description: 'Check bot status' },
+ *   ]))
+ *   .build(appPrivateData, jwtSecret)
+ *
+ * bot.onSlashCommand('help', async (handler, event) => {
+ *   await handler.sendMessage(event.channelId, 'Available commands: /help, /status')
+ * })
+ * ```
+ */
+export function commands<C extends BotCommand[]>(cmds: C): BotExtension<{ commands: C }> {
+    return {
+        name: 'commands',
+        build(_ctx: BotBuildContext): { commands: C } {
+            return { commands: cmds }
+        },
+        async onBuild(_runtime: BotRuntime, ctx: OnBuildContext) {
+            // Register commands with App Registry
+            try {
+                const appRegistryClient = await ctx.client.appServiceClient()
+                await appRegistryClient.updateAppMetadata({
+                    appId: bin_fromHexString(ctx.botId),
+                    updateMask: ['slash_commands'],
+                    metadata: {
+                        slashCommands: cmds,
+                    },
+                })
+            } catch (err) {
+                // eslint-disable-next-line no-console
+                console.warn('[@towns-protocol/bot] failed to update slash commands', err)
+            }
+        },
+    }
+}

--- a/packages/bot/src/extensions/dedup.ts
+++ b/packages/bot/src/extensions/dedup.ts
@@ -1,0 +1,26 @@
+import { EventDedup, type EventDedupConfig } from '../eventDedup'
+import type { BotExtension, BotBuildContext } from './types'
+
+/**
+ * Event deduplication extension.
+ *
+ * Provides in-memory deduplication of bot events to prevent duplicate processing
+ * when the App Registry replays events during restarts.
+ *
+ * @param config - Optional configuration for the dedup cache
+ *
+ * @example
+ * ```typescript
+ * const bot = await createBot()
+ *   .extend(dedup({ maxSizePerStream: 1000 }))
+ *   .build(appPrivateData, jwtSecret)
+ * ```
+ */
+export function dedup(config?: EventDedupConfig): BotExtension<{ dedup: EventDedup }> {
+    return {
+        name: 'dedup',
+        build(_ctx: BotBuildContext): { dedup: EventDedup } {
+            return { dedup: new EventDedup(config) }
+        },
+    }
+}

--- a/packages/bot/src/extensions/identity.ts
+++ b/packages/bot/src/extensions/identity.ts
@@ -1,0 +1,31 @@
+import type { BotIdentityConfig } from '../identity-types'
+import type { BotExtension, BotBuildContext } from './types'
+
+/**
+ * ERC-8004 identity extension.
+ *
+ * Configures the bot's on-chain identity metadata for the
+ * `/.well-known/agent-metadata.json` endpoint.
+ *
+ * @param config - Identity configuration including name, description, domain, etc.
+ *
+ * @example
+ * ```typescript
+ * const bot = await createBot()
+ *   .extend(identity({
+ *     name: 'My Bot',
+ *     description: 'A helpful bot',
+ *     image: 'https://example.com/avatar.png',
+ *     domain: 'bot.example.com',
+ *   }))
+ *   .build(appPrivateData, jwtSecret)
+ * ```
+ */
+export function identity(config: BotIdentityConfig): BotExtension<{ identity: BotIdentityConfig }> {
+    return {
+        name: 'identity',
+        build(_ctx: BotBuildContext): { identity: BotIdentityConfig } {
+            return { identity: config }
+        },
+    }
+}

--- a/packages/bot/src/extensions/index.ts
+++ b/packages/bot/src/extensions/index.ts
@@ -1,0 +1,10 @@
+// Extension types
+export type { BotExtension, BotBuildContext, BotRuntime, OnBuildContext, BotCommand } from './types'
+
+// Builder
+export { BotBuilder, createBot } from './builder'
+
+// Built-in extensions
+export { dedup } from './dedup'
+export { identity } from './identity'
+export { commands } from './commands'

--- a/packages/bot/src/extensions/types.ts
+++ b/packages/bot/src/extensions/types.ts
@@ -1,0 +1,74 @@
+import type { ClientV2 } from '@towns-protocol/sdk'
+import type { WalletClient, Transport, Chain, Account, Address } from 'viem'
+import type { EventDedup } from '../eventDedup'
+import type { BotIdentityConfig } from '../identity-types'
+import type { BotCommand } from '../bot'
+
+// Re-export BotCommand for convenience - canonical definition is in bot.ts
+export type { BotCommand }
+
+/**
+ * Context available during the build() phase of extensions.
+ * This phase runs before the client is initialized, so context is minimal.
+ */
+export type BotBuildContext = {}
+
+/**
+ * Context available during the onBuild() phase of extensions.
+ * This phase runs after the client is fully initialized.
+ */
+export type OnBuildContext = {
+    client: ClientV2<any>
+    viem: WalletClient<Transport, Chain, Account>
+    appAddress: Address
+    botId: string
+}
+
+/**
+ * Runtime configuration passed to the Bot class.
+ * Contains all extension-provided functionality.
+ */
+export type BotRuntime = {
+    /** Event deduplication - always present */
+    dedup: EventDedup
+    /** ERC-8004 identity configuration */
+    identity?: BotIdentityConfig
+    /** Slash commands */
+    commands?: BotCommand[]
+}
+
+/**
+ * Interface for bot extensions.
+ * Extensions add functionality to the bot runtime in a composable way.
+ *
+ * @template R - The runtime slice this extension contributes
+ *
+ * @example
+ * ```typescript
+ * const myExtension: BotExtension<{ myFeature: MyFeature }> = {
+ *   name: 'my-extension',
+ *   build(ctx) {
+ *     return { myFeature: new MyFeature() }
+ *   },
+ *   async onBuild(runtime, ctx) {
+ *     // Post-initialization setup
+ *   }
+ * }
+ * ```
+ */
+export interface BotExtension<R extends Record<string, unknown> = {}> {
+    /** Unique name for this extension */
+    name: string
+
+    /**
+     * Build phase - creates the runtime slice for this extension.
+     * Called before the Bot is instantiated.
+     */
+    build: (ctx: BotBuildContext) => R
+
+    /**
+     * Post-build hook - runs after the Bot is fully initialized.
+     * Use this for async setup that requires the client.
+     */
+    onBuild?: (runtime: BotRuntime, ctx: OnBuildContext) => void | Promise<void>
+}

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -7,3 +7,12 @@ export * from './identity-types'
 export * from './re-exports'
 export * from './smart-account'
 export * from './snapshot-getter'
+
+// Extension system exports
+export { createBot, BotBuilder, dedup, identity, commands } from './extensions'
+export type {
+    BotExtension,
+    BotBuildContext,
+    BotRuntime,
+    OnBuildContext,
+} from './extensions'


### PR DESCRIPTION
### Description

Refactored the Bot class to use a composable extension system, making it more modular and easier to extend with new functionality. This introduces a builder pattern for bot creation that allows developers to add features through extensions rather than configuration parameters.

### Changes

- Created a new extension system with a `BotBuilder` class for composable bot creation
- Implemented core extensions for existing functionality:
  - `dedup` - Event deduplication
  - `identity` - ERC-8004 identity configuration
  - `commands` - Slash command registration
- Moved implementation details from `Bot` constructor to the builder
- Added a runtime object to store extension-provided functionality
- Exposed new extension API through `createBot()` builder function
- Maintained backward compatibility with existing `makeTownsBot` function

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines