### PR TITLE
feat: add ModifyAppSettings permission check on app installation

### DIFF
--- a/packages/contracts/src/apps/simple/app/ISimpleApp.sol
+++ b/packages/contracts/src/apps/simple/app/ISimpleApp.sol
@@ -64,11 +64,6 @@ interface ISimpleAppBase {
     /// @param owner The owner of the app
     /// @param agentId The ID of the agent
     event AgentPromoted(address indexed owner, uint256 indexed agentId);
-
-    /// @notice Emitted when payment is received
-    /// @param sender The address that sent the payment
-    /// @param amount The amount of payment that was sent
-    event OnPaymentReceived(address indexed sender, uint256 amount);
 }
 
 interface ISimpleApp is ISimpleAppBase {

--- a/packages/contracts/src/apps/simple/app/SimpleAppFacet.sol
+++ b/packages/contracts/src/apps/simple/app/SimpleAppFacet.sol
@@ -42,7 +42,6 @@ contract SimpleAppFacet is
     uint256 internal constant MAX_PERMISSIONS = 10;
 
     receive() external payable override(BaseApp, Receiver) {
-        emit OnPaymentReceived(msg.sender, msg.value);
         _onPayment(msg.sender, msg.value);
     }
 


### PR DESCRIPTION
### Description

This PR enhances app registry permissions by replacing the owner-only check with a more flexible entitlements system.

### Changes

- Updated `AppRegistryBase` to use `IEntitlementsManager` with the new `ModifyAppSettings` permission instead of only checking for ownership
- Added a new `ModifyAppSettings` permission to the `Permissions` library
- Changed permission constants in `Permissions.sol` from `public` to `internal`

### Checklist

- [x] Tests added where required
- [x] Documentation updated where applicable
- [x] Changes adhere to the repository's contribution guidelines