### PR TITLE
Fix stream reinitialize deadlock

### DIFF
--- a/core/node/storage/pg_stream_store.go
+++ b/core/node/storage/pg_stream_store.go
@@ -2754,7 +2754,7 @@ func (s *PostgresStreamStore) reinitializeStreamStorageTx(
 				streamId,
 			).Func("ReinitializeStreamStorage")
 		}
-		if err := s.reinitializeExistingStreamNoLockTx(
+		if err := s.reinitializeExistingStreamLockedTx(
 			ctx,
 			tx,
 			streamId,
@@ -2791,7 +2791,7 @@ func (s *PostgresStreamStore) reinitializeStreamStorageTx(
 				return err
 			}
 
-			if err := s.reinitializeExistingStreamNoLockTx(
+			if err := s.reinitializeExistingStreamLockedTx(
 				ctx,
 				tx,
 				streamId,
@@ -2848,8 +2848,8 @@ func (s *PostgresStreamStore) reinitializeStreamStorageTx(
 	return nil
 }
 
-// reinitializeExistingStreamNoLockTx expects caller to have a lock on the stream.
-func (s *PostgresStreamStore) reinitializeExistingStreamNoLockTx(
+// reinitializeExistingStreamLockedTx expects caller to have a lock on the stream.
+func (s *PostgresStreamStore) reinitializeExistingStreamLockedTx(
 	ctx context.Context,
 	tx pgx.Tx,
 	streamId StreamId,


### PR DESCRIPTION
Summary of Changes

  The commit refactors the reinitializeStreamStorageTx function in core/node/storage/pg_stream_store.go to address a potential deadlock situation.

  The previous implementation attempted an INSERT ... ON CONFLICT DO NOTHING. If the conflict occurred (meaning the stream already existed), it would then proceed to lock the stream for an update. This pattern is prone to deadlocks if two
  concurrent transactions attempt to reinitialize the same stream, as they could both attempt the insert, both conflict, and then both try to acquire a lock on the same row, leading to a deadlock.

  The new implementation reverses this logic:

   1. It now attempts to lockStream first.
   2. If the lock is successful, it means the stream exists, and it proceeds to update the existing stream's data by calling the newly extracted reinitializeExistingStreamNoLockTx function.
   3. If `lockStream` fails with a `NOT_FOUND` error, it means the stream does not exist. It then attempts to INSERT the new stream. There is a check here for a race condition where another transaction might have created the stream in the
      meantime.
   4. A minor grammatical correction was also made to a comment.

  Potential Problems or Behavioral Changes

   * Positive Behavioral Change (Bug Fix): The primary change is the fix for the deadlock vulnerability. The new logic is more robust against race conditions during stream reinitialization. By locking the stream record upfront, it serializes
     access for updates, preventing deadlocks between concurrent reinitialization attempts for the same stream.
   * No Negative Functional Changes: The underlying logic for what gets written to the database (miniblocks, snapshots, etc.) remains the same. The change is in the concurrency control strategy. The extraction of
     reinitializeExistingStreamNoLockTx is a good refactoring that improves code clarity without changing the core logic.

  Conclusion

  This change appears to be a solid improvement. It directly addresses a potential deadlock scenario and makes the stream reinitialization process more robust in a concurrent environment. I do not see any potential problems or regressions
  introduced by this change.

> are there any performance penalties of this change?

✦ That's an excellent question. Here's a breakdown of the performance implications:

   * Stream Creation (the "miss" case): The new approach might be slightly slower when creating a stream that doesn't already exist.
       * Old way: It performed a single INSERT ... ON CONFLICT DO NOTHING. This is one database round-trip.
       * New way: It first attempts a SELECT ... FOR UPDATE (which finds nothing) and then performs an INSERT. This is two database round-trips.

   * Stream Update (the "hit" case): The new approach is likely slightly faster when reinitializing an existing stream.
       * Old way: It performed an INSERT ... ON CONFLICT (which did nothing but was still an operation) and then a SELECT ... FOR UPDATE before proceeding with the updates.
       * New way: It goes directly to the SELECT ... FOR UPDATE. This saves one database operation.

  Conclusion

  There is a minor performance trade-off: stream creation is theoretically slightly slower, while stream updates are slightly faster.

  However, the key takeaway is that this change was made to prevent deadlocks. A deadlock is a critical failure that can halt operations entirely, making it a far more severe issue than the negligible performance cost of an extra database query.

  Therefore, any minor performance difference is a worthwhile trade-off for the significant gain in database concurrency safety and application stability. The primary goal of this commit was to fix a correctness bug, not to optimize performance.