### PR TITLE
chore(playground): minor tweaks

### DIFF
--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -17,7 +17,6 @@ function App() {
     const [persistedAuth] = useState(() => loadAuth())
     useEffect(() => {
         if (persistedAuth) {
-            console.log('river_env', persistedAuth.riverEnvironmentId)
             connectTowns(persistedAuth.signerContext, {
                 townsConfig: townsEnv(VITE_ENV_OPTIONS).makeTownsConfig(
                     persistedAuth.riverEnvironmentId,

--- a/packages/playground/src/routes/t/dashboard.tsx
+++ b/packages/playground/src/routes/t/dashboard.tsx
@@ -1,5 +1,5 @@
 import { Outlet, useNavigate } from 'react-router-dom'
-import { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
+import { Suspense, useCallback, useMemo, useState } from 'react'
 import {
     useDm,
     useGdm,
@@ -44,9 +44,6 @@ export const DashboardRoute = () => {
     const { streamIds: dmStreamIds } = useUserDms()
     const { data: bots, isLoading: botsLoading } = useAllBots()
 
-    useEffect(() => {
-        console.log('bots', bots)
-    }, [bots])
     const [joinSpaceDialogOpen, setJoinSpaceDialogOpen] = useState(false)
     const [createSpaceDialogOpen, setCreateSpaceDialogOpen] = useState(false)
     const [createDmDialogOpen, setCreateDmDialogOpen] = useState(false)

--- a/packages/sdk/src/tests/testUtils.ts
+++ b/packages/sdk/src/tests/testUtils.ts
@@ -34,7 +34,6 @@ import { bin_fromHexString, check, dlog, publicKeyToAddress } from '@towns-proto
 import { ethers, ContractTransaction } from 'ethers'
 import { RiverDbManager } from '../riverDbManager'
 import { StreamRpcClient, makeStreamRpcClient } from '../makeStreamRpcClient'
-import assert from 'assert'
 import { forEachRight } from 'lodash-es'
 import { MockEntitlementsDelegate } from '../utils'
 import { SignerContext, makeSignerContext } from '../signerContext'
@@ -421,7 +420,7 @@ export const makeDonePromise = (): DonePromise => {
 
 export const sendFlush = async (client: StreamRpcClient): Promise<void> => {
     const r = await client.info({ debug: ['flush_cache'] })
-    assert(r.graffiti === 'cache flushed')
+    check(r.graffiti === 'cache flushed')
 }
 
 export async function* iterableWrapper<T>(


### PR DESCRIPTION
Removing console.logs and using `check` instead of `node:assert` (was blocking playground load)