### PR TITLE
fix(sync-agent): use onchain free supply instead of hardcoding

### DIFF
--- a/packages/sdk/src/sync-agent/constants.ts
+++ b/packages/sdk/src/sync-agent/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_MEMBERSHIP_LIMIT = 13_500

--- a/packages/sdk/src/sync-agent/utils/spaceUtils.ts
+++ b/packages/sdk/src/sync-agent/utils/spaceUtils.ts
@@ -7,13 +7,14 @@ import {
     getDynamicPricingModule,
     getFixedPricingModule,
 } from '@towns-protocol/web3'
+import { DEFAULT_MEMBERSHIP_LIMIT } from '../constants'
 
 export async function makeDefaultMembershipInfo(
     spaceDapp: SpaceDapp,
     feeRecipient: string,
     pricing: 'dynamic' | 'fixed' = 'dynamic',
 ): Promise<MembershipStruct> {
-    const [pricingModule, maxSupply] = await Promise.all([
+    const [pricingModule, freeAllocation] = await Promise.all([
         pricing == 'dynamic'
             ? getDynamicPricingModule(spaceDapp)
             : getFixedPricingModule(spaceDapp),
@@ -24,11 +25,11 @@ export async function makeDefaultMembershipInfo(
             name: 'Everyone',
             symbol: 'MEMBER',
             price: 0,
-            maxSupply,
+            maxSupply: DEFAULT_MEMBERSHIP_LIMIT,
             duration: 0,
             currency: ETH_ADDRESS,
             feeRecipient: feeRecipient,
-            freeAllocation: maxSupply,
+            freeAllocation,
             pricingModule: pricingModule.module,
         },
         permissions: [Permission.Read, Permission.Write],


### PR DESCRIPTION
On `omega`, the create space call was reverting with `Membership__InvalidFreeAllocation`. That's because we're trying to use 1000, while `omega` supports 100.

Ethers hides errors with `UNPREDICTABLE_GAS_LIMIT` instead of showing the error. Very painful.

I also updated the max supply to match towns app.	

Should close #4574 