### PR TITLE
feat: require token ownership for reviews and add tokenId field

### DIFF
--- a/packages/contracts/src/spaces/facets/review/IReview.sol
+++ b/packages/contracts/src/spaces/facets/review/IReview.sol
@@ -11,6 +11,7 @@ interface IReviewBase {
     }
 
     struct Review {
+        uint256 tokenId;
         string comment;
         uint8 rating;
     }
@@ -23,6 +24,8 @@ interface IReviewBase {
     error ReviewFacet__InvalidRating();
     error ReviewFacet__ReviewAlreadyExists();
     error ReviewFacet__ReviewDoesNotExist();
+    error ReviewFacet__UserIsBanned();
+    error ReviewFacet__NotTokenOwner();
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                           EVENTS                           */

--- a/packages/contracts/test/fork/ForkUserOp.t.sol
+++ b/packages/contracts/test/fork/ForkUserOp.t.sol
@@ -37,7 +37,8 @@ contract ForkUserOp is TestUtils {
         vm.createSelectFork("base", 27_294_553);
         IReviewBase.Review memory review = IReviewBase.Review({
             comment: "I'm a good friend of YAZ who created this group chat. He asked me to rate this town. I would give it 5 stars, but only God is perfect, so I give it 4.",
-            rating: 4
+            rating: 4,
+            tokenId: 1
         });
         vm.etch(0x8Dfe21D0e911c54bA9104539a2c346168Dd94662, type(ReviewFacet).runtimeCode);
         vm.prank(0x405Ad07b01E3366e686f0056Bab0F89B091944f3);


### PR DESCRIPTION
### Description

This PR enhances the review system by requiring users to own the token of the space they're reviewing. It adds validation to ensure only token owners can submit reviews, preventing unauthorized reviews.

### Changes

- Added `tokenId` field to the `Review` struct to track which token is being reviewed with
- Added new error types: `ReviewFacet__UserIsBanned` and `ReviewFacet__NotTokenOwner`
- Enhanced `_validateReview()` to verify the reviewer owns the token they're reviewing
- Extended `ReviewFacet` to inherit from `BanningBase` and `ERC721ABase` for token ownership verification
- Updated tests to include token ownership validation and test the new error cases

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines