### PR TITLE
fix(docker): enable arm64 builds by skipping native module compilation

### DIFF
--- a/packages/anvil-docker/Dockerfile
+++ b/packages/anvil-docker/Dockerfile
@@ -55,7 +55,7 @@ COPY ./packages/generated/package.json packages/generated/
 COPY ./packages/prettier-config/package.json packages/prettier-config/
 
 # Install dependencies with Bun
-RUN bun install --filter @towns-protocol/contracts && bun pm cache rm
+RUN bun install --ignore-scripts --filter @towns-protocol/contracts && bun pm cache rm
 
 # Copy rest of the project files
 COPY ./packages/anvil-docker/scripts packages/anvil-docker/scripts

--- a/packages/subgraph/Dockerfile
+++ b/packages/subgraph/Dockerfile
@@ -57,7 +57,7 @@ COPY packages/web3/package.json ./packages/web3/
 COPY protocol/package.json ./protocol/
 
 # Install all dependencies (cached unless package.json files change)
-RUN bun install && bun pm cache rm
+RUN bun install --ignore-scripts && bun pm cache rm
 
 # ==========================================
 # Source Code and Build


### PR DESCRIPTION
Add --ignore-scripts to bun install in Dockerfiles.

bufferutil and utf-8-validate lack linux-arm64 prebuilt binaries, causing node-gyp to attempt compilation which fails due to a bun/node-gyp incompatibility when fetching Node.js headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
