### PR TITLE
Always send key fulfullments

### DIFF
--- a/packages/sdk/src/decryptionExtensions.ts
+++ b/packages/sdk/src/decryptionExtensions.ts
@@ -1090,7 +1090,10 @@ export abstract class BaseDecryptionExtensions {
             streamId,
             userId: item.fromUserId,
             deviceKey: item.solicitation.deviceKey,
-            sessionIds: fulfilledSessionIds,
+            sessionIds:
+                fulfilledSessionIds.length > 0
+                    ? fulfilledSessionIds
+                    : allSessions.map((x) => x.sessionId).sort(),
             ephemeral: item.ephemeral,
         })
 


### PR DESCRIPTION

Okay i think i have this sorted, we have users that will create lots of new devices and they end up with solicitations like this one in ax1

────────────────────────────────────────────────────────────────────────────────
  SNAPSHOT SOLICITATIONS (miniblock 710716) for 0x766f84bf8057d2943905e38c6bf7b3a52a8e4a1b
────────────────────────────────────────────────────────────────────────────────

  Device Key: k6q0kBj5clBPbPN3zd99tZLzgVfr9nBoCz4xYBPee1o
    Is New Device: No
    Sessions: 100

  Device Key: oTp/n/Xr7mGWCqrmMXkhw3+Kcp1g4Wjj5A1hcGIw5A8
    Is New Device: Yes
    Sessions: 1

  Device Key: Vg8Kkb2RecxUCigO8iwlJza+NJicD2HKXxH2ok5TDEY
    Is New Device: Yes
    Sessions: 1

  Device Key: wmgQJ8c0BjLFiRdwkqp+tj/Zo3W77lSUU74DcYNdGSQ
    Is New Device: Yes
    Sessions: 1

  Device Key: 5E+sNfp5XcviusqhGGp/k4UVj29HiRdq+Ok5ZKX2J0c
    Is New Device: Yes
    Sessions: 1

  Device Key: a60Lprgv6ikWWIm+XK+QTpDiHoNHmCMSOGdP1mEb5Tc
    Is New Device: Yes
    Sessions: 1

  Device Key: qs1thpLCgk5TNW4in/7Snc/xQJGLfaDotPz75x8opnU
    Is New Device: Yes
    Sessions: 1

  Device Key: bwQl9mfaK0zwQ0QaPpECqB/IB9qSXfoAhnaWM585szk
    Is New Device: Yes
    Sessions: 1

  Device Key: xTGp+mu4OdZggRKJ8CrJb6XZ4/GmTwzwAL2lSPiXTxY
    Is New Device: Yes
    Sessions: 1

  Device Key: XH67CBqSY5Xao6YCJdXPHGNzCyjiREDvEt7wtTPwnBQ
    Is New Device: Yes
    Sessions: 1

  Device Key: q6rfH9Gp8MdnOqzmptm76+9ruGIxN5F8/p+xpnHuljg
    Is New Device: Yes
    Sessions: 1

────────────────────────────────────────────────────────────────────────────────
  EVENTS IN POOL (after snapshot)
────────────────────────────────────────────────────────────────────────────────
  Total Key Solicitations: 0
  Total Key Fulfillments: 0

  For 0x766f84bf8057d2943905e38c6bf7b3a52a8e4a1b:
    Solicitations: 0
    Fulfillments (targeting user): 0

5 months ago i added this https://github.com/towns-protocol/towns/commit/6f0cb78886628061d2832ef4935e53b2f10d6f3e
which doesn't send a fulfillment if we don't have matching sessions, but reverting it https://github.com/towns-protocol/towns/pull/4681/files
because that results in the above table, where the user requested lost ids on their new device so everyone sends them all their keys all the time. 🤦‍♂️
why did this start happening in november? I have no idea! But I'll pretty confident this should fix most of the problem. I'll put up a pr for a node change to further guard this as well, but that should be less important.

why this fix works: sending any fulfillment will reset the isNewDevice flag so people stop spamming them with all the keys